### PR TITLE
fix: call preventDefault only when it's cancelable

### DIFF
--- a/src/inputType/PanInput.ts
+++ b/src/inputType/PanInput.ts
@@ -266,8 +266,10 @@ export class PanInput implements IInputType {
 			]);
 		const prevent = offset.some(v => v !== 0);
 		if (prevent) {
-			event.srcEvent.preventDefault();
-			event.srcEvent.stopPropagation();
+			const srcEvent = event.srcEvent;
+
+			srcEvent.cancelable && srcEvent.preventDefault();
+			srcEvent.stopPropagation();
 		}
 		event.preventSystemEvent = prevent;
 		prevent && this.observer.change(this, event, toAxis(this.axes, offset));


### PR DESCRIPTION
Calling preventDefault when cancelable=false can produce error message in console.
```
[Intervention] Ignored attempt to cancel a touchmove event with cancelable=false, 
for example because scrolling is in progress and cannot be interrupted.
```

Issue: #147 