### PR TITLE
remove hammerjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,15 +38,13 @@
 		"name": "NAVER Corp."
 	},
 	"namespace": {
-		"eg": "eg",
-		"Hammer": "Hammer"
+		"eg": "eg"
 	},
 	"license": "MIT",
 	"homepage": "https://github.com/naver/egjs-axes",
 	"dependencies": {
 		"@egjs/agent": "^2.2.1",
-		"@egjs/component": "^2.2.2",
-		"@egjs/hammerjs": "^2.0.15"
+		"@egjs/component": "^2.2.2"
 	},
 	"devDependencies": {
 		"@egjs/build-helper": "^0.1.2",
@@ -63,8 +61,6 @@
 		"egjs-jsdoc-template": "^1.4.4",
 		"fs-extra": "^5.0.0",
 		"gh-pages": "^1.1.0",
-		"hammer-simulator": "0.0.1",
-		"hammerjs-compatible": "^1.1.0",
 		"husky": "^0.14.3",
 		"inject-loader": "^3.0.1",
 		"istanbul-instrumenter-loader": "^3.0.0",

--- a/packages/react/package-lock.json
+++ b/packages/react/package-lock.json
@@ -9,8 +9,7 @@
       "resolved": "https://registry.npmjs.org/@egjs/axes/-/axes-2.4.3.tgz",
       "integrity": "sha512-IT57seJDfrlwLhIuTybyHhPPyVuyCQGzRjvSZUzZKPNX3CzPR+a8nSTU3L/uyVmlQOwXtFxU5nVD3qXxUytnbg==",
       "requires": {
-        "@egjs/component": "2.1.0",
-        "hammerjs": "2.0.8"
+        "@egjs/component": "2.1.0"
       }
     },
     "@egjs/component": {
@@ -4918,11 +4917,6 @@
       "requires": {
         "duplexer": "0.1.1"
       }
-    },
-    "hammerjs": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/hammerjs/-/hammerjs-2.0.8.tgz",
-      "integrity": "sha1-BO93hiz/K7edMPdpIJWTAiK/YPE="
     },
     "handle-thing": {
       "version": "1.2.5",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,7 +1,6 @@
 const buildHelper = require("@egjs/build-helper");
 
 const external = {
-	"@egjs/hammerjs": "Hammer",
 	"@egjs/agent": "eg.agent",
 	"@egjs/component": "eg.Component",
 };

--- a/src/Axes.ts
+++ b/src/Axes.ts
@@ -262,13 +262,6 @@ export default class Axes extends Component<AxesEvents> {
 			this.disconnect(inputType);
 		}
 
-		// check same element in hammer type for share
-		if ("hammer" in inputType) {
-			const targets = this._inputs.filter(v => v.hammer && v.element === inputType.element);
-			if (targets.length) {
-				inputType.hammer = targets[0].hammer;
-			}
-		}
 		inputType.mapAxes(mapped);
 		inputType.connect(this.io);
 		this._inputs.push(inputType);

--- a/src/const.ts
+++ b/src/const.ts
@@ -26,3 +26,9 @@ export const TRANSFORM = (() => {
 	}
 	return "";
 })();
+
+export const cssProps = {
+	"touch-action": "none",
+	"user-select": "none",
+	"-webkit-user-drag": "none",
+};

--- a/src/const.ts
+++ b/src/const.ts
@@ -1,22 +1,12 @@
-// export const DIRECTION_NONE = 1;
-// export const DIRECTION_LEFT = 2;
-// export const DIRECTION_RIGHT = 4;
-// export const DIRECTION_HORIZONTAL = 2 | 4;
-// export const DIRECTION_UP = 8;
-// export const DIRECTION_DOWN = 16;
-// export const DIRECTION_VERTICAL = 8 | 16;
-// export const DIRECTION_ALL = 2 | 4 | 8 | 16;
+export const DIRECTION_NONE = 1;
+export const DIRECTION_LEFT = 2;
+export const DIRECTION_RIGHT = 4;
+export const DIRECTION_HORIZONTAL = 2 | 4;
+export const DIRECTION_UP = 8;
+export const DIRECTION_DOWN = 16;
+export const DIRECTION_VERTICAL = 8 | 16;
+export const DIRECTION_ALL = 2 | 4 | 8 | 16;
 
-export {
-	DIRECTION_NONE,
-	DIRECTION_LEFT,
-	DIRECTION_RIGHT,
-	DIRECTION_UP,
-	DIRECTION_DOWN,
-	DIRECTION_HORIZONTAL,
-	DIRECTION_VERTICAL,
-	DIRECTION_ALL,
-} from "@egjs/hammerjs";
 import getAgent from "@egjs/agent";
 import { window } from "./browser";
 

--- a/src/inputType/InputType.ts
+++ b/src/inputType/InputType.ts
@@ -48,14 +48,40 @@ export function convertInputType(inputType: string[] = []): ActiveInput {
 			// no default
 		}
 	});
-	if (hasPointer) {
-		return "pointer";
+	if (hasPointer && "PointerEvent" in window) {
+		return {
+			start: ["pointerdown"],
+			move: ["pointermove"],
+			end: ["pointerup", "pointercancel"],
+		};
+	} else if (hasPointer && "MSPointerEvent" in window) {
+		return {
+			start: ["MSPointerDown"],
+			move: ["MSPointerMove"],
+			end: ["MSPointerUp", "MSPointerCancel"],
+		};
 	} else if (hasTouch && hasMouse) {
-		return "touchmouse";
+		return {
+			start: ["mousedown", "touchstart"],
+			move: ["mousemove", "touchmove"],
+			end: ["mouseup", "touchend", "touchcancel"],
+		};
 	} else if (hasTouch) {
-		return "touch";
+		return {
+			start: ["touchstart"],
+			move: ["touchmove"],
+			end: ["touchend", "touchcancel"],
+		};
 	} else if (hasMouse) {
-		return "mouse";
+		return {
+			start: ["mousedown"],
+			move: ["mousemove"],
+			end: ["mouseup"],
+		};
 	}
-	return null;
+	return {
+		start: [],
+		move: [],
+		end: [],
+	};
 }

--- a/src/inputType/InputType.ts
+++ b/src/inputType/InputType.ts
@@ -1,12 +1,11 @@
-import {Manager, PointerEventInput, TouchMouseInput, TouchInput, MouseInput} from "@egjs/hammerjs";
 import { Axis } from "../AxisManager";
 import { AxesOption } from "../Axes";
 import { window } from "../browser";
