### PR TITLE
v3: move animation calculation to AnimationManager

### DIFF
--- a/src/AnimationManager.ts
+++ b/src/AnimationManager.ts
@@ -44,6 +44,17 @@ export class AnimationManager {
 			this.options.maximumDuration);
 	}
 
+	getDisplacement(velocity: number[]): number[] {
+		const totalVelocity = Math.pow(velocity.reduce((total, v) => total + v * v, 0), 1 / (velocity.length));
+		const duration = Math.abs(totalVelocity / -this.options.deceleration);
+		return velocity.map(v => v / 2 * duration);
+	}
+
+	interpolate(displacement: number, threshold: number): number {
+		const initSlope = this.easing(0.00001) / 0.00001;
+		return this.easing(displacement / (threshold * initSlope)) * threshold;
+	}
+
 	private createAnimationParam(pos: Axis, duration: number, option?: ChangeEventOption): AnimationParam {
 		const depaPos: Axis = this.axm.get();
 		const destPos: Axis = pos;

--- a/src/inputType/InputType.ts
+++ b/src/inputType/InputType.ts
@@ -21,7 +21,7 @@ export interface IInputTypeObserver {
 	get(inputType: IInputType): Axis;
 	change(inputType: IInputType, event, offset: Axis);
 	hold(inputType: IInputType, event);
-	release(inputType: IInputType, event, offset: Axis, duration?: number);
+	release(inputType: IInputType, event, velocity: number[], duration?: number);
 }
 
 export const SUPPORT_POINTER_EVENTS = "PointerEvent" in window || "MSPointerEvent" in window;

--- a/src/inputType/MoveKeyInput.ts
+++ b/src/inputType/MoveKeyInput.ts
@@ -147,7 +147,7 @@ export class MoveKeyInput implements IInputType {
 		}
 		clearTimeout(this._timer);
 		this._timer = setTimeout(() => {
-			this.observer.release(this, e, toAxis(this.axes, [0, 0]));
+			this.observer.release(this, e, [0, 0]);
 			this._isHolded = false;
 		}, DELAY);
 	}

--- a/src/inputType/PanInput.ts
+++ b/src/inputType/PanInput.ts
@@ -25,17 +25,6 @@ export function getDirectionByAngle(angle: number, thresholdAngle: number) {
 		DIRECTION_VERTICAL : DIRECTION_HORIZONTAL;
 }
 
-export function getNextOffset(speeds: number[], deceleration: number) {
-	const normalSpeed = Math.sqrt(
-		speeds[0] * speeds[0] + speeds[1] * speeds[1],
-	);
-	const duration = Math.abs(normalSpeed / -deceleration);
-	return [
-		speeds[0] / 2 * duration,
-		speeds[1] / 2 * duration,
-	];
-}
-
 export function useDirection(
 	checkType,
 	direction,
@@ -352,7 +341,7 @@ export class PanInput implements IInputType {
 		}
 		clearTimeout(this.rightEdgeTimer);
 		this.panFlag = false;
-		let offset: number[] = this.getOffset(
+		const velocity = this.getOffset(
 			[
 				Math.abs(event.velocityX) * (event.deltaX < 0 ? -1 : 1),
 				Math.abs(event.velocityY) * (event.deltaY < 0 ? -1 : 1),
@@ -361,8 +350,7 @@ export class PanInput implements IInputType {
 				useDirection(DIRECTION_HORIZONTAL, this._direction),
 				useDirection(DIRECTION_VERTICAL, this._direction),
 			]);
-		offset = getNextOffset(offset, this.observer.options.deceleration);
-		this.observer.release(this, event, toAxis(this.axes, offset));
+		this.observer.release(this, event, velocity);
 	}
 
 	private attachEvent(observer: IInputTypeObserver) {

--- a/src/inputType/PinchInput.ts
+++ b/src/inputType/PinchInput.ts
@@ -164,7 +164,7 @@ export class PinchInput implements IInputType {
 	private onPinchEnd(event) {
 		const offset = this.getOffset(event.scale, this._prev);
 		this.observer.change(this, event, toAxis(this.axes, [offset]));
-		this.observer.release(this, event, toAxis(this.axes, [0]), 0);
+		this.observer.release(this, event, [0], 0);
 		this._base = null;
 		this._prev = null;
 	}

--- a/src/inputType/RotatePanInput.ts
+++ b/src/inputType/RotatePanInput.ts
@@ -76,7 +76,10 @@ export class RotatePanInput extends PanInput {
 
 	onPanend(event) {
 		this.triggerChange(event);
-		this.triggerAnimation(event);
+		const vx = event.velocityX;
+		const vy = event.velocityY;
+		const velocity = Math.sqrt(vx * vx + vy * vy) * (this.lastDiff > 0 ? -1 : 1); // clockwise
+		this.observer.release(this, event, [velocity * this.coefficientForDistanceToAngle]);
 	}
 
 	private triggerChange(event) {
@@ -93,16 +96,6 @@ export class RotatePanInput extends PanInput {
 
 		this.lastDiff = diff;
 		this.observer.change(this, event, toAxis(this.axes, [-diff])); // minus for clockwise
-	}
-
-	private triggerAnimation(event) {
-		const vx = event.velocityX;
-		const vy = event.velocityY;
-		const velocity = Math.sqrt(vx * vx + vy * vy) * (this.lastDiff > 0 ? -1 : 1); // clockwise
-		const duration = Math.abs(velocity / -this.observer.options.deceleration);
-		const distance = velocity / 2 * duration;
-
-		this.observer.release(this, event, toAxis(this.axes, [distance * this.coefficientForDistanceToAngle]));
 	}
 
 	private getDifference(prevAngle: number, angle: number, prevQuadrant: number, quadrant: number) {

--- a/src/inputType/WheelInput.ts
+++ b/src/inputType/WheelInput.ts
@@ -97,7 +97,7 @@ export class WheelInput implements IInputType {
 		this._timer = setTimeout(() => {
 			if (this._isHolded) {
 				this._isHolded = false;
-				this.observer.release(this, event, toAxis(this.axes, [0]));
+				this.observer.release(this, event, [0]);
 			}
 		}, 50);
 	}


### PR DESCRIPTION
## Details
The logic that determines movement in a coordinate system is split in several pieces of code out of the AnimationManager. and all of them have been replaced to AnimationManager.
  - When releasing pointer in range using PanInput, RotatePanInput. It moves coordinates by applying the deceleration option and speed obtained from the last input. Both logic calculates next offset at each InputType but it should be handled at AnimationManager since different animation types can have different next offset with same releasing velocity. 
  - When holding pointer out of range within bounce area, it directly uses easing function from AnimationManager. Considering new animation types, it is necessary to calculate and return the result from AnimationManager rather than calling the easing function directly at InputObserver.