### PR TITLE
fix(EventManager): replace invalid var to valid var

### DIFF
--- a/src/EventManager.ts
+++ b/src/EventManager.ts
@@ -167,11 +167,11 @@ export class EventManager {
 			inputEvent,
 			isTrusted: !!inputEvent,
 			input: option && option.input || eventInfo && eventInfo.input || null,
-			set: event ? this.createUserControll(moveTo.pos) : () => { },
+			set: inputEvent ? this.createUserControll(moveTo.pos) : () => { },
 		};
 		this.axes.trigger("change", param);
 
-		event && this.am.axm.set(param.set()["destPos"]);
+		inputEvent && this.am.axm.set(param.set()["destPos"]);
 	}
 
 	/**


### PR DESCRIPTION
## Issue
#76

## Details
Replace invalid variable `event` with `inputEvent` that are valid.

It makes firefox firing script error.
