### PR TITLE
fix(WheelInput): make only release event debounced

### DIFF
--- a/declaration/inputType/WheelInput.d.ts
+++ b/declaration/inputType/WheelInput.d.ts
@@ -8,6 +8,7 @@ export declare class WheelInput implements IInputType {
     axes: string[];
     element: HTMLElement;
     private _isEnabled;
+    private _isHolded;
     private _timer;
     private observer;
     constructor(el: any, options?: WheelInputOption);

--- a/declaration/inputType/WheelInput.d.ts
+++ b/declaration/inputType/WheelInput.d.ts
@@ -1,7 +1,6 @@
 import { IInputType, IInputTypeObserver } from "./InputType";
 export interface WheelInputOption {
     scale?: number;
-    throttle?: number;
 }
 export declare class WheelInput implements IInputType {
     options: WheelInputOption;

--- a/src/inputType/WheelInput.ts
+++ b/src/inputType/WheelInput.ts
@@ -6,14 +6,12 @@ import { Axis } from "../AxisManager";
 
 export interface WheelInputOption {
 	scale?: number;
-	throttle?: number;
 }
 
 /**
  * @typedef {Object} WheelInputOption The option object of the eg.Axes.WheelInput module
  * @ko eg.Axes.WheelInput 모듈의 옵션 객체
  * @property {Number} [scale=1] Coordinate scale that a user can move<ko>사용자의 동작으로 이동하는 좌표의 배율</ko>
- * @property {Number} [throttle=100]
 **/
 
 /**
@@ -44,8 +42,7 @@ export class WheelInput implements IInputType {
 		this.element = $(el);
 		this.options = {
 			...{
-				scale: 1,
-				throttle: 100
+				scale: 1
 			}, ...options
     };
 		this.onWheel = this.onWheel.bind(this);

--- a/test/unit/inputType/TestHeler.js
+++ b/test/unit/inputType/TestHeler.js
@@ -4,10 +4,6 @@ export default class TestHelper {
 			return;
 		}
 
-		if (target.dispatchEvent) {
-			return;
-		}
-
 		const params = {deltaY: value};
 		let wheelEvent;
 

--- a/test/unit/inputType/TestHeler.js
+++ b/test/unit/inputType/TestHeler.js
@@ -1,0 +1,54 @@
+export default class TestHelper {
+	static wheelVertical(target, value, callback) {
+		if (target instanceof Element === false) {
+			return;
+		}
+
+		if (target.dispatchEvent) {
+			return;
+		}
+
+		const params = {deltaY: value};
+		let wheelEvent;
+
+		try {
+			wheelEvent = new WheelEvent("wheel", params);
+		} catch (e) {
+			wheelEvent = document.createEvent("WheelEvent");
+			wheelEvent.initEvent("wheel", params);
+		}
+
+		function callbackOnce() {
+			callback && callback();
+			target.removeEventListener("wheel", callbackOnce);// Is this posible??
+		}
+		target.addEventListener("wheel", callbackOnce);
+		target.dispatchEvent(wheelEvent);
+	}
+	/**
+	 * looping async function
+	 *
+	 * @param {*} count loop count
+	 * @param {*} loopFunc user loop function
+	 * @param {*} complete callback function which called if done.
+	 */
+	static asyncLoop(count, loopFunc, complete) {
+		let i = 0;
+
+		function loop() {
+			if (i >= count) {
+				complete();
+				return;
+			}
+
+			loopFunc(i, () => {
+				// done
+				i++;
+				loop();
+			});
+		}
+
+		loop();
+	}
+}
+

--- a/test/unit/inputType/WheelInput.spec.js
+++ b/test/unit/inputType/WheelInput.spec.js
@@ -1,4 +1,6 @@
 import Hammer from "hammerjs";
+import TestHeler from "./TestHeler";
+import Axes from "../../../src/Axes.ts";
 import {WheelInput} from "../../../src/inputType/WheelInput";
 import {UNIQUEKEY} from "../../../src/inputType/InputType";
 
@@ -87,6 +89,63 @@ describe("WheelInput", () => {
 
       // Then
       expect(this.inst.isEnable()).to.be.true;
-    });    
+    }); 
+  });
+
+  describe("wheel event test", function() {
+    beforeEach(() => {
+      this.el = sandbox();
+      this.input = new WheelInput(this.el); 
+      this.inst = new Axes({
+        x: {
+          range: [10, 120]
+        }
+      }, {}, {
+        x: 50
+      });
+      this.inst.connect(["x"], this.input);
+    });
+
+    afterEach(() => {
+      if (this.ins) {
+        this.inst.destroy();
+        this.inst = null;
+      }
+      if (this.input) {
+        this.input.destroy();
+        this.input = null;
+      }
+      cleanup();
+    });
+
+    it("event triggering order test", () => {
+      // Given
+      const deltaY = 1;
+      const eventLog = [];
+      const eventLogAnswer = ["hold", "change", "change", "release"];
+
+      this.inst
+      .on("hold", () => {
+        eventLog.push("hold");
+      }).on("change", () => {
+        eventLog.push("change");
+      }).on("release", () => {
+        eventLog.push("release");
+      });
+
+      // When
+      TestHeler.wheelVertical(document.body, deltaY, () => {
+        setTimeout(()=> {
+          TestHeler.wheelVertical(document.body, deltaY, () => {
+            setTimeout(()=> {
+              // Then
+				      expect(eventLog).to.be.deep.equal(eventLogAnswer);
+              done();
+            }, 60);
+          });
+        }, 20);		
+			});
+    });
   });
 });
