### PR TITLE
fix(PinchInput): remove PinchRecognizer from hammer manager when disconnecting PinchInput

### DIFF
--- a/declaration/inputType/PinchInput.d.ts
+++ b/declaration/inputType/PinchInput.d.ts
@@ -12,6 +12,7 @@ export declare class PinchInput implements IInputType {
     private observer;
     private _base;
     private _prev;
+    private _pinchRecognizer;
     constructor(el: any, options?: PinchInputOption);
     mapAxes(axes: string[]): void;
     connect(observer: IInputTypeObserver): IInputType;

--- a/src/inputType/PanInput.ts
+++ b/src/inputType/PanInput.ts
@@ -188,7 +188,7 @@ export class PanInput implements IInputType {
 	*/
 	destroy() {
 		this.disconnect();
-		if (this.hammer) {
+		if (this.hammer && this.hammer.recognizers.length === 1) {
 			this.hammer.destroy();
 		}
 		delete this.element[UNIQUEKEY];

--- a/src/inputType/PinchInput.ts
+++ b/src/inputType/PinchInput.ts
@@ -35,6 +35,7 @@ export interface PinchInputOption {
  * @param {PinchInputOption} [options] The option object of the eg.Axes.PinchInput module<ko>eg.Axes.PinchInput 모듈의 옵션 객체</ko>
  */
 export class PinchInput implements IInputType {
+
 	options: PinchInputOption;
 	axes: string[] = [];
 	hammer = null;
@@ -42,6 +43,8 @@ export class PinchInput implements IInputType {
   private observer: IInputTypeObserver;
   private _base: number = null;
   private _prev: number = null;
+  private _pinchRecognizer = null;
+
 	constructor(el, options?: PinchInputOption) {
 		/**
 		 * Hammer helps you add support for touch gestures to your page
@@ -87,7 +90,8 @@ export class PinchInput implements IInputType {
     if (this.hammer) { // for sharing hammer instance.
       this.dettachEvent();
 			// hammer remove previous PinchRecognizer.
-			this.hammer.add(new Hammer.Pinch(hammerOption));
+			this._pinchRecognizer = this._pinchRecognizer || new Hammer.Pinch(hammerOption);
+			this.hammer.add(this._pinchRecognizer);
     } else {
       let keyValue: string = this.element[UNIQUEKEY];
 			if (keyValue) {
@@ -109,6 +113,7 @@ export class PinchInput implements IInputType {
 
   disconnect() {
 		if (this.hammer) {
+			this.hammer.remove(this._pinchRecognizer);
 			this.dettachEvent();
 		}
 		return this;
@@ -121,7 +126,7 @@ export class PinchInput implements IInputType {
 	*/
 	destroy() {
 		this.disconnect();
-		if (this.hammer) {
+		if (this.hammer && this.hammer.recognizers.length === 1) {
 			this.hammer.destroy();
 		}
 		delete this.element[UNIQUEKEY];
@@ -162,7 +167,7 @@ export class PinchInput implements IInputType {
 	private dettachEvent() {
     this.hammer.off("pinchstart", this.onPinchStart)
       .off("pinchmove", this.onPinchMove)
-      .off("pinchend", this.onPinchEnd);
+	  .off("pinchend", this.onPinchEnd);
     this.observer = null;
     this._prev = null;
 	}

--- a/src/inputType/PinchInput.ts
+++ b/src/inputType/PinchInput.ts
@@ -88,9 +88,9 @@ export class PinchInput implements IInputType {
 			threshold: this.options.threshold,
 		};
     if (this.hammer) { // for sharing hammer instance.
-      this.dettachEvent();
+      this.disconnect();
 			// hammer remove previous PinchRecognizer.
-			this._pinchRecognizer = this._pinchRecognizer || new Hammer.Pinch(hammerOption);
+			this._pinchRecognizer = new Hammer.Pinch(hammerOption);
 			this.hammer.add(this._pinchRecognizer);
     } else {
       let keyValue: string = this.element[UNIQUEKEY];
@@ -114,6 +114,7 @@ export class PinchInput implements IInputType {
   disconnect() {
 		if (this.hammer) {
 			this.hammer.remove(this._pinchRecognizer);
+			this._pinchRecognizer = null;
 			this.dettachEvent();
 		}
 		return this;


### PR DESCRIPTION
## Issue
#100

## Details
* remove PinchRecognizer from hammer manager when disconnecting PinchInput
* make PanInput destroy hammer manager only when one recognizer left.