+import { ActiveInput } from "..";
 
 export interface IInputType {
 	axes: string[];
 	element: HTMLElement;
-	hammer?;
 	mapAxes(axes: string[]);
 	connect(observer: IInputTypeObserver): IInputType;
 	disconnect();
@@ -24,7 +23,7 @@ export interface IInputTypeObserver {
 	release(inputType: IInputType, event, offset: Axis, duration?: number);
 }
 
-export const SUPPORT_POINTER_EVENTS = "PointerEvent" in window || "MSPointerEvent" in window;
+export const SUPPORT_POINTER_EVENTS = "PointerEvent" in window || "MSPointerEvent" in window; // TODO: support pointer events at Pan, Pinch
 export const SUPPORT_TOUCH = "ontouchstart" in window;
 export const UNIQUEKEY = "_EGJS_AXES_INPUTTYPE_";
 export function toAxis(source: string[], offset: number[]): Axis {
@@ -35,35 +34,24 @@ export function toAxis(source: string[], offset: number[]): Axis {
 		return acc;
 	}, {});
 }
-export function createHammer(element: HTMLElement, options) {
-	try {
-		// create Hammer
-		return new Manager(element, { ...options });
-	} catch (e) {
-		return null;
-	}
-}
-export function convertInputType(inputType: string[] = []): any {
+
+export function convertInputType(inputType: string[] = []): ActiveInput {
 	let hasTouch = false;
 	let hasMouse = false;
-	let hasPointer = false;
 
 	inputType.forEach(v => {
 		switch (v) {
 			case "mouse": hasMouse = true; break;
-			case "touch": hasTouch = SUPPORT_TOUCH; break;
-			case "pointer": hasPointer = SUPPORT_POINTER_EVENTS;
+			case "touch": hasTouch = SUPPORT_TOUCH;
 			// no default
 		}
 	});
-	if (hasPointer) {
-		return PointerEventInput;
-	} else if (hasTouch && hasMouse) {
-		return TouchMouseInput;
+	if (hasTouch && hasMouse) {
+		return 'touchmouse';
 	} else if (hasTouch) {
-		return TouchInput;
+		return 'touch';
 	} else if (hasMouse) {
-		return MouseInput;
+		return 'mouse';
 	}
 	return null;
 }

--- a/src/inputType/InputType.ts
+++ b/src/inputType/InputType.ts
@@ -23,7 +23,7 @@ export interface IInputTypeObserver {
 	release(inputType: IInputType, event, offset: Axis, duration?: number);
 }
 
-export const SUPPORT_POINTER_EVENTS = "PointerEvent" in window || "MSPointerEvent" in window; // TODO: support pointer events at Pan, Pinch
+export const SUPPORT_POINTER_EVENTS = "PointerEvent" in window || "MSPointerEvent" in window;
 export const SUPPORT_TOUCH = "ontouchstart" in window;
 export const UNIQUEKEY = "_EGJS_AXES_INPUTTYPE_";
 export function toAxis(source: string[], offset: number[]): Axis {
@@ -38,15 +38,19 @@ export function toAxis(source: string[], offset: number[]): Axis {
 export function convertInputType(inputType: string[] = []): ActiveInput {
 	let hasTouch = false;
 	let hasMouse = false;
+	let hasPointer = false;
 
 	inputType.forEach(v => {
 		switch (v) {
 			case "mouse": hasMouse = true; break;
-			case "touch": hasTouch = SUPPORT_TOUCH;
+			case "touch": hasTouch = SUPPORT_TOUCH; break;
+			case "pointer": hasPointer = SUPPORT_POINTER_EVENTS;
 			// no default
 		}
 	});
-	if (hasTouch && hasMouse) {
+	if (hasPointer) {
+		return "pointer";
+	} else if (hasTouch && hasMouse) {
 		return "touchmouse";
 	} else if (hasTouch) {
 		return "touch";

--- a/src/inputType/InputType.ts
+++ b/src/inputType/InputType.ts
@@ -47,11 +47,11 @@ export function convertInputType(inputType: string[] = []): ActiveInput {
 		}
 	});
 	if (hasTouch && hasMouse) {
-		return 'touchmouse';
+		return "touchmouse";
 	} else if (hasTouch) {
-		return 'touch';
+		return "touch";
 	} else if (hasMouse) {
-		return 'mouse';
+		return "mouse";
 	}
 	return null;
 }

--- a/src/inputType/InputType.ts
+++ b/src/inputType/InputType.ts
@@ -23,8 +23,10 @@ export interface IInputTypeObserver {
 	release(inputType: IInputType, event, offset: Axis, duration?: number);
 }
 
-export const SUPPORT_POINTER_EVENTS = "PointerEvent" in window || "MSPointerEvent" in window;
 export const SUPPORT_TOUCH = "ontouchstart" in window;
+export const SUPPORT_POINTER = "PointerEvent" in window;
+export const SUPPORT_MSPOINTER = "MSPointerEvent" in window;
+export const SUPPORT_POINTER_EVENTS = SUPPORT_POINTER || SUPPORT_MSPOINTER;
 export const UNIQUEKEY = "_EGJS_AXES_INPUTTYPE_";
 export function toAxis(source: string[], offset: number[]): Axis {
 	return offset.reduce((acc, v, i) => {

--- a/src/inputType/PanInput.ts
+++ b/src/inputType/PanInput.ts
@@ -97,7 +97,7 @@ export class PanInput implements IInputType {
 	constructor(el: string | HTMLElement, options?: PanInputOption) {
 		this.element = $(el);
 		this.options = {
-			inputType: ["touch", "mouse"],
+			inputType: ["touch", "mouse", "pointer"],
 			scale: [1, 1],
 			thresholdAngle: 45,
 			threshold: 0,
@@ -327,34 +327,58 @@ export class PanInput implements IInputType {
 		this.observer = observer;
 		this.isEnabled = true;
 		this.activeInput = convertInputType(this.options.inputType);
-		if (!this.activeInput) {
-			throw new Error("Wrong inputType parameter!");
-		}
-
-		if (this.activeInput === "mouse" || this.activeInput === "touchmouse") {
-			this.element.addEventListener("mousedown", this.onPanstart, false);
-			window.addEventListener("mousemove", this.onPanmove, false);
-			window.addEventListener("mouseup", this.onPanend, false);
-		}
-		if (this.activeInput === "touch" || this.activeInput === "touchmouse") {
-			this.element.addEventListener("touchstart", this.onPanstart, false);
-			window.addEventListener("touchmove", this.onPanmove, false);
-			window.addEventListener("touchend", this.onPanend, false);
-			window.addEventListener("touchcancel", this.onPanend, false);
+		if (this.activeInput === "pointer") {
+			if ("PointerEvent" in window) {
+				this.element.addEventListener("pointerdown", this.onPanstart, false);
+				window.addEventListener("pointermove", this.onPanmove, false);
+				window.addEventListener("pointerup", this.onPanend, false);
+				window.addEventListener("pointercancel", this.onPanend, false);
+			} else if ("MSPointerEvent" in window) {
+				this.element.addEventListener("MSPointerDown", this.onPanstart, false);
+				window.addEventListener("MSPointerMove", this.onPanmove, false);
+				window.addEventListener("MSPointerUp", this.onPanend, false);
+				window.addEventListener("MSPointerCancel", this.onPanend, false);
+			}
+		} else {
+			if (this.activeInput === "mouse" || this.activeInput === "touchmouse") {
+				this.element.addEventListener("mousedown", this.onPanstart, false);
+				window.addEventListener("mousemove", this.onPanmove, false);
+				window.addEventListener("mouseup", this.onPanend, false);
+			}
+			if (this.activeInput === "touch" || this.activeInput === "touchmouse") {
+				this.element.addEventListener("touchstart", this.onPanstart, false);
+				window.addEventListener("touchmove", this.onPanmove, false);
+				window.addEventListener("touchend", this.onPanend, false);
+				window.addEventListener("touchcancel", this.onPanend, false);
+			}
 		}
 	}
 
 	private dettachEvent() {
-		if (this.activeInput === "mouse" || this.activeInput === "touchmouse") {
-			this.element.removeEventListener("mousedown", this.onPanstart, false);
-			window.removeEventListener("mousemove", this.onPanmove, false);
-			window.removeEventListener("mouseup", this.onPanend, false);
-		}
-		if (this.activeInput === "touch" || this.activeInput === "touchmouse") {
-			this.element.removeEventListener("touchstart", this.onPanstart, false);
-			window.removeEventListener("touchmove", this.onPanmove, false);
-			window.removeEventListener("touchend", this.onPanend, false);
-			window.removeEventListener("touchcancel", this.onPanend, false);
+		if (this.activeInput === "pointer") {
+			if ("PointerEvent" in window) {
+				this.element.removeEventListener("pointerdown", this.onPanstart, false);
+				window.removeEventListener("pointermove", this.onPanmove, false);
+				window.removeEventListener("pointerup", this.onPanend, false);
+				window.removeEventListener("pointercancel", this.onPanend, false);
+			} else if ("MSPointerEvent" in window) {
+				this.element.removeEventListener("MSPointerDown", this.onPanstart, false);
+				window.removeEventListener("MSPointerMove", this.onPanmove, false);
+				window.removeEventListener("MSPointerUp", this.onPanend, false);
+				window.removeEventListener("MSPointerCancel", this.onPanend, false);
+			}
+		} else {
+			if (this.activeInput === "mouse" || this.activeInput === "touchmouse") {
+				this.element.removeEventListener("mousedown", this.onPanstart, false);
+				window.removeEventListener("mousemove", this.onPanmove, false);
+				window.removeEventListener("mouseup", this.onPanend, false);
+			}
+			if (this.activeInput === "touch" || this.activeInput === "touchmouse") {
+				this.element.removeEventListener("touchstart", this.onPanstart, false);
+				window.removeEventListener("touchmove", this.onPanmove, false);
+				window.removeEventListener("touchend", this.onPanend, false);
+				window.removeEventListener("touchcancel", this.onPanend, false);
+			}
 		}
 		this.isEnabled = false;
 		this.observer = null;

--- a/src/inputType/PanInput.ts
+++ b/src/inputType/PanInput.ts
@@ -87,7 +87,11 @@ export class PanInput implements IInputType {
 	element: HTMLElement = null;
 	protected observer: IInputTypeObserver;
 	protected _direction;
-	private activeInput: ActiveInput = null;
+	private activeInput: ActiveInput = {
+		start: [],
+		move: [],
+		end: [],
+	};
 	private isEnabled = false;
 	private isRightEdge = false;
 	private rightEdgeTimer = 0;
@@ -281,7 +285,7 @@ export class PanInput implements IInputType {
 
 	protected transformEvent(event: InputEventType): PanEvent {
 		const prev = this.prevInput;
-		if (event.type === "mouseup" || event.type === "touchend") {
+		if (this.activeInput.end.indexOf(event.type) !== -1) {
 			return prev;
 		}
 		const center = getCenter(event);
@@ -327,59 +331,27 @@ export class PanInput implements IInputType {
 		this.observer = observer;
 		this.isEnabled = true;
 		this.activeInput = convertInputType(this.options.inputType);
-		if (this.activeInput === "pointer") {
-			if ("PointerEvent" in window) {
-				this.element.addEventListener("pointerdown", this.onPanstart, false);
-				window.addEventListener("pointermove", this.onPanmove, false);
-				window.addEventListener("pointerup", this.onPanend, false);
-				window.addEventListener("pointercancel", this.onPanend, false);
-			} else if ("MSPointerEvent" in window) {
-				this.element.addEventListener("MSPointerDown", this.onPanstart, false);
-				window.addEventListener("MSPointerMove", this.onPanmove, false);
-				window.addEventListener("MSPointerUp", this.onPanend, false);
-				window.addEventListener("MSPointerCancel", this.onPanend, false);
-			}
-		} else {
-			if (this.activeInput === "mouse" || this.activeInput === "touchmouse") {
-				this.element.addEventListener("mousedown", this.onPanstart, false);
-				window.addEventListener("mousemove", this.onPanmove, false);
-				window.addEventListener("mouseup", this.onPanend, false);
-			}
-			if (this.activeInput === "touch" || this.activeInput === "touchmouse") {
-				this.element.addEventListener("touchstart", this.onPanstart, false);
-				window.addEventListener("touchmove", this.onPanmove, false);
-				window.addEventListener("touchend", this.onPanend, false);
-				window.addEventListener("touchcancel", this.onPanend, false);
-			}
-		}
+		this.activeInput.start.forEach(event => {
+			this.element.addEventListener(event, this.onPanstart, false);
+		});
+		this.activeInput.move.forEach(event => {
+			window.addEventListener(event, this.onPanmove, false);
+		});
+		this.activeInput.end.forEach(event => {
+			window.addEventListener(event, this.onPanend, false);
+		});
 	}
 
 	private dettachEvent() {
-		if (this.activeInput === "pointer") {
-			if ("PointerEvent" in window) {
-				this.element.removeEventListener("pointerdown", this.onPanstart, false);
-				window.removeEventListener("pointermove", this.onPanmove, false);
-				window.removeEventListener("pointerup", this.onPanend, false);
-				window.removeEventListener("pointercancel", this.onPanend, false);
-			} else if ("MSPointerEvent" in window) {
-				this.element.removeEventListener("MSPointerDown", this.onPanstart, false);
-				window.removeEventListener("MSPointerMove", this.onPanmove, false);
-				window.removeEventListener("MSPointerUp", this.onPanend, false);
-				window.removeEventListener("MSPointerCancel", this.onPanend, false);
-			}
-		} else {
-			if (this.activeInput === "mouse" || this.activeInput === "touchmouse") {
-				this.element.removeEventListener("mousedown", this.onPanstart, false);
-				window.removeEventListener("mousemove", this.onPanmove, false);
-				window.removeEventListener("mouseup", this.onPanend, false);
-			}
-			if (this.activeInput === "touch" || this.activeInput === "touchmouse") {
-				this.element.removeEventListener("touchstart", this.onPanstart, false);
-				window.removeEventListener("touchmove", this.onPanmove, false);
-				window.removeEventListener("touchend", this.onPanend, false);
-				window.removeEventListener("touchcancel", this.onPanend, false);
-			}
-		}
+		this.activeInput.start.forEach(event => {
+			this.element.removeEventListener(event, this.onPanstart, false);
+		});
+		this.activeInput.move.forEach(event => {
+			window.removeEventListener(event, this.onPanmove, false);
+		});
+		this.activeInput.end.forEach(event => {
+			window.removeEventListener(event, this.onPanend, false);
+		});
 		this.isEnabled = false;
 		this.observer = null;
 	}

--- a/src/inputType/PanInput.ts
+++ b/src/inputType/PanInput.ts
@@ -281,7 +281,7 @@ export class PanInput implements IInputType {
 
 	protected transformEvent(event: InputEventType): PanEvent {
 		const prev = this.prevInput;
-		if (event.type === 'mouseup' || event.type === 'touchend') {
+		if (event.type === "mouseup" || event.type === "touchend") {
 			return prev;
 		}
 		const center = getCenter(event);
@@ -331,12 +331,12 @@ export class PanInput implements IInputType {
 			throw new Error("Wrong inputType parameter!");
 		}
 
-		if (this.activeInput === 'mouse' || this.activeInput === 'touchmouse') {
+		if (this.activeInput === "mouse" || this.activeInput === "touchmouse") {
 			this.element.addEventListener("mousedown", this.onPanstart, false);
 			window.addEventListener("mousemove", this.onPanmove, false);
 			window.addEventListener("mouseup", this.onPanend, false);
 		}
-		if (this.activeInput === 'touch' || this.activeInput === 'touchmouse') {
+		if (this.activeInput === "touch" || this.activeInput === "touchmouse") {
 			this.element.addEventListener("touchstart", this.onPanstart, false);
 			window.addEventListener("touchmove", this.onPanmove, false);
 			window.addEventListener("touchend", this.onPanend, false);
@@ -345,12 +345,12 @@ export class PanInput implements IInputType {
 	}
 
 	private dettachEvent() {
-		if (this.activeInput === 'mouse' || this.activeInput === 'touchmouse') {
+		if (this.activeInput === "mouse" || this.activeInput === "touchmouse") {
 			this.element.removeEventListener("mousedown", this.onPanstart, false);
 			window.removeEventListener("mousemove", this.onPanmove, false);
 			window.removeEventListener("mouseup", this.onPanend, false);
 		}
-		if (this.activeInput === 'touch' || this.activeInput === 'touchmouse') {
+		if (this.activeInput === "touch" || this.activeInput === "touchmouse") {
 			this.element.removeEventListener("touchstart", this.onPanstart, false);
 			window.removeEventListener("touchmove", this.onPanmove, false);
 			window.removeEventListener("touchend", this.onPanend, false);

--- a/src/inputType/PanInput.ts
+++ b/src/inputType/PanInput.ts
@@ -1,6 +1,6 @@
-import { $, getAngle, getCenter, getMovement, getTouches } from "../utils";
+import { $, setCssProps, getAngle, getCenter, getMovement, getTouches } from "../utils";
 import { convertInputType, IInputType, IInputTypeObserver, toAxis, UNIQUEKEY } from "./InputType";
-import { IS_IOS_SAFARI, IOS_EDGE_THRESHOLD, DIRECTION_NONE, DIRECTION_VERTICAL, DIRECTION_HORIZONTAL, DIRECTION_ALL } from "../const";
+import { IS_IOS_SAFARI, IOS_EDGE_THRESHOLD, DIRECTION_NONE, DIRECTION_VERTICAL, DIRECTION_HORIZONTAL, DIRECTION_ALL, cssProps } from "../const";
 import { ActiveInput, InputEventType, PanEvent } from "..";
 
 export interface PanInputOption {
@@ -85,6 +85,7 @@ export class PanInput implements IInputType {
 	options: PanInputOption;
 	axes: string[] = [];
 	element: HTMLElement = null;
+	originalCssProps: { [key: string]: string; } = {};
 	protected observer: IInputTypeObserver;
 	protected _direction;
 	private activeInput: ActiveInput = {
@@ -138,11 +139,15 @@ export class PanInput implements IInputType {
 		}
 		this.element[UNIQUEKEY] = keyValue;
 		this.attachEvent(observer);
+		this.originalCssProps = setCssProps(this.element);
 		return this;
 	}
 
 	public disconnect() {
 		this.dettachEvent();
+		if (this.originalCssProps !== cssProps) {
+			setCssProps(this.element, this.originalCssProps);
+		}
 		this._direction = DIRECTION_NONE;
 		return this;
 	}

--- a/src/inputType/PinchInput.ts
+++ b/src/inputType/PinchInput.ts
@@ -35,7 +35,11 @@ export class PinchInput implements IInputType {
 	axes: string[] = [];
 	element: HTMLElement = null;
 	private observer: IInputTypeObserver;
-	private activeInput: ActiveInput = null;
+	private activeInput: ActiveInput = {
+		start: [],
+		move: [],
+		end: [],
+	};
 	private isEnabled = false;
 	private pinchFlag = false;
 	private baseValue: number = null;
@@ -182,45 +186,27 @@ export class PinchInput implements IInputType {
 		this.observer = observer;
 		this.isEnabled = true;
 		this.activeInput = convertInputType(this.options.inputType);
-		if (this.activeInput === "pointer") {
-			if ("PointerEvent" in window) {
-				this.element.addEventListener("pointerdown", this.onPinchStart, false);
-				this.element.addEventListener("pointermove", this.onPinchMove, false);
-				this.element.addEventListener("pointerup", this.onPinchEnd, false);
-				this.element.addEventListener("pointercancel", this.onPinchEnd, false);
-			} else if ("MSPointerEvent" in window) {
-				this.element.addEventListener("MSPointerDown", this.onPinchStart, false);
-				this.element.addEventListener("MSPointerMove", this.onPinchMove, false);
-				this.element.addEventListener("MSPointerUp", this.onPinchEnd, false);
-				this.element.addEventListener("MSPointerCancel", this.onPinchEnd, false);
-			}
-		} else {
-			this.element.addEventListener("touchstart", this.onPinchStart, false);
-			this.element.addEventListener("touchmove", this.onPinchMove, false);
-			this.element.addEventListener("touchend", this.onPinchEnd, false);
-			this.element.addEventListener("touchcancel", this.onPinchEnd, false);
-		}
+		this.activeInput.start.forEach(event => {
+			this.element.addEventListener(event, this.onPinchStart, false);
+		});
+		this.activeInput.move.forEach(event => {
+			this.element.addEventListener(event, this.onPinchMove, false);
+		});
+		this.activeInput.end.forEach(event => {
+			this.element.addEventListener(event, this.onPinchEnd, false);
+		});
 	}
 
 	private dettachEvent() {
-		if (this.activeInput === "pointer") {
-			if ("PointerEvent" in window) {
-				this.element.removeEventListener("pointerdown", this.onPinchStart, false);
-				this.element.removeEventListener("pointermove", this.onPinchMove, false);
-				this.element.removeEventListener("pointerup", this.onPinchEnd, false);
-				this.element.removeEventListener("pointercancel", this.onPinchEnd, false);
-			} else if ("MSPointerEvent" in window) {
-				this.element.removeEventListener("MSPointerDown", this.onPinchStart, false);
-				this.element.removeEventListener("MSPointerMove", this.onPinchMove, false);
-				this.element.removeEventListener("MSPointerUp", this.onPinchEnd, false);
-				this.element.removeEventListener("MSPointerCancel", this.onPinchEnd, false);
-			}
-		} else {
-			this.element.removeEventListener("touchstart", this.onPinchStart, false);
-			this.element.removeEventListener("touchmove", this.onPinchMove, false);
-			this.element.removeEventListener("touchend", this.onPinchEnd, false);
-			this.element.removeEventListener("touchcancel", this.onPinchEnd, false);
-		}
+		this.activeInput.start.forEach(event => {
+			this.element.removeEventListener(event, this.onPinchStart, false);
+		});
+		this.activeInput.move.forEach(event => {
+			this.element.removeEventListener(event, this.onPinchMove, false);
+		});
+		this.activeInput.end.forEach(event => {
+			this.element.removeEventListener(event, this.onPinchEnd, false);
+		});
 		this.isEnabled = false;
 		this.observer = null;
 	}

--- a/src/inputType/PinchInput.ts
+++ b/src/inputType/PinchInput.ts
@@ -1,4 +1,4 @@
-import { $ } from "../utils";
+import { $, getTouches } from "../utils";
 import { UNIQUEKEY, toAxis, convertInputType, IInputType, IInputTypeObserver } from "./InputType";
 import { ActiveInput, InputEventType, PinchEvent } from "..";
 
@@ -127,7 +127,7 @@ export class PinchInput implements IInputType {
 		if (event instanceof PointerEvent) {
 			this.addPointerEvent(event);
 		}
-		if (!this.isEnable() || this.getTouches(event) !== 2) {
+		if (!this.isEnable() || getTouches(event, this.eventCache) !== 2) {
 			return;
 		}
 
@@ -143,7 +143,7 @@ export class PinchInput implements IInputType {
 		if (event instanceof PointerEvent) {
 			this.addPointerEvent(event);
 		}
-		if (!this.pinchFlag || !this.isEnable() || this.getTouches(event) !== 2) {
+		if (!this.pinchFlag || !this.isEnable() || getTouches(event, this.eventCache) !== 2) {
 			return;
 		}
 
@@ -157,7 +157,7 @@ export class PinchInput implements IInputType {
 		if (event instanceof PointerEvent) {
 			this.removePointerEvent(event);
 		}
-		if (!this.pinchFlag || !this.isEnable() || this.getTouches(event) > 2) {
+		if (!this.pinchFlag || !this.isEnable() || getTouches(event, this.eventCache) > 2) {
 			return;
 		}
 
@@ -209,14 +209,6 @@ export class PinchInput implements IInputType {
 		});
 		this.isEnabled = false;
 		this.observer = null;
-	}
-
-	private getTouches(event: InputEventType) {
-		if (event instanceof PointerEvent) {
-			return this.eventCache.length;
-		} else if (event instanceof TouchEvent) {
-			return event.touches.length;
-		}
 	}
 
 	private getOffset(pinchScale: number, prev: number = 1): number {

--- a/src/inputType/PinchInput.ts
+++ b/src/inputType/PinchInput.ts
@@ -102,7 +102,7 @@ export class PinchInput implements IInputType {
 	 * @method eg.Axes.PinchInput#disable
 	 * @return {eg.Axes.PinchInput} An instance of a module itself <ko>모듈 자신의 인스턴스</ko>
 	 */
-	 public disable() {
+	public disable() {
 		this.isEnabled = false;
 		return this;
 	}
@@ -157,7 +157,7 @@ export class PinchInput implements IInputType {
 		return {
 			srcEvent: event,
 			scale: this.getScale(this.firstInput.touches, event.touches),
-		}
+		};
 	}
 
 	private attachEvent(observer: IInputTypeObserver) {
@@ -192,8 +192,8 @@ export class PinchInput implements IInputType {
 	}
 
 	private getDistance(p1, p2) {
-		let x = p2.clientX - p1.clientX;
-		let y = p2.clientY - p1.clientY;
+		const x = p2.clientX - p1.clientX;
+		const y = p2.clientY - p1.clientY;
 		return Math.sqrt((x * x) + (y * y));
 	}
 }

--- a/src/inputType/PinchInput.ts
+++ b/src/inputType/PinchInput.ts
@@ -1,6 +1,7 @@
-import { $, getTouches } from "../utils";
+import { $, getTouches, setCssProps } from "../utils";
 import { UNIQUEKEY, toAxis, convertInputType, IInputType, IInputTypeObserver } from "./InputType";
 import { ActiveInput, InputEventType, PinchEvent } from "..";
+import { cssProps } from "../const";
 
 export interface PinchInputOption {
 	scale?: number;
@@ -34,6 +35,7 @@ export class PinchInput implements IInputType {
 	options: PinchInputOption;
 	axes: string[] = [];
 	element: HTMLElement = null;
+	originalCssProps: { [key: string]: string; } = {};
 	private observer: IInputTypeObserver;
 	private activeInput: ActiveInput = {
 		start: [],
@@ -73,11 +75,15 @@ export class PinchInput implements IInputType {
 		}
 		this.element[UNIQUEKEY] = keyValue;
 		this.attachEvent(observer);
+		this.originalCssProps = setCssProps(this.element);
 		return this;
 	}
 
 	public disconnect() {
 		this.dettachEvent();
+		if (this.originalCssProps !== cssProps) {
+			setCssProps(this.element, this.originalCssProps);
+		}
 		return this;
 	}
 

--- a/src/inputType/PinchInput.ts
+++ b/src/inputType/PinchInput.ts
@@ -1,13 +1,11 @@
-import { Manager, Pinch } from "@egjs/hammerjs";
 import { $ } from "../utils";
-import { UNIQUEKEY, toAxis, convertInputType, createHammer, IInputType, IInputTypeObserver } from "./InputType";
-import { ObjectInterface } from "../types";
+import { UNIQUEKEY, toAxis, convertInputType, IInputType, IInputTypeObserver } from "./InputType";
+import { ActiveInput, PinchEvent } from "..";
 
 export interface PinchInputOption {
 	scale?: number;
 	threshold?: number;
 	inputType?: string[];
-	hammerManagerOptions?: ObjectInterface;
 }
 
 /**
@@ -15,7 +13,6 @@ export interface PinchInputOption {
  * @ko eg.Axes.PinchInput 모듈의 옵션 객체
  * @property {Number} [scale=1] Coordinate scale that a user can move<ko>사용자의 동작으로 이동하는 좌표의 배율</ko>
  * @property {Number} [threshold=0] Minimal scale before recognizing <ko>사용자의 Pinch 동작을 인식하기 위해산 최소한의 배율</ko>
- * @property {Object} [hammerManagerOptions={cssProps: {userSelect: "none",touchSelect: "none",touchCallout: "none",userDrag: "none"}] Options of Hammer.Manager <ko>Hammer.Manager의 옵션</ko>
 **/
 
 /**
@@ -34,46 +31,23 @@ export interface PinchInputOption {
  * @param {PinchInputOption} [options] The option object of the eg.Axes.PinchInput module<ko>eg.Axes.PinchInput 모듈의 옵션 객체</ko>
  */
 export class PinchInput implements IInputType {
-
 	options: PinchInputOption;
 	axes: string[] = [];
-	hammer = null;
 	element: HTMLElement = null;
-
 	private observer: IInputTypeObserver;
-	private _base: number = null;
-	private _prev: number = null;
-	private pinchRecognizer = null;
+	private activeInput: ActiveInput = null;
+	private isEnabled = false;
+	private pinchFlag = false;
+	private baseValue: number = null;
+	private firstInput: TouchEvent = null;
+	private prevInput: PinchEvent = null;
 
-	constructor(el, options?: PinchInputOption) {
-		/**
-		 * Hammer helps you add support for touch gestures to your page
-		 *
-		 * @external Hammer
-		 * @see {@link http://hammerjs.github.io|Hammer.JS}
-		 * @see {@link http://hammerjs.github.io/jsdoc/Hammer.html|Hammer.JS API documents}
-		 * @see Hammer.JS applies specific CSS properties by {@link http://hammerjs.github.io/jsdoc/Hammer.defaults.cssProps.html|default} when creating an instance. The eg.Axes module removes all default CSS properties provided by Hammer.JS
-		 */
-		if (typeof Manager === "undefined") {
-			throw new Error(`The Hammerjs must be loaded before eg.Axes.PinchInput.\nhttp://hammerjs.github.io/`);
-		}
+	constructor(el: string | HTMLElement, options?: PinchInputOption) {
 		this.element = $(el);
 		this.options = {
-			...{
-				scale: 1,
-				threshold: 0,
-				inputType: ["touch", "pointer"],
-				hammerManagerOptions: {
-					// css properties were removed due to usablility issue
-					// http://hammerjs.github.io/jsdoc/Hammer.defaults.cssProps.html
-					cssProps: {
-						userSelect: "none",
-						touchSelect: "none",
-						touchCallout: "none",
-						userDrag: "none",
-					},
-				},
-			},
+			scale: 1,
+			threshold: 0,
+			inputType: ["touch"],
 			...options,
 		};
 		this.onPinchStart = this.onPinchStart.bind(this);
@@ -81,49 +55,23 @@ export class PinchInput implements IInputType {
 		this.onPinchEnd = this.onPinchEnd.bind(this);
 	}
 
-	mapAxes(axes: string[]) {
+	public mapAxes(axes: string[]) {
 		this.axes = axes;
 	}
 
-	connect(observer: IInputTypeObserver): IInputType {
-		const hammerOption = { threshold: this.options.threshold };
-
-		if (this.hammer) { // for sharing hammer instance.
-			// hammer remove previous PinchRecognizer.
-			this.removeRecognizer();
-			this.dettachEvent();
-		} else {
-			let keyValue: string = this.element[UNIQUEKEY];
-			if (!keyValue) {
-				keyValue = String(Math.round(Math.random() * new Date().getTime()));
-			}
-			const inputClass = convertInputType(this.options.inputType);
-			if (!inputClass) {
-				throw new Error("Wrong inputType parameter!");
-			}
-			this.hammer = createHammer(
-				this.element,
-				{
-					...{
-						inputClass,
-					}, ...this.options.hammerManagerOptions,
-				},
-			);
-			this.element[UNIQUEKEY] = keyValue;
+	public connect(observer: IInputTypeObserver): IInputType {
+		this.dettachEvent();
+		let keyValue: string = this.element[UNIQUEKEY];
+		if (!keyValue) {
+			keyValue = String(Math.round(Math.random() * new Date().getTime()));
 		}
-		this.pinchRecognizer = new Pinch(hammerOption);
-		this.hammer.add(this.pinchRecognizer);
+		this.element[UNIQUEKEY] = keyValue;
 		this.attachEvent(observer);
 		return this;
 	}
 
-	disconnect() {
-		this.removeRecognizer();
-		if (this.hammer) {
-			this.hammer.remove(this.pinchRecognizer);
-			this.pinchRecognizer = null;
-			this.dettachEvent();
-		}
+	public disconnect() {
+		this.dettachEvent();
 		return this;
 	}
 
@@ -132,59 +80,10 @@ export class PinchInput implements IInputType {
 	* @ko 모듈에 사용한 엘리먼트와 속성, 이벤트를 해제한다.
 	* @method eg.Axes.PinchInput#destroy
 	*/
-	destroy() {
+	public destroy() {
 		this.disconnect();
-		if (this.hammer && this.hammer.recognizers.length === 0) {
-			this.hammer.destroy();
-		}
 		delete this.element[UNIQUEKEY];
 		this.element = null;
-		this.hammer = null;
-	}
-
-	private removeRecognizer() {
-		if (this.hammer && this.pinchRecognizer) {
-			this.hammer.remove(this.pinchRecognizer);
-			this.pinchRecognizer = null;
-		}
-	}
-
-	private onPinchStart(event) {
-		this._base = this.observer.get(this)[this.axes[0]];
-		const offset = this.getOffset(event.scale);
-		this.observer.hold(this, event);
-		this.observer.change(this, event, toAxis(this.axes, [offset]));
-		this._prev = event.scale;
-	}
-	private onPinchMove(event) {
-		const offset = this.getOffset(event.scale, this._prev);
-		this.observer.change(this, event, toAxis(this.axes, [offset]));
-		this._prev = event.scale;
-	}
-	private onPinchEnd(event) {
-		const offset = this.getOffset(event.scale, this._prev);
-		this.observer.change(this, event, toAxis(this.axes, [offset]));
-		this.observer.release(this, event, toAxis(this.axes, [0]), 0);
-		this._base = null;
-		this._prev = null;
-	}
-	private getOffset(pinchScale: number, prev: number = 1): number {
-		return this._base * (pinchScale - prev) * this.options.scale;
-	}
-
-	private attachEvent(observer: IInputTypeObserver) {
-		this.observer = observer;
-		this.hammer.on("pinchstart", this.onPinchStart)
-			.on("pinchmove", this.onPinchMove)
-			.on("pinchend", this.onPinchEnd);
-	}
-
-	private dettachEvent() {
-		this.hammer.off("pinchstart", this.onPinchStart)
-			.off("pinchmove", this.onPinchMove)
-			.off("pinchend", this.onPinchEnd);
-		this.observer = null;
-		this._prev = null;
 	}
 
 	/**
@@ -193,8 +92,8 @@ export class PinchInput implements IInputType {
 	 * @method eg.Axes.PinchInput#enable
 	 * @return {eg.Axes.PinchInput} An instance of a module itself <ko>모듈 자신의 인스턴스</ko>
 	 */
-	enable() {
-		this.hammer && (this.hammer.get("pinch").options.enable = true);
+	public enable() {
+		this.isEnabled = true;
 		return this;
 	}
 	/**
@@ -203,17 +102,98 @@ export class PinchInput implements IInputType {
 	 * @method eg.Axes.PinchInput#disable
 	 * @return {eg.Axes.PinchInput} An instance of a module itself <ko>모듈 자신의 인스턴스</ko>
 	 */
-	disable() {
-		this.hammer && (this.hammer.get("pinch").options.enable = false);
+	 public disable() {
+		this.isEnabled = false;
 		return this;
 	}
+
 	/**
 	 * Returns whether to use an input device
 	 * @ko 입력 장치를 사용 여부를 반환한다.
 	 * @method eg.Axes.PinchInput#isEnable
 	 * @return {Boolean} Whether to use an input device <ko>입력장치 사용여부</ko>
 	 */
-	isEnable() {
-		return !!(this.hammer && this.hammer.get("pinch").options.enable);
+	public isEnable() {
+		return this.isEnabled;
+	}
+
+	private onPinchStart(event: TouchEvent) {
+		if (!this.isEnable() || event.touches.length !== 2) {
+			return;
+		}
+
+		this.baseValue = this.observer.get(this)[this.axes[0]];
+		this.firstInput = event;
+		this.observer.hold(this, event);
+		this.pinchFlag = true;
+		const pinchEvent = this.transformEvent(event);
+		this.prevInput = pinchEvent;
+	}
+
+	private onPinchMove(event: TouchEvent) {
+		if (!this.pinchFlag || !this.isEnable() || event.touches.length !== 2) {
+			return;
+		}
+
+		const pinchEvent = this.transformEvent(event);
+		const offset = this.getOffset(pinchEvent.scale, this.prevInput.scale);
+		this.observer.change(this, event, toAxis(this.axes, [offset]));
+		this.prevInput = pinchEvent;
+	}
+
+	private onPinchEnd(event: TouchEvent) {
+		if (!this.pinchFlag || !this.isEnable() || event.touches.length > 2) {
+			return;
+		}
+
+		this.observer.release(this, event, toAxis(this.axes, [0]), 0);
+		this.baseValue = null;
+		this.pinchFlag = false;
+		this.firstInput = null;
+		this.prevInput = null;
+	}
+
+	private transformEvent(event: TouchEvent): PinchEvent {
+		return {
+			srcEvent: event,
+			scale: this.getScale(this.firstInput.touches, event.touches),
+		}
+	}
+
+	private attachEvent(observer: IInputTypeObserver) {
+		this.observer = observer;
+		this.isEnabled = true;
+		this.activeInput = convertInputType(this.options.inputType);
+		if (!this.activeInput) {
+			throw new Error("Wrong inputType parameter!");
+		}
+
+		this.element.addEventListener("touchstart", this.onPinchStart, false);
+		this.element.addEventListener("touchmove", this.onPinchMove, false);
+		this.element.addEventListener("touchend", this.onPinchEnd, false);
+		this.element.addEventListener("touchcancel", this.onPinchEnd, false);
+	}
+
+	private dettachEvent() {
+		this.element.removeEventListener("touchstart", this.onPinchStart, false);
+		this.element.removeEventListener("touchmove", this.onPinchMove, false);
+		this.element.removeEventListener("touchend", this.onPinchEnd, false);
+		this.element.removeEventListener("touchcancel", this.onPinchEnd, false);
+		this.isEnabled = false;
+		this.observer = null;
+	}
+
+	private getOffset(pinchScale: number, prev: number = 1): number {
+		return this.baseValue * (pinchScale - prev) * this.options.scale;
+	}
+
+	private getScale(start, end) {
+		return this.getDistance(end[0], end[1]) / this.getDistance(start[0], start[1]);
+	}
+
+	private getDistance(p1, p2) {
+		let x = p2.clientX - p1.clientX;
+		let y = p2.clientY - p1.clientY;
+		return Math.sqrt((x * x) + (y * y));
 	}
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -77,7 +77,7 @@ export type OnFinish = {
 	isTrusted: boolean;
 };
 
-export type ActiveInput = 'touchmouse' | 'touch' | 'mouse';
+export type ActiveInput = "touchmouse" | "touch" | "mouse";
 export type InputEventType = MouseEvent | TouchEvent;
 
 export type PanEvent = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -77,8 +77,8 @@ export type OnFinish = {
 	isTrusted: boolean;
 };
 
-export type ActiveInput = "touchmouse" | "touch" | "mouse";
-export type InputEventType = MouseEvent | TouchEvent;
+export type ActiveInput = "pointer" | "touchmouse" | "touch" | "mouse";
+export type InputEventType = PointerEvent | MouseEvent | TouchEvent;
 
 export type PanEvent = {
 	srcEvent: InputEventType;

--- a/src/types.ts
+++ b/src/types.ts
@@ -76,3 +76,27 @@ export type OnAnimationEnd = {
 export type OnFinish = {
 	isTrusted: boolean;
 };
+
+export type ActiveInput = 'touchmouse' | 'touch' | 'mouse';
+export type InputEventType = MouseEvent | TouchEvent;
+
+export type PanEvent = {
+	srcEvent: InputEventType;
+	angle: number;
+	center: {
+		x: number;
+		y: number;
+	};
+	deltaX: number;
+	deltaY: number;
+	offsetX: number;
+	offsetY: number;
+	velocityX: number;
+	velocityY: number;
+	preventSystemEvent: boolean;
+};
+
+export type PinchEvent = {
+	srcEvent: InputEventType;
+	scale: number;
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -77,7 +77,11 @@ export type OnFinish = {
 	isTrusted: boolean;
 };
 
-export type ActiveInput = "pointer" | "touchmouse" | "touch" | "mouse";
+export type ActiveInput = {
+	start: string[],
+	move: string[],
+	end: string[],
+};
 export type InputEventType = PointerEvent | MouseEvent | TouchEvent;
 
 export type PanEvent = {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -224,3 +224,12 @@ export function getMovement(event: InputEventType, prev: InputEventType) {
 		y: event.movementY,
 	};
 }
+
+export function getTouches(event: InputEventType, eventCache: PointerEvent[]) {
+	if (event instanceof PointerEvent) {
+		return eventCache.length;
+	} else if (event instanceof TouchEvent) {
+		return event.touches.length;
+	}
+	return 0; // case of MouseEvent
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,4 @@
+import { InputEventType } from ".";
 import {window} from "./browser";
 import { ObjectInterface } from "./types";
 
@@ -184,5 +185,42 @@ export function getRoundFunc(v: number) {
 		}
 
 		return Math.round(Math.round(n / v) * v * p) / p;
+	};
+}
+
+export function getAngle(posX: number, posY: number) {
+	const angle = Math.atan2(posY, posX) * 180 / Math.PI;
+	return angle < 0 ? 360 + angle : angle;
+}
+
+export function getCenter(event: InputEventType) {
+	if (event instanceof TouchEvent) {
+		return {
+		  x: event.touches[0].clientX,
+		  y: event.touches[0].clientY,
+		};
+	}
+	return {
+		x: event.clientX,
+		y: event.clientY,
+	};
+}
+
+export function getMovement(event: InputEventType, prev: InputEventType) {
+	if (event instanceof TouchEvent) {
+		if (prev) {
+			return {
+				x: event.touches[0].pageX - (prev as TouchEvent).touches[0].pageX,
+				y: event.touches[0].pageY - (prev as TouchEvent).touches[0].pageY,
+			}
+		}
+		return {
+		  x: 0,
+		  y: 0,
+		};
+	}
+	return {
+		x: event.movementX,
+		y: event.movementY,
 	};
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -196,8 +196,8 @@ export function getAngle(posX: number, posY: number) {
 export function getCenter(event: InputEventType) {
 	if (event instanceof TouchEvent) {
 		return {
-		  x: event.touches[0].clientX,
-		  y: event.touches[0].clientY,
+			x: event.touches[0].clientX,
+			y: event.touches[0].clientY,
 		};
 	}
 	return {
@@ -212,11 +212,11 @@ export function getMovement(event: InputEventType, prev: InputEventType) {
 			return {
 				x: event.touches[0].pageX - (prev as TouchEvent).touches[0].pageX,
 				y: event.touches[0].pageY - (prev as TouchEvent).touches[0].pageY,
-			}
+			};
 		}
 		return {
-		  x: 0,
-		  y: 0,
+			x: 0,
+			y: 0,
 		};
 	}
 	return {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,6 @@
 import { InputEventType } from ".";
 import {window} from "./browser";
+import { cssProps } from "./const";
 import { ObjectInterface } from "./types";
 
 declare var jQuery: any;
@@ -207,21 +208,22 @@ export function getCenter(event: InputEventType) {
 }
 
 export function getMovement(event: InputEventType, prev: InputEventType) {
-	if (event instanceof TouchEvent) {
-		if (prev) {
+	if (prev) {
+		if (event instanceof TouchEvent) {
 			return {
 				x: event.touches[0].pageX - (prev as TouchEvent).touches[0].pageX,
 				y: event.touches[0].pageY - (prev as TouchEvent).touches[0].pageY,
 			};
+		} else if (event instanceof MouseEvent) {
+			return {
+				x: event.pageX - (prev as MouseEvent).pageX,
+				y: event.pageY - (prev as MouseEvent).pageY,
+			};
 		}
-		return {
-			x: 0,
-			y: 0,
-		};
 	}
 	return {
-		x: event.movementX,
-		y: event.movementY,
+		x: 0,
+		y: 0,
 	};
 }
 
@@ -232,4 +234,16 @@ export function getTouches(event: InputEventType, eventCache: PointerEvent[]) {
 		return event.touches.length;
 	}
 	return 0; // case of MouseEvent
+}
+
+export function setCssProps(element: HTMLElement, originalCssProps?: { [key: string]: string; }): { [key: string]: string; } {
+	const oldCssProps = {};
+	if (element.style) {
+		const newCssProps = originalCssProps ? originalCssProps : cssProps;
+		Object.keys(newCssProps).forEach(prop => {
+			oldCssProps[prop] = element.style[prop];
+			element.style[prop] = newCssProps[prop];
+		});
+	}
+	return oldCssProps;
 }


### PR DESCRIPTION
## Details
axes의 번들 사이즈 중 약 45%를 차지하고 있는 hammer.js의 의존성을 제거합니다.
axes의 option들 중 hammerManagerOptions의 지원이 중단됩니다.
axes.pkgd.js의 용량은 약 206kb에서 122kb로 감소하였으며, axes.pkgd.min.js의 용량은 약 49kb에서 33kb로 감소했습니다.

hammer.js dependency has removed from axes component, which was 45% size of bundle size.
hammerManagerOptions is no longer usable at input options.
size of axes.pkgd.js has reduced from 206kb to 122kb, axes.pkgd.min.js has reduced from 49kb to 33kb.