+

--- a/test/unit/inputType/WheelInput.spec.js
+++ b/test/unit/inputType/WheelInput.spec.js
@@ -4,7 +4,7 @@ import Axes from "../../../src/Axes.ts";
 import {WheelInput} from "../../../src/inputType/WheelInput";
 import {UNIQUEKEY} from "../../../src/inputType/InputType";
 
-describe("WheelInput", () => {
+describe.only("WheelInput", () => {
   describe("instance method", function() {
     beforeEach(() => {
       this.inst = new WheelInput(sandbox());
@@ -100,8 +100,6 @@ describe("WheelInput", () => {
         x: {
           range: [10, 120]
         }
-      }, {}, {
-        x: 50
       });
       this.inst.connect(["x"], this.input);
     });
@@ -118,7 +116,44 @@ describe("WheelInput", () => {
       cleanup();
     });
 
-    it("event triggering order test", () => {
+    it("no event triggering when disconnected", (done) => {
+      // Given
+      const deltaY = 1;
+      let changeTriggered = false;
+
+      this.inst
+      .on("change", () => {
+        changeTriggered = true;
+      });
+      this.inst.disconnect();
+
+      // When
+      TestHeler.wheelVertical(this.el, deltaY, () => {
+        // Then
+        expect(changeTriggered).to.be.false;
+        done();
+			});
+    });
+
+    it("no event triggering when offset is 0", (done) => {
+      // Given
+      const deltaY = 0;
+      let changeTriggered = false;
+
+      this.inst
+      .on("change", () => {
+        changeTriggered = true;
+      });
+
+      // When
+      TestHeler.wheelVertical(this.el, deltaY, () => {
+        // Then
+        expect(changeTriggered).to.be.false;
+        done();
+			});
+    });
+
+    it("triggering order test", (done) => {
       // Given
       const deltaY = 1;
       const eventLog = [];
@@ -134,9 +169,9 @@ describe("WheelInput", () => {
       });
 
       // When
-      TestHeler.wheelVertical(document.body, deltaY, () => {
+      TestHeler.wheelVertical(this.el, deltaY, () => {
         setTimeout(()=> {
-          TestHeler.wheelVertical(document.body, deltaY, () => {
+          TestHeler.wheelVertical(this.el, deltaY, () => {
             setTimeout(()=> {
               // Then
 				      expect(eventLog).to.be.deep.equal(eventLogAnswer);

--- a/test/unit/inputType/WheelInput.spec.js
+++ b/test/unit/inputType/WheelInput.spec.js
@@ -4,7 +4,7 @@ import Axes from "../../../src/Axes.ts";
 import {WheelInput} from "../../../src/inputType/WheelInput";
 import {UNIQUEKEY} from "../../../src/inputType/InputType";
 
-describe.only("WheelInput", () => {
+describe("WheelInput", () => {
   describe("instance method", function() {
     beforeEach(() => {
       this.inst = new WheelInput(sandbox());


### PR DESCRIPTION
## Issue
#57 

## Details
debounce delay for release event is 50ms. (referened jQuery UI's scrollstop event)