### PR TITLE
v3: support smooth WheeInput for mouse scrolling

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 	"homepage": "https://github.com/naver/egjs-axes",
 	"dependencies": {
 		"@egjs/agent": "^2.2.1",
-		"@egjs/component": "^2.2.2"
+		"@egjs/component": "^3.0.1"
 	},
 	"devDependencies": {
 		"@egjs/build-helper": "^0.1.2",

--- a/src/AnimationManager.ts
+++ b/src/AnimationManager.ts
@@ -74,7 +74,7 @@ export class AnimationManager {
 		};
 	}
 
-	grab(axes: string[], option?: ChangeEventOption) {
+	stop(axes: string[], option?: ChangeEventOption) {
 		if (this._animateParam && axes.length) {
 			const orgPos: Axis = this.axm.get(axes);
 			const pos: Axis = this.axm.map(orgPos,
@@ -287,7 +287,7 @@ export class AnimationManager {
 
 	setTo(pos: Axis, duration: number = 0) {
 		const axes: string[] = Object.keys(pos);
-		this.grab(axes);
+		this.stop(axes);
 		const orgPos: Axis = this.axm.get(axes);
 
 		if (equal(pos, orgPos)) {

--- a/src/AxisManager.ts
+++ b/src/AxisManager.ts
@@ -7,9 +7,9 @@ export interface Axis {
 }
 
 export interface AxisOption {
-	range?: number[];
-	bounce?: number | number[];
-	circular?: boolean | boolean[];
+	range?: [number, number];
+	bounce?: number | [number, number];
+	circular?: boolean | [boolean, boolean];
 }
 
 export class AxisManager {

--- a/src/AxisManager.ts
+++ b/src/AxisManager.ts
@@ -7,9 +7,9 @@ export interface Axis {
 }
 
 export interface AxisOption {
-	range?: [number, number];
-	bounce?: number | [number, number];
-	circular?: boolean | [boolean, boolean];
+	range?: number[];
+	bounce?: number | number[];
+	circular?: boolean | boolean[];
 }
 
 export class AxisManager {

--- a/src/EventManager.ts
+++ b/src/EventManager.ts
@@ -184,6 +184,7 @@ export class EventManager {
 			isTrusted: !!inputEvent,
 			input: option && option.input || eventInfo && eventInfo.input || null,
 			set: inputEvent ? this.createUserControll(moveTo.pos) : () => { },
+			stop: () => { },
 		};
 		const result = this.axes.trigger("change", param);
 
@@ -228,7 +229,7 @@ export class EventManager {
 	 *   event.setTo({x: 10}, 2000);
 	 * });
 	 */
-	triggerAnimationStart(param: AnimationParam): boolean {
+	triggerAnimationStart(param: AnimationParam): Axes {
 		const {roundPos, roundDepa} = this.getRoundPos(param.destPos, param.depaPos);
 		param.destPos = roundPos;
 		param.depaPos = roundDepa;

--- a/src/EventManager.ts
+++ b/src/EventManager.ts
@@ -185,7 +185,6 @@ export class EventManager {
 			isTrusted: !!inputEvent,
 			input: option && option.input || eventInfo && eventInfo.input || null,
 			set: inputEvent ? this.createUserControll(moveTo.pos) : () => { },
-			stop: () => { },
 		};
 		const result = this.axes.trigger(new ComponentEvent("change", param));
 

--- a/src/EventManager.ts
+++ b/src/EventManager.ts
@@ -1,3 +1,4 @@
+import { ComponentEvent } from "@egjs/component";
 import { IInputType } from "./inputType/InputType";
 import { Axis } from "./AxisManager";
 import { AnimationManager } from "./AnimationManager";
@@ -42,12 +43,12 @@ export class EventManager {
 	triggerHold(pos: Axis, option: ChangeEventOption) {
 		const {roundPos} = this.getRoundPos(pos);
 
-		this.axes.trigger("hold", {
+		this.axes.trigger(new ComponentEvent("hold", {
 			pos: roundPos,
 			input: option.input || null,
 			inputEvent: option.event || null,
 			isTrusted: true,
-		});
+		}));
 	}
 
 	/**
@@ -126,10 +127,10 @@ export class EventManager {
 		param.destPos = roundPos;
 		param.depaPos = roundDepa;
 		param.setTo = this.createUserControll(param.destPos, param.duration);
-		this.axes.trigger("release", {
+		this.axes.trigger(new ComponentEvent("release", {
 			...param,
 			bounceRatio: this.getBounceRatio(roundPos),
-		} as OnRelease);
+		} as OnRelease));
 	}
 
 	/**
@@ -186,7 +187,7 @@ export class EventManager {
 			set: inputEvent ? this.createUserControll(moveTo.pos) : () => { },
 			stop: () => { },
 		};
-		const result = this.axes.trigger("change", param);
+		const result = this.axes.trigger(new ComponentEvent("change", param));
 
 		inputEvent && axm.set(param.set()["destPos"]);
 
@@ -234,7 +235,7 @@ export class EventManager {
 		param.destPos = roundPos;
 		param.depaPos = roundDepa;
 		param.setTo = this.createUserControll(param.destPos, param.duration);
-		return this.axes.trigger("animationStart", param as OnAnimationStart);
+		return this.axes.trigger(new ComponentEvent("animationStart", param as OnAnimationStart));
 	}
 
 	/**
@@ -258,9 +259,9 @@ export class EventManager {
 	 * });
 	 */
 	triggerAnimationEnd(isTrusted: boolean = false) {
-		this.axes.trigger("animationEnd", {
+		this.axes.trigger(new ComponentEvent("animationEnd", {
 			isTrusted,
-		});
+		}));
 	}
 	/**
 	 * This event is fired when all actions have been completed.
@@ -283,9 +284,9 @@ export class EventManager {
 	 * });
 	 */
 	triggerFinish(isTrusted: boolean = false) {
-		this.axes.trigger("finish", {
+		this.axes.trigger(new ComponentEvent("finish", {
 			isTrusted,
-		});
+		}));
 	}
 	private createUserControll(pos: Axis, duration: number = 0) {
 		// to controll

--- a/src/inputType/InputType.ts
+++ b/src/inputType/InputType.ts
@@ -22,9 +22,9 @@ export interface IInputType {
 export interface IInputTypeObserver {
 	options: AxesOption;
 	get(inputType: IInputType): Axis;
-	change(inputType: IInputType, event, offset: Axis);
+	change(inputType: IInputType, event, offset: Axis, useDuration?: boolean);
 	hold(inputType: IInputType, event);
-	release(inputType: IInputType, event, velocity: number[], duration?: number);
+	release(inputType: IInputType, event, velocity: number[], inputDuration?: number);
 }
 
 export function toAxis(source: string[], offset: number[]): Axis {

--- a/src/inputType/MoveKeyInput.ts
+++ b/src/inputType/MoveKeyInput.ts
@@ -149,7 +149,7 @@ export class MoveKeyInput implements IInputType {
 		}
 		clearTimeout(this._timer);
 		this._timer = setTimeout(() => {
-			this.observer.release(this, event, [0, 0]);
+			this._observer.release(this, event, [0, 0]);
 			this._holding = false;
 		}, DELAY);
 	}

--- a/src/inputType/PanInput.ts
+++ b/src/inputType/PanInput.ts
@@ -211,13 +211,7 @@ export class PanInput implements IInputType {
 
 			if (swipeLeftToRight) {
 				// iOS swipe left => right
-				this.release({
-					...this._activeInput.prevEvent,
-					velocityX: 0,
-					velocityY: 0,
-					offsetX: 0,
-					offsetY: 0,
-				});
+				this.onPanend(event);
 				return;
 			} else if (this._atRightEdge) {
 				clearTimeout(this._rightEdgeTimer);
@@ -230,13 +224,7 @@ export class PanInput implements IInputType {
 				} else {
 					// iOS swipe right => left
 					this._rightEdgeTimer = window.setTimeout(() => {
-						this.release({
-							...this._activeInput.prevEvent,
-							velocityX: 0,
-							velocityY: 0,
-							offsetX: 0,
-							offsetY: 0,
-						});
+						this.onPanend(event);
 					}, 100);
 				}
 			}
@@ -267,7 +255,7 @@ export class PanInput implements IInputType {
 		}
 		this._panFlag = false;
 		clearTimeout(this._rightEdgeTimer);
-    const prevEvent = this._activeInput.prevEvent;
+		const prevEvent = this._activeInput.prevEvent;
 		const velocity = this.getOffset(
 			[
 				Math.abs(prevEvent.velocityX) * (prevEvent.offsetX < 0 ? -1 : 1),
@@ -277,7 +265,7 @@ export class PanInput implements IInputType {
 				useDirection(DIRECTION_HORIZONTAL, this._direction),
 				useDirection(DIRECTION_VERTICAL, this._direction),
 			]);
-		this.observer.release(this, prevEvent, velocity);
+		this._observer.release(this, prevEvent, velocity);
 	}
 
 	private attachEvent(observer: IInputTypeObserver) {

--- a/src/inputType/RotatePanInput.ts
+++ b/src/inputType/RotatePanInput.ts
@@ -88,12 +88,12 @@ export class RotatePanInput extends PanInput {
 		if (!this._panFlag || !this.isEnabled) {
 			return;
 		}
-    const prevEvent = this._activeInput.prevEvent;
+		const prevEvent = this._activeInput.prevEvent;
 		this.triggerChange(prevEvent);
 		const vx = prevEvent.velocityX;
 		const vy = prevEvent.velocityY;
-		const velocity = Math.sqrt(vx * vx + vy * vy) * (this.lastDiff > 0 ? -1 : 1); // clockwise
-		this.observer.release(this, prevEvent, [velocity * this.coefficientForDistanceToAngle]);
+		const velocity = Math.sqrt(vx * vx + vy * vy) * (this._lastDiff > 0 ? -1 : 1); // clockwise
+		this._observer.release(this, prevEvent, [velocity * this._coefficientForDistanceToAngle]);
 		this._panFlag = false;
 	}
 

--- a/src/inputType/WheelInput.ts
+++ b/src/inputType/WheelInput.ts
@@ -3,7 +3,7 @@ import { toAxis, IInputType, IInputTypeObserver } from "./InputType";
 
 export interface WheelInputOption {
 	scale?: number;
-	releaseThreshold?: number;
+	releaseDelay?: number;
 	useNormalized?: boolean;
 }
 
@@ -11,7 +11,7 @@ export interface WheelInputOption {
  * @typedef {Object} WheelInputOption The option object of the eg.Axes.WheelInput module
  * @ko eg.Axes.WheelInput 모듈의 옵션 객체
  * @property {Number} [scale=1] Coordinate scale that a user can move<ko>사용자의 동작으로 이동하는 좌표의 배율</ko>
- * @property {Number} [releaseThreshold=300] Millisecond that trigger release event after last input<ko>마지막 입력 이후 release 이벤트가 트리거되기까지의 밀리초</ko>
+ * @property {Number} [releaseDelay=300] Millisecond that trigger release event after last input<ko>마지막 입력 이후 release 이벤트가 트리거되기까지의 밀리초</ko>
 **/
 
 /**
@@ -44,7 +44,7 @@ export class WheelInput implements IInputType {
 		this.options = {
 			...{
 				scale: 1,
-				releaseThreshold: 300,
+				releaseDelay: 300,
 				useNormalized: true,
 			}, ...options,
 		};
@@ -99,7 +99,7 @@ export class WheelInput implements IInputType {
 				this._holding = false;
 				this._observer.release(this, event, [0]);
 			}
-		}, this.options.releaseThreshold);
+		}, this.options.releaseDelay);
 	}
 
 	private attachEvent(observer: IInputTypeObserver) {

--- a/src/inputType/WheelInput.ts
+++ b/src/inputType/WheelInput.ts
@@ -97,8 +97,8 @@ export class WheelInput implements IInputType {
 
 		this._timer = setTimeout(() => {
 			if (this._holding) {
-				this._isHolded = false;
-				this.observer.release(this, event, [0]);
+				this._holding = false;
+				this._observer.release(this, event, [0]);
 			}
 		}, 50);
 	}

--- a/src/inputType/WheelInput.ts
+++ b/src/inputType/WheelInput.ts
@@ -1,10 +1,9 @@
-import { InputObserver } from "./../InputObserver";
 import { $ } from "../utils";
 import { toAxis, IInputType, IInputTypeObserver } from "./InputType";
-import { Axis } from "../AxisManager";
 
 export interface WheelInputOption {
 	scale?: number;
+	releaseThreshold?: number;
 	useNormalized?: boolean;
 }
 
@@ -12,6 +11,7 @@ export interface WheelInputOption {
  * @typedef {Object} WheelInputOption The option object of the eg.Axes.WheelInput module
  * @ko eg.Axes.WheelInput 모듈의 옵션 객체
  * @property {Number} [scale=1] Coordinate scale that a user can move<ko>사용자의 동작으로 이동하는 좌표의 배율</ko>
+ * @property {Number} [releaseThreshold=300] Millisecond that trigger release event after last input<ko>마지막 입력 이후 release 이벤트가 트리거되기까지의 밀리초</ko>
 **/
 
 /**
@@ -44,6 +44,7 @@ export class WheelInput implements IInputType {
 		this.options = {
 			...{
 				scale: 1,
+				releaseThreshold: 300,
 				useNormalized: true,
 			}, ...options,
 		};
@@ -90,17 +91,15 @@ export class WheelInput implements IInputType {
 			this._holding = true;
 		}
 		const offset = (event.deltaY > 0 ? -1 : 1) * this.options.scale * (this.options.useNormalized ? 1 : Math.abs(event.deltaY));
-
-		this._observer.change(this, event, toAxis(this.axes, [offset]));
+		this._observer.change(this, event, toAxis(this.axes, [offset]), true);
 		clearTimeout(this._timer);
-		const inst = this;
 
 		this._timer = setTimeout(() => {
 			if (this._holding) {
 				this._holding = false;
 				this._observer.release(this, event, [0]);
 			}
-		}, 50);
+		}, this.options.releaseThreshold);
 	}
 
 	private attachEvent(observer: IInputTypeObserver) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,15 +8,20 @@ import { IInputType } from "./inputType/InputType";
 
 export type ObjectInterface<T = any> = Record<string | number, T>;
 
-export type AxesEvents = {
+export type InputEventType = PointerEvent | MouseEvent | TouchEvent;
+
+export type ActiveInput = MouseEventInput | TouchEventInput | TouchMouseEventInput | PointerEventInput;
+
+export interface AxesEvents {
 	hold: OnHold;
 	change: OnChange;
 	release: OnRelease;
 	animationStart: OnAnimationStart;
 	animationEnd: OnAnimationEnd;
 	finish: OnFinish;
-};
-export type AnimationParam = {
+}
+
+export interface AnimationParam {
 	depaPos: Axis;
 	destPos: Axis;
 	duration: number;
@@ -28,16 +33,16 @@ export type AnimationParam = {
 	startTime?: number;
 	inputEvent?;
 	input?: IInputType;
-};
+}
 
-export type OnHold = {
+export interface OnHold {
 	pos: Record<string, any>;
 	input: IInputType | null;
 	inputEvent: any;
 	isTrusted: boolean;
-};
+}
 
-export type OnAnimationStart = {
+export interface OnAnimationStart {
 	depaPos: Axis;
 	destPos: Axis;
 	duration: number;
@@ -49,9 +54,9 @@ export type OnAnimationStart = {
 	setTo(destPos?: Axis, duration?: number): void;
 	done(): void;
 	stop(): void;
-};
+}
 
-export type OnChange = {
+export interface OnChange {
 	pos: Axis;
 	delta: Axis;
 	bounceRatio: Axis;
@@ -61,9 +66,9 @@ export type OnChange = {
 	input: IInputType | null;
 	set(toPos?: Axis, userDuration?: number): void;
 	stop(): void;
-};
+}
 
-export type OnRelease = {
+export interface OnRelease {
 	depaPos: Axis;
 	destPos: Axis;
 	duration: number;
@@ -75,20 +80,16 @@ export type OnRelease = {
 	input?: IInputType | null;
 	setTo(destPos?: Axis, duration?: number): void;
 	done(): void;
-};
-export type OnAnimationEnd = {
+}
+export interface OnAnimationEnd {
 	isTrusted: boolean;
-};
+}
 
-export type OnFinish = {
+export interface OnFinish {
 	isTrusted: boolean;
-};
+}
 
-export type InputEventType = PointerEvent | MouseEvent | TouchEvent;
-
-export type ActiveInput = MouseEventInput | TouchEventInput | TouchMouseEventInput | PointerEventInput;
-
-export type ExtendedEvent = {
+export interface ExtendedEvent {
 	srcEvent: InputEventType;
 	angle: number;
 	scale: number;
@@ -103,4 +104,4 @@ export type ExtendedEvent = {
 	velocityX: number;
 	velocityY: number;
 	preventSystemEvent: boolean;
-};
+}


### PR DESCRIPTION
## Details
When using WheelInput with mouse, offset of the virtual coordinate does not update smoothly.
This problem can be solved by using `animateTo` on change, and property named `releaseThreshold` has been added to `WheelInputOption` to trigger release event after animation ends.
`releaseThreshold` decides millisecond that trigger release event after last input. Before this property is added, Release event is automatically triggered after 50ms from last input.

### Demos using mouse scroll within WheelInput Before.

![ezgif com-gif-maker (36)](https://user-images.githubusercontent.com/13797320/154284679-e28b0c02-ba3d-47e1-af53-b9134918ff69.gif)
![ezgif com-gif-maker (35)](https://user-images.githubusercontent.com/13797320/154282663-24805b02-78df-4e6a-814c-bff591edf511.gif)


### Demos using mouse scroll within WheelInput After.

![ezgif com-gif-maker (37)](https://user-images.githubusercontent.com/13797320/154284695-58914f7a-51d2-49c3-a6c0-eba1c9bddd1f.gif)
![ezgif com-gif-maker (34)](https://user-images.githubusercontent.com/13797320/154282631-5d8505ba-87d9-400a-b51d-6d584f44e2a3.gif)
