### PR TITLE
v3: update unit tests

### DIFF
--- a/src/InputObserver.ts
+++ b/src/InputObserver.ts
@@ -131,7 +131,7 @@ export class InputObserver implements InputTypeObserver {
     const depaPos: Axis = this._axisManager.get();
     const displacement = this._animationManager.getDisplacement(velocity);
     const offset = toAxis(input.axes, displacement);
-    let destPos: Axis = this._axisManager.get(
+    const destPos: Axis = this._axisManager.get(
       this._axisManager.map(offset, (v, opt, k) => {
         if (opt.circular && (opt.circular[0] || opt.circular[1])) {
           return pos[k] + v;
@@ -151,9 +151,6 @@ export class InputObserver implements InputTypeObserver {
       inputDuration
     );
 
-    if (duration === 0) {
-      destPos = { ...depaPos };
-    }
     // prepare params
     const param: AnimationParam = {
       depaPos,

--- a/src/eventInput/EventInput.ts
+++ b/src/eventInput/EventInput.ts
@@ -42,12 +42,14 @@ export abstract class EventInput {
     const deltaY = prevEvent ? prevEvent.deltaY + movement.y : movement.y;
     const offsetX = prevEvent ? deltaX - prevEvent.deltaX : 0;
     const offsetY = prevEvent ? deltaY - prevEvent.deltaY : 0;
-    const velocityX = prevEvent
-      ? offsetX / (event.timeStamp - prevEvent.srcEvent.timeStamp)
-      : 0;
-    const velocityY = prevEvent
-      ? offsetY / (event.timeStamp - prevEvent.srcEvent.timeStamp)
-      : 0;
+    const velocityX =
+      prevEvent && event.timeStamp - prevEvent.srcEvent.timeStamp !== 0
+        ? offsetX / (event.timeStamp - prevEvent.srcEvent.timeStamp)
+        : 0;
+    const velocityY =
+      prevEvent && event.timeStamp - prevEvent.srcEvent.timeStamp !== 0
+        ? offsetY / (event.timeStamp - prevEvent.srcEvent.timeStamp)
+        : 0;
     return {
       srcEvent: event,
       scale,

--- a/src/eventInput/EventInput.ts
+++ b/src/eventInput/EventInput.ts
@@ -42,14 +42,11 @@ export abstract class EventInput {
     const deltaY = prevEvent ? prevEvent.deltaY + movement.y : movement.y;
     const offsetX = prevEvent ? deltaX - prevEvent.deltaX : 0;
     const offsetY = prevEvent ? deltaY - prevEvent.deltaY : 0;
-    const velocityX =
-      prevEvent && event.timeStamp - prevEvent.srcEvent.timeStamp !== 0
-        ? offsetX / (event.timeStamp - prevEvent.srcEvent.timeStamp)
-        : 0;
-    const velocityY =
-      prevEvent && event.timeStamp - prevEvent.srcEvent.timeStamp !== 0
-        ? offsetY / (event.timeStamp - prevEvent.srcEvent.timeStamp)
-        : 0;
+    const deltaTime = prevEvent
+      ? event.timeStamp - prevEvent.srcEvent.timeStamp
+      : 0;
+    const velocityX = prevEvent && deltaTime !== 0 ? offsetX / deltaTime : 0;
+    const velocityY = prevEvent && deltaTime !== 0 ? offsetY / deltaTime : 0;
     return {
       srcEvent: event,
       scale,

--- a/src/inputType/PanInput.ts
+++ b/src/inputType/PanInput.ts
@@ -241,7 +241,7 @@ export class PanInput implements InputType {
 
       if (swipeLeftToRight) {
         // iOS swipe left => right
-        this._onPanend(event);
+        this._observer.release(this, this._activeInput.prevEvent, [0, 0]);
         return;
       } else if (this._atRightEdge) {
         clearTimeout(this._rightEdgeTimer);
@@ -254,7 +254,7 @@ export class PanInput implements InputType {
         } else {
           // iOS swipe right => left
           this._rightEdgeTimer = window.setTimeout(() => {
-            this._onPanend(event);
+            this._observer.release(this, this._activeInput.prevEvent, [0, 0]);
           }, 100);
         }
       }

--- a/src/inputType/RotatePanInput.ts
+++ b/src/inputType/RotatePanInput.ts
@@ -47,7 +47,7 @@ export class RotatePanInput extends PanInput {
     this.axes = axes;
   }
 
-  public onPanstart(event: MouseEvent) {
+  protected _onPanstart(event: MouseEvent) {
     this._activeInput.onEventStart(event);
     if (!this.isEnabled) {
       return;
@@ -73,7 +73,7 @@ export class RotatePanInput extends PanInput {
     this._activeInput.prevEvent = panEvent;
   }
 
-  public onPanmove(event: MouseEvent) {
+  protected _onPanmove(event: MouseEvent) {
     this._activeInput.onEventMove(event);
     if (!this._panFlag || !this.isEnabled) {
       return;
@@ -89,7 +89,7 @@ export class RotatePanInput extends PanInput {
     this._activeInput.prevEvent = panEvent;
   }
 
-  public onPanend(event: MouseEvent) {
+  protected _onPanend(event: MouseEvent) {
     this._activeInput.onEventEnd(event);
     if (!this._panFlag || !this.isEnabled) {
       return;
@@ -109,15 +109,16 @@ export class RotatePanInput extends PanInput {
   private _triggerChange(event: ExtendedEvent) {
     const { x, y } = this._getPosFromOrigin(event.center.x, event.center.y);
     const angle = getAngle(x, y);
+    const positiveAngle = angle < 0 ? 360 + angle : angle;
     const quadrant = this._getQuadrant(event.center.x, event.center.y);
     const diff = this._getDifference(
       this._prevAngle,
-      angle,
+      positiveAngle,
       this._prevQuadrant,
       quadrant
     );
 
-    this._prevAngle = angle;
+    this._prevAngle = positiveAngle;
     this._prevQuadrant = quadrant;
 
     if (diff === 0) {

--- a/test/manual/index.html
+++ b/test/manual/index.html
@@ -80,7 +80,6 @@ button {
   <!--[if IE 8]>
 <script type="text/javascript" src="../../node_modules/hammerjs-compatible/dist/hammerjs.compatible.js"></script>
 <![endif]-->
-  <script src="../../node_modules/@egjs/hammerjs/dist/hammer.js"></script>
   <script src="../../node_modules/@egjs/component/dist/component.js"></script>
   <script src="../../dist/axes.pkgd.js"></script>
   <!-- <script src="../../dist/axes.pkgd.js"></script> -->

--- a/test/manual/rotate.html
+++ b/test/manual/rotate.html
@@ -63,7 +63,6 @@
   <!--[if IE 8]>
 <script type="text/javascript" src="../../node_modules/hammerjs-compatible/dist/hammerjs.compatible.js"></script>
 <![endif]-->
-  <script src="../../node_modules/@egjs/hammerjs/dist/hammer.js"></script>
   <script src="../../node_modules/@egjs/component/dist/component.js"></script>
   <script src="../../dist/axes.pkgd.js"></script>
   <!-- <script src="../../dist/axes.pkgd.js"></script> -->

--- a/test/unit/AnimationManager.spec.js
+++ b/test/unit/AnimationManager.spec.js
@@ -2,579 +2,628 @@ import { AnimationManager } from "../../src/AnimationManager";
 import { AxisManager } from "../../src/AxisManager";
 import { InterruptManager } from "../../src/InterruptManager";
 import { EventManager } from "../../src/EventManager";
-import Component from "@egjs/component";
-import { map } from "../../src/utils";
+import Axes from "../../src";
 
 describe("AnimationManager", function () {
-	describe("method test", function () {
-		beforeEach(() => {
-			this.axis = {
-				x: {
-					range: [0, 100],
-					bounce: [50, 50],
-					circular: false
-				},
-				y: {
-					range: [0, 200],
-					bounce: [0, 0],
-					circular: false
-				},
-				z: {
-					range: [-100, 200],
-					bounce: [50, 0],
-					circular: true
-				}
-			};
-			this.options = {
-				deceleration: 0.0001,
-				maximumDuration: 2000,
-				minimumDuration: 0
-			};
-			this.inst = new AnimationManager({
-				options: this.options,
-				itm: new InterruptManager(this.options),
-				em: new EventManager(null),
-				axm: new AxisManager(this.axis, this.options)
-			});
-		});
-		afterEach(() => {
-		});
+  describe("method test", function () {
+    beforeEach(() => {
+      this.axis = {
+        x: {
+          range: [0, 100],
+          bounce: [50, 50],
+          circular: false,
+        },
+        y: {
+          range: [0, 200],
+          bounce: [0, 0],
+          circular: false,
+        },
+        z: {
+          range: [-100, 200],
+          bounce: [50, 0],
+          circular: true,
+        },
+      };
+      this.options = {
+        deceleration: 0.0001,
+        maximumDuration: 2000,
+        minimumDuration: 0,
+      };
+      this.inst = new AnimationManager({
+        options: this.options,
+        interruptManager: new InterruptManager(this.options),
+        eventManager: new EventManager(null),
+        axisManager: new AxisManager(this.axis, this.options),
+      });
+    });
+    afterEach(() => {});
 
-		it("should check 'getDuration' method", () => {
-			// Given
-			// When
-			const depaPos = {
-				x: 0,
-				y: 0
-			};
-			const destPos = {
-				x: 100,
-				y: 50
-			};
+    it("should check 'getDuration' method", () => {
+      // Given
+      // When
+      const depaPos = {
+        x: 0,
+        y: 0,
+      };
+      const destPos = {
+        x: 100,
+        y: 50,
+      };
 
-			// When/Then
-			expect(this.inst.getDuration(depaPos, destPos)).to.be.equal(1414.213562373095);
+      // When/Then
+      expect(this.inst.getDuration(depaPos, destPos)).to.be.equal(
+        1414.213562373095
+      );
 
-			// When (change option)
-			this.options.maximumDuration = 1200;
+      // When (change option)
+      this.options.maximumDuration = 1200;
 
-			// Then
-			expect(this.inst.getDuration(depaPos, destPos)).to.be.equal(1200);
+      // Then
+      expect(this.inst.getDuration(depaPos, destPos)).to.be.equal(1200);
 
-			// When/Then
-			expect(this.inst.getDuration(depaPos, destPos, 1000)).to.be.equal(1000);
+      // When/Then
+      expect(this.inst.getDuration(depaPos, destPos, 1000)).to.be.equal(1000);
 
-			// When/Then
-			expect(this.inst.getDuration(depaPos, destPos, 2000)).to.be.equal(1200);
-		});
+      // When/Then
+      expect(this.inst.getDuration(depaPos, destPos, 2000)).to.be.equal(1200);
+    });
 
-		it("should check 'createAnimationParam' method", () => {
-			// Given
-			// When
-			const pos = {
-				x: 200,
-				y: 210,
-				z: -155
-			};
+    it("should check 'getDisplacement' method", () => {
+      // 0.001
+      this.options.deceleration = 0.001;
+      expect(this.inst.getDisplacement([1.5, 1])).to.be.eql([
+        1352.0817282989958, 901.3878188659972,
+      ]);
+      expect(this.inst.getDisplacement([1, 1.5])).to.be.eql([
+        901.3878188659972, 1352.0817282989958,
+      ]);
 
-			// When
-			// createAnimationParam does not change the 'pos' param since 2017.10.27
-			let param = this.inst.createAnimationParam(pos, 1000);
+      // 0.01
+      this.options.deceleration = 0.01;
+      expect(this.inst.getDisplacement([1.5, 1])).to.be.eql([
+        135.20817282989958, 90.13878188659973,
+      ]);
+      expect(this.inst.getDisplacement([1, 1.5])).to.be.eql([
+        90.13878188659973, 135.20817282989958,
+      ]);
+    });
 
-			// Then
-			expect(param.depaPos).to.be.eql({ x: 0, y: 0, z: -100 });
-			expect(param.destPos).to.be.eql({ x: 200, y: 210, z: -155 }); // do not change destPos.
-			expect(param.duration).to.be.eql(1000);
-			expect(param.delta).to.be.eql({ x: 200, y: 210, z: -55 });
-			expect(param.inputEvent).to.be.eql(null);
-			expect(param.input).to.be.eql(null);
+    it("should check 'createAnimationParam' method", () => {
+      // Given
+      // When
+      const pos = {
+        x: 200,
+        y: 210,
+        z: -155,
+      };
 
-			// When
-			this.options.maximumDuration = 500;
-			const eventValue = { event: "i'm inputEvent" };
-			param = this.inst.createAnimationParam(pos, 1000, {
-				event: eventValue
-			});
+      // When
+      // createAnimationParam does not change the 'pos' param since 2017.10.27
+      let param = this.inst._createAnimationParam(pos, 1000);
 
-			// Then
-			expect(param.depaPos).to.be.eql({ x: 0, y: 0, z: -100 });
-			expect(param.destPos).to.be.eql({ x: 200, y: 210, z: -155 });
-			expect(param.duration).to.be.eql(500);
-			expect(param.delta).to.be.eql({ x: 200, y: 210, z: -55 });
-			expect(param.inputEvent).to.be.equal(eventValue);
-		});
-	});
+      // Then
+      expect(param.depaPos).to.be.eql({ x: 0, y: 0, z: -100 });
+      expect(param.destPos).to.be.eql({ x: 200, y: 210, z: -155 }); // do not change destPos.
+      expect(param.duration).to.be.eql(1000);
+      expect(param.delta).to.be.eql({ x: 200, y: 210, z: -55 });
+      expect(param.inputEvent).to.be.eql(null);
+      expect(param.input).to.be.eql(null);
 
-	describe("animation test", function () {
-		beforeEach(() => {
-			this.axis = {
-				x: {
-					range: [0, 100],
-					bounce: [50, 50],
-					circular: false/*[false, false]*/
-				},
-				y: {
-					range: [0, 200],
-					bounce: [0, 0],
-					circular: false/*[false, false]*/
-				},
-				z: {
-					range: [-100, 200],
-					bounce: [50, 0],
-					circular: true/*[true, true]*/
-				}
-			};
-			this.options = {
-				easing: function easeOutCubic(x) {
-					return 1 - Math.pow(1 - x, 3);
-				},
-				interruptable: true,
-				deceleration: 0.0001,
-				minimumDuration: 0,
-				maximumDuration: 2000
-			};
-			this.component = new Component();
-			var axm = new AxisManager(this.axis, this.options);
-			var em = new EventManager(this.component);
-			this.inst = new AnimationManager({
-				options: this.options,
-				itm: new InterruptManager(this.options),
-				em,
-				axm
-			});
-			em.setAnimationManager(this.inst);
-		});
-		afterEach(() => {
-			this.component.off();
-		});
-		it("should check 'setTo' method(duration: 0)", () => {
-			// Given
-			const changeHandler = sinon.spy();
-			const finishHandler = sinon.spy();
-			this.component.on({
-				"change": changeHandler,
-				"finish": finishHandler,
-			});
+      // When
+      this.options.maximumDuration = 500;
+      const eventValue = { event: "i'm inputEvent" };
+      param = this.inst._createAnimationParam(pos, 1000, {
+        event: eventValue,
+      });
 
-			// When
-			this.inst.setTo({
-				x: 100,
-				y: 200
-			}, 0);
+      // Then
+      expect(param.depaPos).to.be.eql({ x: 0, y: 0, z: -100 });
+      expect(param.destPos).to.be.eql({ x: 200, y: 210, z: -155 });
+      expect(param.duration).to.be.eql(500);
+      expect(param.delta).to.be.eql({ x: 200, y: 210, z: -55 });
+      expect(param.inputEvent).to.be.equal(eventValue);
+    });
+  });
 
-			// Then
-			expect(changeHandler.calledOnce).to.be.true;
-			expect(finishHandler.calledOnce).to.be.true;
-			expect(this.inst.axm.get()).to.be.eql({ x: 100, y: 200, z: -100 });
-		});
-		it("should check 'setTo' method (outside)", () => {
-			// Given
-			const depaPos = this.inst.axm.get();
-			const destPos = {
-				x: 200,
-				z: -155
-			};
-			const self = this.inst;
-			const startHandler = sinon.spy();
-			const changeHandler = sinon.spy();
-			const endHandler = sinon.spy();
-			this.component.on({
-				"animationStart": startHandler,
-				"change": changeHandler,
-				"animationEnd": endHandler
-			});
+  describe("animation test", function () {
+    beforeEach(() => {
+      this.axis = {
+        x: {
+          range: [0, 100],
+          bounce: [50, 50],
+          circular: false /*[false, false]*/,
+        },
+        y: {
+          range: [0, 200],
+          bounce: [0, 0],
+          circular: false /*[false, false]*/,
+        },
+        z: {
+          range: [-100, 200],
+          bounce: [50, 0],
+          circular: true /*[true, true]*/,
+        },
+      };
+      this.options = {
+        easing: function easeOutCubic(x) {
+          return 1 - Math.pow(1 - x, 3);
+        },
+        interruptable: true,
+        deceleration: 0.0001,
+        minimumDuration: 0,
+        maximumDuration: 2000,
+      };
+      this.axes = new Axes(this.axis, this.options);
+      var axisManager = new AxisManager(this.axis, this.options);
+      var eventManager = new EventManager(this.axes);
+      this.inst = new AnimationManager({
+        options: this.options,
+        interruptManager: new InterruptManager(this.options),
+        eventManager,
+        axisManager,
+      });
+      eventManager.setAnimationManager(this.inst);
+    });
+    afterEach(() => {
+      this.axes.off();
+    });
+    it("should check 'setTo' method(duration: 0)", () => {
+      // Given
+      const changeHandler = sinon.spy();
+      const finishHandler = sinon.spy();
+      this.axes.on({
+        change: changeHandler,
+        finish: finishHandler,
+      });
 
-			// When
-			this.inst.setTo(destPos, 0);
+      // When
+      this.inst.setTo(
+        {
+          x: 100,
+          y: 200,
+        },
+        0
+      );
 
-			// Then
-			expect(startHandler.called).to.be.false;
-			expect(endHandler.called).to.be.false;
-			expect(changeHandler.called).to.be.true;
-			expect(changeHandler.getCall(0).args[0].isTrusted).to.be.false;
-			expect(self.axm.get()).to.be.eql({ x: 100, y: 0, z: 145 });
-		});
-		it("should check 'setTo' method (outside, duration)", (done) => {
-			// Given
-			const depaPos = this.inst.axm.get();
-			const destPos = {
-				x: 200,
-				z: -155
-			};
-			const self = this.inst;
-			const startHandler = sinon.spy();
-			const changeHandler = sinon.spy(function (event) {
-				expect(event.input).to.be.null;
-				expect(event.inputEvent).to.be.null;
-				expect(self.getEventInfo()).to.be.null;
-			});
-			this.component.on({
-				"animationStart": startHandler,
-				"change": changeHandler,
-				"animationEnd": function (event) {
-					expect(self.axm.get()).to.be.eql({ x: 100, y: 0, z: 145 });
-					expect(startHandler.callCount).to.be.equal(1);
-					expect(startHandler.getCall(0).args[0].isTrusted).to.be.false;
-					expect(changeHandler.called).to.be.true;
-					expect(event.isTrusted).to.be.false;
-					done();
-				}
-			});
+      // Then
+      expect(changeHandler.calledOnce).to.be.true;
+      expect(finishHandler.calledOnce).to.be.true;
+      expect(this.inst.axisManager.get()).to.be.eql({
+        x: 100,
+        y: 200,
+        z: -100,
+      });
+    });
+    it("should check 'setTo' method (outside)", () => {
+      // Given
+      const depaPos = this.inst.axisManager.get();
+      const destPos = {
+        x: 200,
+        z: -155,
+      };
+      const self = this.inst;
+      const startHandler = sinon.spy();
+      const changeHandler = sinon.spy();
+      const endHandler = sinon.spy();
+      this.axes.on({
+        animationStart: startHandler,
+        change: changeHandler,
+        animationEnd: endHandler,
+      });
 
-			// When
-			this.inst.setTo(destPos, 1000);
-		});
+      // When
+      this.inst.setTo(destPos, 0);
 
-		it("should check 'setTo' method (same position #1)", (done) => {
-			// Given
-			const depaPos = this.inst.axm.get();
-			const destPos = {
-				x: 0,
-				z: -100
-			};
-			const self = this.inst;
-			const changeHandler = sinon.spy();
-			this.component.on({
-				"change": changeHandler,
-			});
+      // Then
+      expect(startHandler.called).to.be.false;
+      expect(endHandler.called).to.be.false;
+      expect(changeHandler.called).to.be.true;
+      expect(changeHandler.getCall(0).args[0].isTrusted).to.be.false;
+      expect(self.axisManager.get()).to.be.eql({ x: 100, y: 0, z: 145 });
+    });
+    it("should check 'setTo' method (outside, duration)", (done) => {
+      // Given
+      const depaPos = this.inst.axisManager.get();
+      const destPos = {
+        x: 200,
+        z: -155,
+      };
+      const self = this.inst;
+      const startHandler = sinon.spy();
+      const changeHandler = sinon.spy(function (event) {
+        expect(event.input).to.be.null;
+        expect(event.inputEvent).to.be.null;
+        expect(self.getEventInfo()).to.be.null;
+      });
+      this.axes.on({
+        animationStart: startHandler,
+        change: changeHandler,
+        animationEnd: function (event) {
+          expect(self.axisManager.get()).to.be.eql({ x: 100, y: 0, z: 145 });
+          expect(startHandler.callCount).to.be.equal(1);
+          expect(startHandler.getCall(0).args[0].isTrusted).to.be.false;
+          expect(changeHandler.called).to.be.true;
+          expect(event.isTrusted).to.be.false;
+          done();
+        },
+      });
 
-			// When
-			const ret = this.inst.setTo(destPos);
+      // When
+      this.inst.setTo(destPos, 1000);
+    });
 
-			// Then
-			setTimeout(() => {
-				expect(changeHandler.called).to.be.false;
-				expect(ret).to.be.eq(self);
-				done();
-			}, 100);
-		});
+    it("should check 'setTo' method (same position #1)", (done) => {
+      // Given
+      const depaPos = this.inst.axisManager.get();
+      const destPos = {
+        x: 0,
+        z: -100,
+      };
+      const self = this.inst;
+      const changeHandler = sinon.spy();
+      this.axes.on({
+        change: changeHandler,
+      });
 
-		it("should check 'setTo' method (same position #2 - completely same)", (done) => {
-			// Given
-			const depaPos = this.inst.axm.get();
-			const destPos = {
-				x: 0,
-				z: -100
-			};
-			const self = this.inst;
-			const changeHandler = sinon.spy();
-			this.component.on({
-				"change": changeHandler,
-			});
+      // When
+      const ret = this.inst.setTo(destPos);
 
-			// When
-			const ret = this.inst.setTo(destPos);
+      // Then
+      setTimeout(() => {
+        expect(changeHandler.called).to.be.false;
+        expect(ret).to.be.eq(self);
+        done();
+      }, 100);
+    });
 
-			// Then
-			setTimeout(() => {
-				expect(changeHandler.called).to.be.false;
-				expect(ret).to.be.eq(self);
-				done();
-			}, 100);
-		});
+    it("should check 'setTo' method (same position #2 - completely same)", (done) => {
+      // Given
+      const depaPos = this.inst.axisManager.get();
+      const destPos = {
+        x: 0,
+        z: -100,
+      };
+      const self = this.inst;
+      const changeHandler = sinon.spy();
+      this.axes.on({
+        change: changeHandler,
+      });
 
-		it("should check 'setTo' method (circular, no duration)", (done) => {
-			// Given
-			const depaPos = this.inst.axm.get();
-			const destPos = { z: -200 };
-			const self = this.inst;
-			const changeHandler = sinon.spy(function (event) {
-				// Then
-				expect(self.axm.get()).to.be.eql({ x: 0, y: 0, z: 100 });
-				done();
-			});
-			this.component.on({
-				"change": changeHandler,
-			});
+      // When
+      const ret = this.inst.setTo(destPos);
 
-			// When
-			const ret = this.inst.setTo(destPos, 0, true);
-		});
+      // Then
+      setTimeout(() => {
+        expect(changeHandler.called).to.be.false;
+        expect(ret).to.be.eq(self);
+        done();
+      }, 100);
+    });
 
-		it("should check 'setTo' method (same position after range limit, useCircular)", (done) => {
-			// Given
-			// depaPos: {x: 0, y: 0, z: -100}
-			const destPos = { x: -100, z: 500 };
-			const self = this.inst;
-			const changeHandler = sinon.spy();
-			this.component.on({
-				"change": changeHandler,
-			});
+    it("should check 'setTo' method (circular, no duration)", (done) => {
+      // Given
+      const depaPos = this.inst.axisManager.get();
+      const destPos = { z: -200 };
+      const self = this.inst;
+      const changeHandler = sinon.spy(function (event) {
+        // Then
+        expect(self.axisManager.get()).to.be.eql({ x: 0, y: 0, z: 100 });
+        done();
+      });
+      this.axes.on({
+        change: changeHandler,
+      });
 
-			// When
-			const ret = this.inst.setTo(destPos, 0); // last (useCircular) param makes invalidating z-pos change(500)
+      // When
+      const ret = this.inst.setTo(destPos, 0, true);
+    });
 
-			// Then
-			setTimeout(() => {
-				expect(self.axm.get()).to.be.eql({ x: 0, y: 0, z: -100 });
-				expect(changeHandler.callCount).to.be.equals(1);
-				expect(changeHandler.args[0][0].delta).to.be.eql({ x: 0, y: 0, z: 600 });
-				expect(ret).to.be.eq(self);
-				done();
-			}, 100);
-		});
+    it("should check 'setTo' method (same position after range limit, useCircular)", (done) => {
+      // Given
+      // depaPos: {x: 0, y: 0, z: -100}
+      const destPos = { x: -100, z: 500 };
+      const self = this.inst;
+      const changeHandler = sinon.spy();
+      this.axes.on({
+        change: changeHandler,
+      });
 
-		it("should check 'setTo' method (diff position after range limit)", (done) => {
-			// Given
-			const depaPos = this.inst.axm.get();
-			const destPos = { x: -100, z: 450 };
-			const self = this.inst;
-			const changeHandler = sinon.spy(function (event) {
-				// Then
-				expect(self.axm.get()).to.be.eql({ x: 0, y: 0, z: 150 });
-				done();
-			});
-			this.component.on({
-				"change": changeHandler,
-			});
+      // When
+      const ret = this.inst.setTo(destPos, 0); // last (useCircular) param makes invalidating z-pos change(500)
 
-			// When
-			const ret = this.inst.setTo(destPos);
-		});
+      // Then
+      setTimeout(() => {
+        expect(self.axisManager.get()).to.be.eql({ x: 0, y: 0, z: -100 });
+        expect(changeHandler.callCount).to.be.equals(1);
+        expect(changeHandler.args[0][0].delta).to.be.eql({
+          x: 0,
+          y: 0,
+          z: 600,
+        });
+        expect(ret).to.be.eq(self);
+        done();
+      }, 100);
+    });
 
-		it("should check 'setBy' method (inside, duration)", (done) => {
-			// Given
-			const depaPos = this.inst.axm.get();
-			const byPos = {
-				x: 20,
-				z: 40
-			};
-			const self = this.inst;
-			const startHandler = sinon.spy();
-			const changeHandler = sinon.spy(function (event) {
-				expect(event.input).to.be.null;
-				expect(event.inputEvent).to.be.null;
-				expect(self.getEventInfo()).to.be.null;
-			});
-			this.component.on({
-				"animationStart": startHandler,
-				"change": changeHandler,
-				"animationEnd": function (event) {
-					expect(self.axm.get()).to.be.eql({ x: depaPos.x + byPos.x, y: 0, z: depaPos.z + byPos.z });
-					expect(startHandler.callCount).to.be.equal(1);
-					expect(startHandler.getCall(0).args[0].isTrusted).to.be.false;
-					expect(changeHandler.called).to.be.true;
-					expect(event.isTrusted).to.be.false;
-					done();
-				}
-			});
+    it("should check 'setTo' method (diff position after range limit)", (done) => {
+      // Given
+      const depaPos = this.inst.axisManager.get();
+      const destPos = { x: -100, z: 450 };
+      const self = this.inst;
+      const changeHandler = sinon.spy(function (event) {
+        // Then
+        expect(self.axisManager.get()).to.be.eql({ x: 0, y: 0, z: 150 });
+        done();
+      });
+      this.axes.on({
+        change: changeHandler,
+      });
 
-			// When
-			this.inst.setBy(byPos, 1000);
-		});
-		it("should check 'setBy' method (outside, duration)", (done) => {
-			// Given
-			const depaPos = this.inst.axm.get();
-			const minZ = this.axis.z.range[0];
-			const rangeLength = this.axis.z.range[1] - this.axis.z.range[0];
-			const byPos = {
-				x: 200,
-				z: 500
-			};
-			const self = this.inst;
-			const startHandler = sinon.spy();
-			const changeHandler = sinon.spy(function (event) {
-				// console.log("change handler", self.axm.get());
-				expect(event.input).to.be.null;
-				expect(event.inputEvent).to.be.null;
-				expect(self.getEventInfo()).to.be.null;
-			});
-			this.component.on({
-				"animationStart": startHandler,
-				"change": changeHandler,
-				"animationEnd": function (event) {
-					expect(self.axm.get()).to.be.eql({ x: 100, y: 0, z: 100 });
-					expect(startHandler.callCount).to.be.equal(1);
-					expect(startHandler.getCall(0).args[0].isTrusted).to.be.false;
-					expect(changeHandler.called).to.be.true;
-					expect(event.isTrusted).to.be.false;
-					done();
-				}
-			});
+      // When
+      const ret = this.inst.setTo(destPos);
+    });
 
-			// When
-			this.inst.setBy(byPos, 1000);
-		});
-		it("should check 'animateTo' method (inside)", (done) => {
-			// Given
-			const depaPos = this.inst.axm.get();
-			const destPos = {
-				x: 90,
-				z: -80
-			};
-			const self = this.inst;
-			const startHandler = sinon.spy();
-			const changeHandler = sinon.spy(function (event) {
-				expect(event.input).to.be.null;
-				expect(event.inputEvent).to.be.null;
-				expect(self.getEventInfo()).to.be.null;
-			});
-			this.component.on({
-				"animationStart": startHandler,
-				"change": changeHandler,
-				"animationEnd": function (event) {
-					expect(self.axm.get()).to.be.eql({ x: 90, y: 0, z: -80 });
-					expect(startHandler.callCount).to.be.equal(1);
-					expect(startHandler.getCall(0).args[0].isTrusted).to.be.false;
-					expect(changeHandler.called).to.be.true;
-					expect(event.isTrusted).to.be.false;
-					done();
-				}
-			});
+    it("should check 'setBy' method (inside, duration)", (done) => {
+      // Given
+      const depaPos = this.inst.axisManager.get();
+      const byPos = {
+        x: 20,
+        z: 40,
+      };
+      const self = this.inst;
+      const startHandler = sinon.spy();
+      const changeHandler = sinon.spy(function (event) {
+        expect(event.input).to.be.null;
+        expect(event.inputEvent).to.be.null;
+        expect(self.getEventInfo()).to.be.null;
+      });
+      this.axes.on({
+        animationStart: startHandler,
+        change: changeHandler,
+        animationEnd: function (event) {
+          expect(self.axisManager.get()).to.be.eql({
+            x: depaPos.x + byPos.x,
+            y: 0,
+            z: depaPos.z + byPos.z,
+          });
+          expect(startHandler.callCount).to.be.equal(1);
+          expect(startHandler.getCall(0).args[0].isTrusted).to.be.false;
+          expect(changeHandler.called).to.be.true;
+          expect(event.isTrusted).to.be.false;
+          done();
+        },
+      });
 
-			// When
-			this.inst.setTo(destPos, 500);
-		});
-		it("should check 'animateTo' method (outside)", (done) => {
-			// Given
-			const depaPos = this.inst.axm.get();
-			const destPos = {
-				x: 200,
-				z: -155
-			};
-			const self = this.inst;
-			const startHandler = sinon.spy();
-			const endHandler = sinon.spy(function (event) {
-				if (endHandler.callCount === 1) {
-					// first destPos
-					expect(self.axm.get()).to.be.eql({ x: 200, y: 0, z: 145 });
-					expect(startHandler.callCount).to.be.equal(1);
-					expect(startHandler.getCall(0).args[0].isTrusted).to.be.false;
-					expect(event.isTrusted).to.be.false;
-				} else if (endHandler.callCount === 2) {
-					// Then
-					expect(self.axm.get()).to.be.eql({ x: 100, y: 0, z: 145 });
-					expect(startHandler.getCall(1).args[0].isTrusted).to.be.false;
-					expect(startHandler.callCount).to.be.equal(2);
-					expect(event.isTrusted).to.be.false;
-					done();
-				}
-			});
-			this.component.on({
-				"animationStart": startHandler,
-				"animationEnd": endHandler
-			});
+      // When
+      this.inst.setBy(byPos, 1000);
+    });
+    it("should check 'setBy' method (outside, duration)", (done) => {
+      // Given
+      const depaPos = this.inst.axisManager.get();
+      const minZ = this.axis.z.range[0];
+      const rangeLength = this.axis.z.range[1] - this.axis.z.range[0];
+      const byPos = {
+        x: 200,
+        z: 500,
+      };
+      const self = this.inst;
+      const startHandler = sinon.spy();
+      const changeHandler = sinon.spy(function (event) {
+        // console.log("change handler", self.axisManager.get());
+        expect(event.input).to.be.null;
+        expect(event.inputEvent).to.be.null;
+        expect(self.getEventInfo()).to.be.null;
+      });
+      this.axes.on({
+        animationStart: startHandler,
+        change: changeHandler,
+        animationEnd: function (event) {
+          expect(self.axisManager.get()).to.be.eql({ x: 100, y: 0, z: 100 });
+          expect(startHandler.callCount).to.be.equal(1);
+          expect(startHandler.getCall(0).args[0].isTrusted).to.be.false;
+          expect(changeHandler.called).to.be.true;
+          expect(event.isTrusted).to.be.false;
+          done();
+        },
+      });
 
-			// When
-			this.inst.animateTo(destPos, 1000);
-		});
-		it("should check 'animateTo' with destPos that can cause floating point", (done) => {
-			// circular: true,
-			// duration: 102
-			// depaPos: 729.5859375
-			// destPos: 1055.984375
-			// range: [-96, 1055.984375]
+      // When
+      this.inst.setBy(byPos, 1000);
+    });
+    it("should check 'animateTo' method (inside)", (done) => {
+      // Given
+      const depaPos = this.inst.axisManager.get();
+      const destPos = {
+        x: 90,
+        z: -80,
+      };
+      const self = this.inst;
+      const startHandler = sinon.spy();
+      const changeHandler = sinon.spy(function (event) {
+        expect(event.input).to.be.null;
+        expect(event.inputEvent).to.be.null;
+        expect(self.getEventInfo()).to.be.null;
+      });
+      this.axes.on({
+        animationStart: startHandler,
+        change: changeHandler,
+        animationEnd: function (event) {
+          expect(self.axisManager.get()).to.be.eql({ x: 90, y: 0, z: -80 });
+          expect(startHandler.callCount).to.be.equal(1);
+          expect(startHandler.getCall(0).args[0].isTrusted).to.be.false;
+          expect(changeHandler.called).to.be.true;
+          expect(event.isTrusted).to.be.false;
+          done();
+        },
+      });
 
-			// Given
-			this.inst.axm.axis.z.range = [-96, 1055.984375];
-			this.inst.setTo({ z: 729.5858375 }, 0);
+      // When
+      this.inst.setTo(destPos, 500);
+    });
+    it("should check 'animateTo' method (outside)", (done) => {
+      // Given
+      const depaPos = this.inst.axisManager.get();
+      const destPos = {
+        x: 200,
+        z: -155,
+      };
+      const self = this.inst;
+      const startHandler = sinon.spy();
+      const endHandler = sinon.spy(function (event) {
+        if (endHandler.callCount === 1) {
+          // first destPos
+          expect(self.axisManager.get()).to.be.eql({ x: 200, y: 0, z: 145 });
+          expect(startHandler.callCount).to.be.equal(1);
+          expect(startHandler.getCall(0).args[0].isTrusted).to.be.false;
+          expect(event.isTrusted).to.be.false;
+        } else if (endHandler.callCount === 2) {
+          // Then
+          expect(self.axisManager.get()).to.be.eql({ x: 100, y: 0, z: 145 });
+          expect(startHandler.getCall(1).args[0].isTrusted).to.be.false;
+          expect(startHandler.callCount).to.be.equal(2);
+          expect(event.isTrusted).to.be.false;
+          done();
+        }
+      });
+      this.axes.on({
+        animationStart: startHandler,
+        animationEnd: endHandler,
+      });
 
-			// When
-			this.inst.animateTo({ z: 1055.984375 }, 102);
+      // When
+      this.inst.animateTo(destPos, 1000);
+    });
+    it("should check 'animateTo' with destPos that can cause floating point", (done) => {
+      // circular: true,
+      // duration: 102
+      // depaPos: 729.5859375
+      // destPos: 1055.984375
+      // range: [-96, 1055.984375]
 
-			setTimeout(() => {
-				// Then
-				expect(this.inst.axm.get().z).to.be.equals(1055.984375);
-				done();
-			}, 200);
-		});
-		it("should check position when animation is running. then, start other animation", (done) => {
-			// Given
-			const startHandler = sinon.spy();
-			const changeHandler = sinon.spy();
-			const endHandler = sinon.spy();
-			this.component.on({
-				"change": changeHandler,
-				"animationStart": startHandler,
-				"animationEnd": endHandler
-			});
+      // Given
+      this.inst.axisManager._axis.z.range = [-96, 1055.984375];
+      this.inst.setTo({ z: 729.5858375 }, 0);
 
-			// When
-			this.inst.setTo({ x: 80, y: 150 }, 200);
+      // When
+      this.inst.animateTo({ z: 1055.984375 }, 102);
 
-			// Then
-			setTimeout(() => {
-				expect(startHandler.calledOnce).to.be.true;
-				expect(changeHandler.called).to.be.true;
-				expect(endHandler.called).to.be.false;
+      setTimeout(() => {
+        // Then
+        expect(this.inst.axisManager.get().z).to.be.equals(1055.984375);
+        done();
+      }, 200);
+    });
+    it("should check position when animation is running. then, start other animation", (done) => {
+      // Given
+      const startHandler = sinon.spy();
+      const changeHandler = sinon.spy();
+      const endHandler = sinon.spy();
+      this.axes.on({
+        change: changeHandler,
+        animationStart: startHandler,
+        animationEnd: endHandler,
+      });
 
-				// When
-				this.inst.setTo({ x: 0, y: 0 }, 300);
-				expect(this.inst.axm.get()).to.not.eql({ x: 80, y: 150, z: -100 });
-			}, 100);
-			setTimeout(() => {
-				expect(startHandler.calledTwice).to.be.true;
-				expect(changeHandler.called).to.be.true;
-				expect(endHandler.calledTwice).to.be.true;
-				const result = this.inst.axm.get();
+      // When
+      this.inst.setTo({ x: 80, y: 150 }, 200);
 
-				expect(result.x).to.be.equal(0);
-				expect(result.y).to.be.equal(0);
-				expect(result.z).to.be.equal(-100);
-				done();
-			}, 500);
-		});
-		[1, -1].forEach(direction => {
-			it(`should check destPos when range changes dynamically during animateLoop(direction: ${direction}, circular: true)`, (done) => {
-				// Given
-				const depaPos = { z: -100 };
-				const destPos = direction > 0 ? { z: 600 } : { z: -600 };
-				const resultPos = direction > 0 ? { z: 300 } : { z: 0 };
+      // Then
+      setTimeout(() => {
+        expect(startHandler.calledOnce).to.be.true;
+        expect(changeHandler.called).to.be.true;
+        expect(endHandler.called).to.be.false;
 
-				// When
-				setTimeout(() => {
-					// the right time for a range to be crossed
-					// 'pos' is off the range.
-					// z.range[1] 200 => 600
-					this.axis.z.range[1] = 600;
-				}, 300)
+        // When
+        this.inst.setTo({ x: 0, y: 0 }, 300);
+        expect(this.inst.axisManager.get()).to.not.eql({
+          x: 80,
+          y: 150,
+          z: -100,
+        });
+      }, 100);
+      setTimeout(() => {
+        expect(startHandler.calledTwice).to.be.true;
+        expect(changeHandler.called).to.be.true;
+        expect(endHandler.calledTwice).to.be.true;
+        const result = this.inst.axisManager.get();
 
-				this.inst.animateLoop({
-					duration: 1000,
-					depaPos,
-					destPos,
-					delta: { z: destPos.z - depaPos.z },
-				}, () => {
-					// Then
-					expect(this.inst.axm.get(["z"]).z).to.be.equals(resultPos.z);
-					done();
-				});
-			});
-			it(`should check destPos when range changes dynamically during animateLoop and change(direction: ${direction}, circular: true)`, (done) => {
-				// Given
-				const depaPos = { z: -100 };
-				const destPos = direction > 0 ? { z: 600 } : { z: -600 };
-				const resultPos = direction > 0 ? { z: 300 } : { z: 0 };
+        expect(result.x).to.be.equal(0);
+        expect(result.y).to.be.equal(0);
+        expect(result.z).to.be.equal(-100);
+        done();
+      }, 500);
+    });
+    [1, -1].forEach((direction) => {
+      it(`should check destPos when range changes dynamically during animateLoop(direction: ${direction}, circular: true)`, (done) => {
+        // Given
+        const depaPos = { z: -100 };
+        const destPos = direction > 0 ? { z: 600 } : { z: -600 };
+        const resultPos = direction > 0 ? { z: 300 } : { z: 0 };
 
-				// When
-				let willChange = false;
-				setTimeout(() => {
-					// Starts with the exception of -100, which is the start position.
-					this.component.on("change", e => {
-						if (
-							// range[0] = -100
-							(direction === -1 && e.pos.z < -80)
-							// range[1] = 200
-							|| (direction === 1 && e.pos.z > 180)
-						) {
-							willChange = true;
-						} else if (willChange) {
-							this.axis.z.range[1] = 600;
-						}
-					});
-				}, 100);
+        // When
+        setTimeout(() => {
+          // the right time for a range to be crossed
+          // 'pos' is off the range.
+          // z.range[1] 200 => 600
+          this.axis.z.range[1] = 600;
+        }, 300);
 
-				this.inst.animateLoop({
-					duration: 1000,
-					depaPos,
-					destPos,
-					delta: { z: destPos.z - depaPos.z },
-				}, () => {
-					// Then
-					expect(this.inst.axm.get(["z"]).z).to.be.equals(resultPos.z);
-					done();
-				});
-			});
-		});
-	});
+        this.inst._animateLoop(
+          {
+            duration: 1000,
+            depaPos,
+            destPos,
+            delta: { z: destPos.z - depaPos.z },
+          },
+          () => {
+            // Then
+            expect(this.inst.axisManager.get(["z"]).z).to.be.equals(
+              resultPos.z
+            );
+            done();
+          }
+        );
+      });
+      it(`should check destPos when range changes dynamically during animateLoop and change(direction: ${direction}, circular: true)`, (done) => {
+        // Given
+        const depaPos = { z: -100 };
+        const destPos = direction > 0 ? { z: 600 } : { z: -600 };
+        const resultPos = direction > 0 ? { z: 300 } : { z: 0 };
+
+        // When
+        let willChange = false;
+        setTimeout(() => {
+          // Starts with the exception of -100, which is the start position.
+          this.axes.on("change", (e) => {
+            if (
+              // range[0] = -100
+              (direction === -1 && e.pos.z < -80) ||
+              // range[1] = 200
+              (direction === 1 && e.pos.z > 180)
+            ) {
+              willChange = true;
+            } else if (willChange) {
+              this.axis.z.range[1] = 600;
+            }
+          });
+        }, 100);
+
+        this.inst._animateLoop(
+          {
+            duration: 1000,
+            depaPos,
+            destPos,
+            delta: { z: destPos.z - depaPos.z },
+          },
+          () => {
+            // Then
+            expect(this.inst.axisManager.get(["z"]).z).to.be.equals(
+              resultPos.z
+            );
+            done();
+          }
+        );
+      });
+    });
+  });
 });

--- a/test/unit/Axes.spec.js
+++ b/test/unit/Axes.spec.js
@@ -5,1123 +5,1197 @@ import { getDecimalPlace, roundNumber } from "../../src/utils";
 import PanInputInjector from "inject-loader!../../src/inputType/PanInput.ts";
 
 describe("Axes", function () {
-	describe("Axes Test", function () {
-		beforeEach(() => {
-			this.inst = null;
-		});
-		afterEach(() => {
-			if (this.inst) {
-				this.inst.destroy();
-				this.inst = null;
-			}
-		});
+  describe("Axes Test", function () {
+    beforeEach(() => {
+      this.inst = null;
+    });
+    afterEach(() => {
+      if (this.inst) {
+        this.inst.destroy();
+        this.inst = null;
+      }
+    });
 
-		it("should check a initialization empty value", () => {
-			// Given
-			// When
-			this.inst = new Axes();
-			// Then
+    it("should check a initialization empty value", () => {
+      // Given
+      // When
+      this.inst = new Axes();
+      // Then
 
-			const defaultOptions = {
-				easing: function easeOutCubic(x) {
-					return 1 - Math.pow(1 - x, 3);
-				},
-				interruptable: true,
-				minimumDuration: 0,
-				maximumDuration: Infinity,
-				deceleration: 0.0006,
-			}
+      const defaultOptions = {
+        easing: function easeOutCubic(x) {
+          return 1 - Math.pow(1 - x, 3);
+        },
+        interruptable: true,
+        minimumDuration: 0,
+        maximumDuration: Infinity,
+        deceleration: 0.0006,
+      };
 
-			expect(this.inst).to.be.exist;
-			expect(defaultOptions.easing(0.5)).to.be.equal(this.inst.options.easing(0.5));
-			expect(defaultOptions.easing(0.3)).to.be.equal(this.inst.options.easing(0.3));
-			expect(defaultOptions.easing(0.1)).to.be.equal(this.inst.options.easing(0.1));
-			expect(defaultOptions.easing(0.7)).to.be.equal(this.inst.options.easing(0.7));
-			expect(defaultOptions.easing(0.9)).to.be.equal(this.inst.options.easing(0.9));
-			expect(defaultOptions.interruptable).to.be.equal(this.inst.options.interruptable);
-			expect(defaultOptions.minimumDuration).to.be.equal(this.inst.options.minimumDuration);
-			expect(defaultOptions.maximumDuration).to.be.equal(this.inst.options.maximumDuration);
-			expect(defaultOptions.deceleration).to.be.equal(this.inst.options.deceleration);
-		});
+      expect(this.inst).to.be.exist;
+      expect(defaultOptions.easing(0.5)).to.be.equal(
+        this.inst.options.easing(0.5)
+      );
+      expect(defaultOptions.easing(0.3)).to.be.equal(
+        this.inst.options.easing(0.3)
+      );
+      expect(defaultOptions.easing(0.1)).to.be.equal(
+        this.inst.options.easing(0.1)
+      );
+      expect(defaultOptions.easing(0.7)).to.be.equal(
+        this.inst.options.easing(0.7)
+      );
+      expect(defaultOptions.easing(0.9)).to.be.equal(
+        this.inst.options.easing(0.9)
+      );
+      expect(defaultOptions.interruptable).to.be.equal(
+        this.inst.options.interruptable
+      );
+      expect(defaultOptions.minimumDuration).to.be.equal(
+        this.inst.options.minimumDuration
+      );
+      expect(defaultOptions.maximumDuration).to.be.equal(
+        this.inst.options.maximumDuration
+      );
+      expect(defaultOptions.deceleration).to.be.equal(
+        this.inst.options.deceleration
+      );
+    });
 
-		it("should check initialization status", () => {
-			// Given
-			// When
-			this.inst = new Axes({
-				x: {
-					range: [0, 100],
-					bounce: [30, 50],
-					circular: true
-				},
-				otherX: {
-					range: [-100, 100],
-					bounce: 40,
-					circular: [false, true]
-				}
-			}, {
-				deceleration: 0.001
-			}, {
-				x: 50,
-				otherX: 0,
-			});
+    it("should check initialization status", () => {
+      // Given
+      // When
+      this.inst = new Axes(
+        {
+          x: {
+            range: [0, 100],
+            bounce: [30, 50],
+            circular: true,
+          },
+          otherX: {
+            range: [-100, 100],
+            bounce: 40,
+            circular: [false, true],
+          },
+        },
+        {
+          deceleration: 0.001,
+        },
+        {
+          x: 50,
+          otherX: 0,
+        }
+      );
 
-			// Then
-			expect(this.inst.axis.x.bounce).to.deep.equal([30, 50]);
-			expect(this.inst.axis.x.circular).to.deep.equal([true, true]);
-			expect(this.inst.axis.otherX.bounce).to.deep.equal([40, 40]);
-			expect(this.inst.axis.otherX.circular).to.deep.equal([false, true]);
-			expect(this.inst.get().x).to.equal(50);
-			expect(this.inst.get().otherX).to.equal(0);
-		});
-		it("should check `setTo/setBy` method", () => {
-			// Given
-			this.inst = new Axes({
-				x: {
-					range: [0, 100],
-					bounce: [30, 50],
-					circular: true
-				},
-				otherX: {
-					range: [-100, 100],
-					bounce: 40,
-					circular: [false, true]
-				}
-			}, {
-				deceleration: 0.001
-			});
-			// When
-			let ret = this.inst.setTo({ x: 20 });
+      // Then
+      expect(this.inst.axis.x.bounce).to.deep.equal([30, 50]);
+      expect(this.inst.axis.x.circular).to.deep.equal([true, true]);
+      expect(this.inst.axis.otherX.bounce).to.deep.equal([40, 40]);
+      expect(this.inst.axis.otherX.circular).to.deep.equal([false, true]);
+      expect(this.inst.get().x).to.equal(50);
+      expect(this.inst.get().otherX).to.equal(0);
+    });
+    it("should check `setTo/setBy` method", () => {
+      // Given
+      this.inst = new Axes(
+        {
+          x: {
+            range: [0, 100],
+            bounce: [30, 50],
+            circular: true,
+          },
+          otherX: {
+            range: [-100, 100],
+            bounce: 40,
+            circular: [false, true],
+          },
+        },
+        {
+          deceleration: 0.001,
+        }
+      );
+      // When
+      let ret = this.inst.setTo({ x: 20 });
 
-			// Then
-			expect(this.inst.get()).to.be.eql({ x: 20, otherX: -100 });
-			expect(ret).to.be.equal(this.inst);
+      // Then
+      expect(this.inst.get()).to.be.eql({ x: 20, otherX: -100 });
+      expect(ret).to.be.equal(this.inst);
 
-			// When
-			this.inst.setBy({ x: 10 });
+      // When
+      this.inst.setBy({ x: 10 });
 
-			// Then
-			expect(this.inst.get()).to.be.eql({ x: 30, otherX: -100 });
-		});
+      // Then
+      expect(this.inst.get()).to.be.eql({ x: 30, otherX: -100 });
+    });
 
-		it("should check `setTo` method (with duration)", () => {
-			// Given
-			const startHandler = sinon.spy();
-			const changeHandler = sinon.spy();
-			const endHandler = sinon.spy(function () {
-				// Then
-				expect(startHandler.callCount).to.be.equal(1);
-				expect(changeHandler.called).to.be.true;
-				expect(this.inst.get()).to.be.eql({ x: 20, otherX: -100 });
-				done();
-			});
-			this.inst = new Axes({
-				x: {
-					range: [0, 100],
-					bounce: [30, 50],
-					circular: true
-				},
-				otherX: {
-					range: [-100, 100],
-					bounce: 40,
-					circular: [false, true]
-				}
-			}, {
-				deceleration: 0.001
-			}).on({
-				"animationStart": startHandler,
-				"change": changeHandler,
-				"animationEnd": endHandler
-			});
+    it("should check `setTo` method (with duration)", () => {
+      // Given
+      const startHandler = sinon.spy();
+      const changeHandler = sinon.spy();
+      const endHandler = sinon.spy(function () {
+        // Then
+        expect(startHandler.callCount).to.be.equal(1);
+        expect(changeHandler.called).to.be.true;
+        expect(this.inst.get()).to.be.eql({ x: 20, otherX: -100 });
+        done();
+      });
+      this.inst = new Axes(
+        {
+          x: {
+            range: [0, 100],
+            bounce: [30, 50],
+            circular: true,
+          },
+          otherX: {
+            range: [-100, 100],
+            bounce: 40,
+            circular: [false, true],
+          },
+        },
+        {
+          deceleration: 0.001,
+        }
+      ).on({
+        animationStart: startHandler,
+        change: changeHandler,
+        animationEnd: endHandler,
+      });
 
-			// When
-			this.inst.setTo({ x: 20 }, 200);
-		});
+      // When
+      this.inst.setTo({ x: 20 }, 200);
+    });
 
-		it("should check `setBy` method (with duration)", () => {
-			// Given
-			this.inst = new Axes({
-				x: {
-					range: [0, 100],
-					bounce: [30, 50],
-					circular: true
-				},
-				otherX: {
-					range: [-100, 100],
-					bounce: 40,
-					circular: [false, true]
-				}
-			}, {
-				deceleration: 0.001
-			});
-			this.inst.setTo({ x: 50 });
-			expect(this.inst.get()).to.be.eql({ x: 50, otherX: -100 });
+    it("should check `setBy` method (with duration)", () => {
+      // Given
+      this.inst = new Axes(
+        {
+          x: {
+            range: [0, 100],
+            bounce: [30, 50],
+            circular: true,
+          },
+          otherX: {
+            range: [-100, 100],
+            bounce: 40,
+            circular: [false, true],
+          },
+        },
+        {
+          deceleration: 0.001,
+        }
+      );
+      this.inst.setTo({ x: 50 });
+      expect(this.inst.get()).to.be.eql({ x: 50, otherX: -100 });
 
-			this.inst.on({
-				"animationStart": startHandler,
-				"change": changeHandler,
-				"animationEnd": endHandler
-			});
+      this.inst.on({
+        animationStart: startHandler,
+        change: changeHandler,
+        animationEnd: endHandler,
+      });
 
-			const startHandler = sinon.spy();
-			const changeHandler = sinon.spy();
-			const endHandler = sinon.spy(function () {
-				// Then
-				expect(startHandler.callCount).to.be.equal(1);
-				expect(changeHandler.called).to.be.true;
-				expect(this.inst.get()).to.be.eql({ x: 40, otherX: -100 });
-				done();
-			});
+      const startHandler = sinon.spy();
+      const changeHandler = sinon.spy();
+      const endHandler = sinon.spy(function () {
+        // Then
+        expect(startHandler.callCount).to.be.equal(1);
+        expect(changeHandler.called).to.be.true;
+        expect(this.inst.get()).to.be.eql({ x: 40, otherX: -100 });
+        done();
+      });
 
-			// When
-			this.inst.setBy({ x: -10 }, 200);
-		});
-	});
+      // When
+      this.inst.setBy({ x: -10 }, 200);
+    });
+  });
 
-	describe("Axes Test with InputType", function () {
-		beforeEach(() => {
-			this.inst = new Axes({
-				x: {
-					range: [0, 100],
-					bounce: [30, 50],
-					circular: true
-				},
-				otherX: {
-					range: [-100, 100],
-					bounce: 40,
-					circular: [false, true]
-				}
-			}, {
-				deceleration: 0.001
-			});
-			sandbox();
-		});
-		afterEach(() => {
-			if (this.inst) {
-				this.inst.destroy();
-				this.inst = null;
-			}
-			cleanup();
-		});
+  describe("Axes Test with InputType", function () {
+    beforeEach(() => {
+      this.inst = new Axes(
+        {
+          x: {
+            range: [0, 100],
+            bounce: [30, 50],
+            circular: true,
+          },
+          otherX: {
+            range: [-100, 100],
+            bounce: 40,
+            circular: [false, true],
+          },
+        },
+        {
+          deceleration: 0.001,
+        }
+      );
+      sandbox();
+    });
+    afterEach(() => {
+      if (this.inst) {
+        this.inst.destroy();
+        this.inst = null;
+      }
+      cleanup();
+    });
 
-		it("should check `connect` method", () => {
-			// Given
-			const input = new PanInput("#sandbox");
+    it("should check `connect` method", () => {
+      // Given
+      const input = new PanInput("#sandbox");
 
-			// When
-			let ret = this.inst.connect("x", input);
+      // When
+      let ret = this.inst.connect("x", input);
 
-			// Then
-			expect(input.axes).to.be.eql(["x"]);
-			expect(this.inst._inputs.length).to.be.equal(1);
-			expect(ret).to.be.equal(this.inst);
+      // Then
+      expect(input.axes).to.be.eql(["x"]);
+      expect(this.inst._inputs.length).to.be.equal(1);
+      expect(ret).to.be.equal(this.inst);
 
-			// When
-			ret = this.inst.connect(["x"], input);
+      // When
+      ret = this.inst.connect(["x"], input);
 
-			// Then
-			expect(input.axes).to.be.eql(["x"]);
-			expect(this.inst._inputs.length).to.be.equal(1);
-			expect(ret).to.be.equal(this.inst);
+      // Then
+      expect(input.axes).to.be.eql(["x"]);
+      expect(this.inst._inputs.length).to.be.equal(1);
+      expect(ret).to.be.equal(this.inst);
 
-			// When
-			ret = this.inst.connect(["x", "y"], input);
+      // When
+      ret = this.inst.connect(["x", "y"], input);
 
-			// Then
-			expect(input.axes).to.be.eql(["x", "y"]);
-			expect(this.inst._inputs.length).to.be.equal(1);
-			expect(ret).to.be.equal(this.inst);
+      // Then
+      expect(input.axes).to.be.eql(["x", "y"]);
+      expect(this.inst._inputs.length).to.be.equal(1);
+      expect(ret).to.be.equal(this.inst);
 
-			// When
-			ret = this.inst.connect("x y", input);
+      // When
+      ret = this.inst.connect("x y", input);
 
-			// Then
-			expect(input.axes).to.be.eql(["x", "y"]);
-			expect(this.inst._inputs.length).to.be.equal(1);
-			expect(ret).to.be.equal(this.inst);
+      // Then
+      expect(input.axes).to.be.eql(["x", "y"]);
+      expect(this.inst._inputs.length).to.be.equal(1);
+      expect(ret).to.be.equal(this.inst);
 
-			input.destroy();
-		});
+      input.destroy();
+    });
 
-		it("should check `disconnect` method", () => {
-			// Given
-			const input1 = new PanInput("#sandbox");
-			const input2 = new PanInput("#sandbox");
-			const input3 = new PanInput("#sandbox");
-			this.inst.connect("x", input1);
-			this.inst.connect("y", input2);
-			this.inst.connect("x y", input3);
+    it("should check `disconnect` method", () => {
+      // Given
+      const input1 = new PanInput("#sandbox");
+      const input2 = new PanInput("#sandbox");
+      const input3 = new PanInput("#sandbox");
+      this.inst.connect("x", input1);
+      this.inst.connect("y", input2);
+      this.inst.connect("x y", input3);
 
-			// When
-			expect(this.inst._inputs.length).to.be.equal(3);
-			let ret = this.inst.disconnect(input1);
+      // When
+      expect(this.inst._inputs.length).to.be.equal(3);
+      let ret = this.inst.disconnect(input1);
 
-			// Then
-			expect(this.inst._inputs.indexOf(input1)).to.be.equal(-1);
-			expect(this.inst._inputs.length).to.be.equal(2);
-			expect(ret).to.be.equal(this.inst);
+      // Then
+      expect(this.inst._inputs.indexOf(input1)).to.be.equal(-1);
+      expect(this.inst._inputs.length).to.be.equal(2);
+      expect(ret).to.be.equal(this.inst);
 
-			// When
-			ret = this.inst.disconnect();
+      // When
+      ret = this.inst.disconnect();
 
-			// Then
-			expect(this.inst._inputs).to.be.eql([]);
-			expect(ret).to.be.equal(this.inst);
-			expect(this.inst._inputs.length).to.be.equal(0);
+      // Then
+      expect(this.inst._inputs).to.be.eql([]);
+      expect(ret).to.be.equal(this.inst);
+      expect(this.inst._inputs.length).to.be.equal(0);
 
-			// When no input, it should not make script error
-			ret = this.inst.disconnect(input1);
+      // When no input, it should not make script error
+      ret = this.inst.disconnect(input1);
 
-			// Then
-			expect(ret).to.be.equal(this.inst);
+      // Then
+      expect(ret).to.be.equal(this.inst);
 
-			input1.destroy();
-			input2.destroy();
-			input3.destroy();
-		});
+      input1.destroy();
+      input2.destroy();
+      input3.destroy();
+    });
 
-		it("should check if hammer instance is shared (diffrent instance, same element)", () => {
-			// Given
-			const input1 = new PanInput("#sandbox");
-			const input2 = new PanInput("#sandbox");
-			const input3 = new PanInput("#sandbox");
-			this.inst.connect("x", input1);
-			this.inst.connect("y", input2);
-			this.inst.connect("x y", input3);
+    it("should work with pan gesture when connecting PanInput after PinchInput disconnected.", (done) => {
+      // Given
+      const MOVE_HORIZONTALLY = {
+        pos: [0, 0],
+        deltaX: 100,
+        deltaY: 10,
+        duration: 200,
+        easing: "linear",
+      };
+      const MOVE_VERTICALLY = {
+        pos: [0, 0],
+        deltaX: 0,
+        deltaY: 100,
+        duration: 200,
+        easing: "linear",
+      };
+      const target = document.querySelector("#sandbox");
+      const pinchInput = new PinchInput(target, { inputType: ["touch"] });
+      const panInput = new PanInput(target, { inputType: ["touch"] });
 
-			// When
-			expect(this.inst._inputs.length).to.be.equal(3);
+      this.inst.connect("x", pinchInput);
+      this.inst.disconnect(pinchInput);
+      this.inst.connect(["x", "otherX"], panInput);
 
-			// Then
-			expect(input1.hammer).to.be.equal(input2.hammer);
-			expect(input3.hammer).to.be.equal(input2.hammer);
-			expect(input1).to.be.not.equal(input2);
-			expect(input2).to.be.not.equal(input3);
-			expect(input3).to.be.not.equal(input1);
-			expect(input1.element).to.be.equal(input2.element);
-			expect(input1.element).to.be.equal(input2.element);
+      const prevX = this.inst.get()["x"];
+      const prevY = this.inst.get()["otherX"];
 
-			input1.destroy();
-			input2.destroy();
-			input3.destroy();
-		});
+      // When
+      Simulator.gestures.pan(target, MOVE_HORIZONTALLY, () => {
+        Simulator.gestures.pan(target, MOVE_VERTICALLY, () => {
+          // Then
+          const currX = this.inst.get()["x"];
+          const currY = this.inst.get()["otherX"];
 
-		it("should work with pan gesture when connecting PanInput after PinchInput disconnected.", done => {
-			// Given
-			const MOVE_HORIZONTALLY = {
-				pos: [0, 0],
-				deltaX: 100,
-				deltaY: 10,
-				duration: 200,
-				easing: "linear"
-			};
-			const MOVE_VERTICALLY = {
-				pos: [0, 0],
-				deltaX: 0,
-				deltaY: 100,
-				duration: 200,
-				easing: "linear"
-			};
-			const target = document.querySelector("#sandbox");
-			const pinchInput = new PinchInput(target, { inputType: ["touch"] });
-			const panInput = new PanInput(target, { inputType: ["touch"] });
+          expect(currX).to.be.not.equal(prevX);
+          expect(currY).to.be.not.equal(prevY);
 
-			this.inst.connect("x", pinchInput);
-			this.inst.disconnect(pinchInput);
-			this.inst.connect(["x", "otherX"], panInput);
-
-			const prevX = this.inst.get()["x"];
-			const prevY = this.inst.get()["otherX"];
-
-			// When
-			Simulator.gestures.pan(target, MOVE_HORIZONTALLY, () => {
-				Simulator.gestures.pan(target, MOVE_VERTICALLY, () => {
-					// Then
-					const currX = this.inst.get()["x"];
-					const currY = this.inst.get()["otherX"];
-
-					expect(currX).to.be.not.equal(prevX);
-					expect(currY).to.be.not.equal(prevY);
-
-					pinchInput.destroy();
-					panInput.destroy();
-					done();
-				});
-			});
-		});
-	});
-	[20, 30, 40, 50].forEach(iOSEdgeSwipeThreshold => {
-		describe(`Axes iOS Edge Test (iOSEdgeSwipeThreshold: ${iOSEdgeSwipeThreshold})`, function () {
-			beforeEach(() => {
-				this.inst = new Axes({
-					x: {
-						range: [0, 300],
-						bounce: 100
-					},
-					y: {
-						range: [0, 400],
-						bounce: 100
-					}
-				}, {
-					deceleration: 0.001
-				});
-				this.el = sandbox();
-				this.el.innerHTML = `<div id="area"
+          pinchInput.destroy();
+          panInput.destroy();
+          done();
+        });
+      });
+    });
+  });
+  [20, 30, 40, 50].forEach((iOSEdgeSwipeThreshold) => {
+    describe(`Axes iOS Edge Test (iOSEdgeSwipeThreshold: ${iOSEdgeSwipeThreshold})`, function () {
+      beforeEach(() => {
+        this.inst = new Axes(
+          {
+            x: {
+              range: [0, 300],
+              bounce: 100,
+            },
+            y: {
+              range: [0, 400],
+              bounce: 100,
+            },
+          },
+          {
+            deceleration: 0.001,
+          }
+        );
+        this.el = sandbox();
+        this.el.innerHTML = `<div id="area"
 		style="position:relative; border:5px solid #444; width:300px; height:400px; color:#aaa; margin:0;box-sizing:content-box; z-index:9;"></div>`;
 
-				this.releaseHandler = sinon.spy();
-				this.finishHandler = sinon.spy();
-				const MockPanInputInjector = PanInputInjector({
-					"../const": {
-						IOS_EDGE_THRESHOLD: 30,
-						IS_IOS_SAFARI: true,
-					},
-				});
-				this.input = new MockPanInputInjector.PanInput(this.el, {
-					iOSEdgeSwipeThreshold,
-					inputType: ["touch"],
-				});
-				this.inst.on({
-					"release": this.releaseHandler,
-					"finish": this.finishHandler,
-				}).connect(["x", "y"], this.input);
+        this.releaseHandler = sinon.spy();
+        this.finishHandler = sinon.spy();
+        const MockPanInputInjector = PanInputInjector({
+          "../const": {
+            IOS_EDGE_THRESHOLD: 30,
+            IS_IOS_SAFARI: true,
+          },
+        });
+        this.input = new MockPanInputInjector.PanInput(this.el, {
+          iOSEdgeSwipeThreshold,
+          inputType: ["touch"],
+        });
+        this.inst
+          .on({
+            release: this.releaseHandler,
+            finish: this.finishHandler,
+          })
+          .connect(["x", "y"], this.input);
 
-				const touchTrigger = Simulator.events.touch.trigger;
+        const touchTrigger = Simulator.events.touch.trigger;
 
-				Simulator.events.touch.originalTrigger = touchTrigger;
-				Simulator.events.touch.trigger = function (touches, element, type) {
-					if (type === "end") {
-						return;
-					}
-					touchTrigger.call(Simulator.events.touch, touches, element, type);
-				};
-			});
-			afterEach(() => {
-				Simulator.events.touch.trigger = Simulator.events.touch.originalTrigger;
-				if (this.inst) {
-					this.inst.destroy();
-					this.inst = null;
-				}
-				if (this.input) {
-					this.input.destroy();
-					this.input = null;
-				}
-				this.releaseHandler.resetHistory();
-				this.finishHandler.resetHistory();
-				cleanup();
-			});
-			it("should check release event occurs when swiping on ios safari edge. (left to right)", (done) => {
-				// Given, When
-				// clientX + => -
-				Simulator.gestures.pan(this.el, {
-					pos: [30, 30],
-					deltaX: -50,
-					deltaY: 10,
-					duration: 200,
-					easing: "linear"
-				}, () => {
-					// Then
-					// for test animation event
-					setTimeout(() => {
-						const releaseEvent = this.releaseHandler.getCall(0).args[0];
-						expect(this.releaseHandler.calledOnce).to.be.true;
-						expect(releaseEvent.inputEvent.isFinal).to.be.false;
-						expect(releaseEvent.isTrusted).to.be.true;
+        Simulator.events.touch.originalTrigger = touchTrigger;
+        Simulator.events.touch.trigger = function (touches, element, type) {
+          if (type === "end") {
+            return;
+          }
+          touchTrigger.call(Simulator.events.touch, touches, element, type);
+        };
+      });
+      afterEach(() => {
+        Simulator.events.touch.trigger = Simulator.events.touch.originalTrigger;
+        if (this.inst) {
+          this.inst.destroy();
+          this.inst = null;
+        }
+        if (this.input) {
+          this.input.destroy();
+          this.input = null;
+        }
+        this.releaseHandler.resetHistory();
+        this.finishHandler.resetHistory();
+        cleanup();
+      });
+      it("should check release event occurs when swiping on ios safari edge. (left to right)", (done) => {
+        // Given, When
+        // clientX + => -
+        Simulator.gestures.pan(
+          this.el,
+          {
+            pos: [30, 30],
+            deltaX: -50,
+            deltaY: 10,
+            duration: 200,
+            easing: "linear",
+          },
+          () => {
+            // Then
+            // for test animation event
+            setTimeout(() => {
+              const releaseEvent = this.releaseHandler.getCall(0).args[0];
+              expect(this.releaseHandler.calledOnce).to.be.true;
+              // expect(releaseEvent.inputEvent.isFinal).to.be.false;
+              expect(releaseEvent.isTrusted).to.be.true;
 
-						const finishEvent = this.finishHandler.getCall(0).args[0];
-						expect(this.finishHandler.called).to.be.true;
-						expect(finishEvent.isTrusted).to.be.true;
-						done();
-					}, 500);
-				});
-			});
-			it("should check release event occurs when swiping a little on ios safari edge. (right to left)", (done) => {
-				// Given, When
-				// window.innerWidth => window.innerWidth - 15
-				Simulator.gestures.pan(this.el, {
-					pos: [window.innerWidth - iOSEdgeSwipeThreshold + 1, 30],
-					deltaX: -15,
-					deltaY: 0,
-					duration: 200,
-					easing: "linear"
-				}, () => {
-					// Then
-					// for test animation event
-					setTimeout(() => {
-						const releaseEvent = this.releaseHandler.getCall(0).args[0];
-						expect(this.releaseHandler.calledOnce).to.be.true;
-						expect(releaseEvent.inputEvent.isFinal).to.be.false;
-						expect(releaseEvent.isTrusted).to.be.true;
+              const finishEvent = this.finishHandler.getCall(0).args[0];
+              expect(this.finishHandler.called).to.be.true;
+              expect(finishEvent.isTrusted).to.be.true;
+              done();
+            }, 500);
+          }
+        );
+      });
+      it("should check release event occurs when swiping a little on ios safari edge. (right to left)", (done) => {
+        // Given, When
+        // window.innerWidth => window.innerWidth - 15
+        Simulator.gestures.pan(
+          this.el,
+          {
+            pos: [window.innerWidth - iOSEdgeSwipeThreshold + 1, 30],
+            deltaX: -15,
+            deltaY: 0,
+            duration: 200,
+            easing: "linear",
+          },
+          () => {
+            // Then
+            // for test animation event
+            setTimeout(() => {
+              const releaseEvent = this.releaseHandler.getCall(0).args[0];
+              expect(this.releaseHandler.calledOnce).to.be.true;
+              // expect(releaseEvent.inputEvent.isFinal).to.be.false;
+              expect(releaseEvent.isTrusted).to.be.true;
 
-						const finishEvent = this.finishHandler.getCall(0).args[0];
-						expect(this.finishHandler.called).to.be.true;
-						expect(finishEvent.isTrusted).to.be.true;
-						done();
-					}, 500);
-				});
-			});
-			it("should check release event not occurs when swiping a lot on ios safari edge. (right to left)", (done) => {
-				// Given, When
-				// window.innerWidth => window.innerWidth - 30
-				Simulator.gestures.pan(this.el, {
-					pos: [window.innerWidth, 30],
-					deltaX: -60,
-					deltaY: 0,
-					duration: 200,
-					easing: "linear"
-				}, () => {
-					// Then
-					// for test animation event
-					setTimeout(() => {
-						expect(this.releaseHandler.callCount).to.be.equals(0);
-						done();
-					}, 500);
-				});
-			});
-		});
-	});
-	[
-		["pointer"], ["touch", "mouse"], ["touch"]
-	].forEach(type => {
-		describe(`Axes Custom Event Test with interruptable(${type})`, function () {
-			beforeEach(() => {
-				if (type.indexOf("pointer") > -1) {
-					Simulator.setType("pointer");
-				} else {
-					Simulator.setType("touch");
-				}
-				this.inst = new Axes({
-					x: {
-						range: [0, 300],
-						bounce: 100
-					},
-					y: {
-						range: [0, 400],
-						bounce: 100
-					}
-				}, {
-					deceleration: 0.001,
-					interruptable: false
-				});
-				this.el = sandbox();
-				this.el.innerHTML = `<div id="area"
+              const finishEvent = this.finishHandler.getCall(0).args[0];
+              expect(this.finishHandler.called).to.be.true;
+              expect(finishEvent.isTrusted).to.be.true;
+              done();
+            }, 500);
+          }
+        );
+      });
+      it("should check release event not occurs when swiping a lot on ios safari edge. (right to left)", (done) => {
+        // Given, When
+        // window.innerWidth => window.innerWidth - 30
+        Simulator.gestures.pan(
+          this.el,
+          {
+            pos: [window.innerWidth, 30],
+            deltaX: -60,
+            deltaY: 0,
+            duration: 200,
+            easing: "linear",
+          },
+          () => {
+            // Then
+            // for test animation event
+            setTimeout(() => {
+              expect(this.releaseHandler.callCount).to.be.equals(0);
+              done();
+            }, 500);
+          }
+        );
+      });
+    });
+  });
+  [["pointer"], ["touch", "mouse"], ["touch"]].forEach((type) => {
+    describe(`Axes Custom Event Test with interruptable(${type})`, function () {
+      beforeEach(() => {
+        if (type.indexOf("pointer") > -1) {
+          Simulator.setType("pointer");
+        } else {
+          Simulator.setType("touch");
+        }
+        this.inst = new Axes(
+          {
+            x: {
+              range: [0, 300],
+              bounce: 100,
+            },
+            y: {
+              range: [0, 400],
+              bounce: 100,
+            },
+          },
+          {
+            deceleration: 0.001,
+            interruptable: false,
+          }
+        );
+        this.el = sandbox();
+        this.el.innerHTML = `<div id="area"
         style="position:relative; border:5px solid #444; width:300px; height:400px; color:#aaa; margin:0;box-sizing:content-box; z-index:9;"></div>`;
-				const self = this.inst;
-				this.preventedFn = function () {
-					expect(self.itm._prevented).to.be.true;
-				};
-				this.notPreventedFn = function () {
-					expect(self.itm._prevented).to.be.false;
-				};
-				this.input = new PanInput(this.el, {
-					inputType: type,
-				});
-				this.inst.connect(["x", "y"], this.input);
-			});
-			afterEach(() => {
-				if (this.inst) {
-					this.inst.destroy();
-					this.inst = null;
-				}
-				if (this.input) {
-					this.input.destroy();
-					this.input = null;
-				}
-				cleanup();
-			});
-			after(() => {
-				// Simulator type should be "touch" type after test complete.
-				// Otherwise this test will affect other simulation test.
-				Simulator.setType("touch");
-			});
-			const testNormalBehavior = done => {
-				// Given
-				const holdHandler = sinon.spy();
-				const changeHandler = sinon.spy();
-				const releaseHandler = sinon.spy();
-				const finishHandler = sinon.spy();
-				const animationStartHandler = sinon.spy();
-				const animationEndHandler = sinon.spy();
-				this.inst.off().on({
-					"hold": holdHandler,
-					"change": changeHandler,
-					"release": releaseHandler,
-					"finish": finishHandler,
-					"animationStart": animationStartHandler,
-					"animationEnd": animationEndHandler
-				});
+        const self = this.inst;
+        this.preventedFn = function () {
+          expect(self.interruptManager._prevented).to.be.true;
+        };
+        this.notPreventedFn = function () {
+          expect(self.interruptManager._prevented).to.be.false;
+        };
+        this.input = new PanInput(this.el, {
+          inputType: type,
+        });
+        this.inst.connect(["x", "y"], this.input);
+      });
+      afterEach(() => {
+        if (this.inst) {
+          this.inst.destroy();
+          this.inst = null;
+        }
+        if (this.input) {
+          this.input.destroy();
+          this.input = null;
+        }
+        cleanup();
+      });
+      after(() => {
+        // Simulator type should be "touch" type after test complete.
+        // Otherwise this test will affect other simulation test.
+        Simulator.setType("touch");
+      });
+      const testNormalBehavior = (done) => {
+        // Given
+        const holdHandler = sinon.spy();
+        const changeHandler = sinon.spy();
+        const releaseHandler = sinon.spy();
+        const finishHandler = sinon.spy();
+        const animationStartHandler = sinon.spy();
+        const animationEndHandler = sinon.spy();
+        this.inst.off().on({
+          hold: holdHandler,
+          change: changeHandler,
+          release: releaseHandler,
+          finish: finishHandler,
+          animationStart: animationStartHandler,
+          animationEnd: animationEndHandler,
+        });
 
-				// When
-				Simulator.gestures.pan(this.el, {
-					pos: [0, 0],
-					deltaX: 100,
-					deltaY: 100,
-					duration: 1000,
-					easing: "linear"
-				}, () => {
-					// Then
-					// for test custom event
-					setTimeout(() => {
-						expect(holdHandler.calledOnce).to.be.true;
-						expect(changeHandler.called).to.be.true;
-						expect(releaseHandler.calledOnce).to.be.true;
-						expect(finishHandler.calledOnce).to.be.true;
-						expect(animationStartHandler.calledOnce).to.be.true;
-						expect(animationEndHandler.calledOnce).to.be.true;
-						done();
-					}, 1000);
-				});
-			}
-			it("should check normal behavior test after user invokes 'stop' from change event", (done) => {
-				// Given
-				let changeCount = 0;
-				let pos = 0;
-				const changeHandler = sinon.spy(e => {
-					++changeCount;
+        // When
+        Simulator.gestures.pan(
+          this.el,
+          {
+            pos: [0, 0],
+            deltaX: 100,
+            deltaY: 100,
+            duration: 1000,
+            easing: "linear",
+          },
+          () => {
+            // Then
+            // for test custom event
+            setTimeout(() => {
+              expect(holdHandler.calledOnce).to.be.true;
+              expect(changeHandler.called).to.be.true;
+              expect(releaseHandler.calledOnce).to.be.true;
+              expect(finishHandler.calledOnce).to.be.true;
+              expect(animationStartHandler.calledOnce).to.be.true;
+              expect(animationEndHandler.calledOnce).to.be.true;
+              done();
+            }, 1000);
+          }
+        );
+      };
+      it("should check normal behavior test after user invokes 'stop' from change event", (done) => {
+        // Given
+        let changeCount = 0;
+        let pos = 0;
+        const changeHandler = sinon.spy((e) => {
+          ++changeCount;
 
-					if (changeCount === 5) {
-						// current position
-						pos = e.pos;
-						// hold => change * 5 (stop) => finish
-						e.stop();
-					}
-				});
-				const holdHandler = sinon.spy();
-				const releaseHandler = sinon.spy();
-				const finishHandler = sinon.spy();
-				const animationStartHandler = sinon.spy();
-				const animationEndHandler = sinon.spy();
-				this.inst.on({
-					"hold": holdHandler,
-					"change": changeHandler,
-					"release": releaseHandler,
-					"finish": finishHandler,
-					"animationStart": animationStartHandler,
-					"animationEnd": animationEndHandler
-				});
+          if (changeCount === 5) {
+            // current position
+            pos = e.pos;
+            // hold => change * 5 (stop) => finish
+            e.stop();
+          }
+        });
+        const holdHandler = sinon.spy();
+        const releaseHandler = sinon.spy();
+        const finishHandler = sinon.spy();
+        const animationStartHandler = sinon.spy();
+        const animationEndHandler = sinon.spy();
+        this.inst.on({
+          hold: holdHandler,
+          change: changeHandler,
+          release: releaseHandler,
+          finish: finishHandler,
+          animationStart: animationStartHandler,
+          animationEnd: animationEndHandler,
+        });
 
-				// When
-				Simulator.gestures.pan(this.el, {
-					pos: [0, 0],
-					deltaX: 100,
-					deltaY: 100,
-					duration: 1000,
-					easing: "linear"
-				}, () => {
-					// Then
-					setTimeout(() => {
-						// The stopped position is the current position.
-						expect(pos).to.be.deep.equals(this.inst.get());
-						expect(holdHandler.calledOnce).to.be.true;
-						expect(changeCount).to.be.equals(5);
-						expect(changeHandler.callCount).to.be.equals(changeCount);
-						expect(finishHandler.calledOnce).to.be.true;
+        // When
+        Simulator.gestures.pan(
+          this.el,
+          {
+            pos: [0, 0],
+            deltaX: 100,
+            deltaY: 100,
+            duration: 1000,
+            easing: "linear",
+          },
+          () => {
+            // Then
+            setTimeout(() => {
+              // The stopped position is the current position.
+              expect(pos).to.be.deep.equals(this.inst.get());
+              expect(holdHandler.calledOnce).to.be.true;
+              expect(changeCount).to.be.equals(5);
+              expect(changeHandler.callCount).to.be.equals(changeCount);
+              expect(finishHandler.calledOnce).to.be.true;
 
-						// not called events
-						expect(releaseHandler.callCount).to.be.equals(0);
-						expect(animationStartHandler.callCount).to.be.equals(0);
-						expect(animationEndHandler.callCount).to.be.equals(0);
-						testNormalBehavior(done);
-					}, 1000);
-				});
-			});
-			it("should check normal behavior test after user invokes 'stop' from change event(after animationStart)", (done) => {
-				// Given
-				const holdHandler = sinon.spy();
-				let changeCount = 0;
-				let pos = 0;
-				const releaseHandler = sinon.spy();
-				const finishHandler = sinon.spy();
-				const animationStartHandler = sinon.spy();
-				const animationEndHandler = sinon.spy();
-				const changeHandler = sinon.spy(e => {
-					if (animationStartHandler.calledOnce) {
-						++changeCount;
+              // not called events
+              expect(releaseHandler.callCount).to.be.equals(0);
+              expect(animationStartHandler.callCount).to.be.equals(0);
+              expect(animationEndHandler.callCount).to.be.equals(0);
+              testNormalBehavior(done);
+            }, 1000);
+          }
+        );
+      });
+      it("should check normal behavior test after user invokes 'stop' from change event(after animationStart)", (done) => {
+        // Given
+        const holdHandler = sinon.spy();
+        let changeCount = 0;
+        let pos = 0;
+        const releaseHandler = sinon.spy();
+        const finishHandler = sinon.spy();
+        const animationStartHandler = sinon.spy();
+        const animationEndHandler = sinon.spy();
+        const changeHandler = sinon.spy((e) => {
+          if (animationStartHandler.calledOnce) {
+            ++changeCount;
 
-						if (changeCount === 5) {
-							// current position
-							pos = e.pos;
-							// hold => change * 5 (stop) => finish
-							e.stop();
-						}
-					}
-				});
-				this.inst.on({
-					"hold": holdHandler,
-					"change": changeHandler,
-					"release": releaseHandler,
-					"finish": finishHandler,
-					"animationStart": animationStartHandler,
-					"animationEnd": animationEndHandler
-				});
+            if (changeCount === 5) {
+              // current position
+              pos = e.pos;
+              // hold => change * 5 (stop) => finish
+              e.stop();
+            }
+          }
+        });
+        this.inst.on({
+          hold: holdHandler,
+          change: changeHandler,
+          release: releaseHandler,
+          finish: finishHandler,
+          animationStart: animationStartHandler,
+          animationEnd: animationEndHandler,
+        });
 
-				const inst = this.inst;
-				// When
-				Simulator.gestures.pan(this.el, {
-					pos: [0, 0],
-					deltaX: 100,
-					deltaY: 100,
-					duration: 1000,
-					easing: "linear"
-				}, () => {
-					// Then
-					setTimeout(() => {
-						// The stopped position is the current position.
-						expect(pos).to.be.deep.equals(inst.get());
-						expect(holdHandler.called).to.be.true;
-						expect(changeCount).to.be.equals(5);
-						expect(releaseHandler.calledOnce).to.be.true;
-						expect(animationStartHandler.calledOnce).to.be.true;
-						expect(finishHandler.calledOnce).to.be.true;
-						// not called events
-						expect(animationEndHandler.callCount).to.be.equals(0);
-						testNormalBehavior(done);
-					}, 1000);
-				});
-			});
-			it("should check interrupt test when user's action is fast", (done) => {
-				const holdHandler = sinon.spy(this.preventedFn);
-				const changeHandler = sinon.spy(this.preventedFn);
-				const releaseHandler = sinon.spy(this.preventedFn);
-				const finishHandler = sinon.spy(this.notPreventedFn);
-				const animationStartHandler = sinon.spy(this.preventedFn);
-				const animationEndHandler = sinon.spy(this.notPreventedFn);
-				this.inst.on({
-					"hold": holdHandler,
-					"change": changeHandler,
-					"release": releaseHandler,
-					"finish": finishHandler,
-					"animationStart": animationStartHandler,
-					"animationEnd": animationEndHandler
-				});
+        const inst = this.inst;
+        // When
+        Simulator.gestures.pan(
+          this.el,
+          {
+            pos: [0, 0],
+            deltaX: 100,
+            deltaY: 100,
+            duration: 1000,
+            easing: "linear",
+          },
+          () => {
+            // Then
+            setTimeout(() => {
+              // The stopped position is the current position.
+              expect(pos).to.be.deep.equals(inst.get());
+              expect(holdHandler.called).to.be.true;
+              expect(changeCount).to.be.equals(5);
+              expect(releaseHandler.calledOnce).to.be.true;
+              expect(animationStartHandler.calledOnce).to.be.true;
+              expect(finishHandler.calledOnce).to.be.true;
+              // not called events
+              expect(animationEndHandler.callCount).to.be.equals(0);
+              testNormalBehavior(done);
+            }, 1000);
+          }
+        );
+      });
+      it("should check interrupt test when user's action is fast", (done) => {
+        const holdHandler = sinon.spy(this.preventedFn);
+        const changeHandler = sinon.spy(this.preventedFn);
+        const releaseHandler = sinon.spy(this.preventedFn);
+        const finishHandler = sinon.spy(this.notPreventedFn);
+        const animationStartHandler = sinon.spy(this.preventedFn);
+        const animationEndHandler = sinon.spy(this.notPreventedFn);
+        this.inst.on({
+          hold: holdHandler,
+          change: changeHandler,
+          release: releaseHandler,
+          finish: finishHandler,
+          animationStart: animationStartHandler,
+          animationEnd: animationEndHandler,
+        });
 
-				// when
-				Simulator.gestures.pan(this.el, {
-					pos: [0, 0],
-					deltaX: 100,
-					deltaY: 100,
-					duration: 1000,
-					easing: "linear"
-				}, () => {
-					// Then
-					// for test custom event
-					setTimeout(() => {
-						expect(holdHandler.calledOnce).to.be.true;
-						expect(changeHandler.called).to.be.true;
-						expect(releaseHandler.calledOnce).to.be.true;
-						expect(finishHandler.calledOnce).to.be.true;
-						expect(animationStartHandler.calledOnce).to.be.true;
-						expect(animationEndHandler.calledOnce).to.be.true;
-						done();
-					}, 1000);
-				});
-			});
-		});
-		describe(`Axes Custom Event Test(${type})`, function () {
-			beforeEach(() => {
-				if (type.indexOf("pointer") > -1) {
-					Simulator.setType("pointer");
-				} else {
-					Simulator.setType("touch");
-				}
-				this.inst = new Axes({
-					x: {
-						range: [0, 300],
-						bounce: 100
-					},
-					y: {
-						range: [0, 400],
-						bounce: 100
-					}
-				}, {
-					deceleration: 0.001
-				});
-				this.el = sandbox();
-				this.el.innerHTML = `<div id="area"
+        // when
+        Simulator.gestures.pan(
+          this.el,
+          {
+            pos: [0, 0],
+            deltaX: 100,
+            deltaY: 100,
+            duration: 1000,
+            easing: "linear",
+          },
+          () => {
+            // Then
+            // for test custom event
+            setTimeout(() => {
+              expect(holdHandler.calledOnce).to.be.true;
+              expect(changeHandler.called).to.be.true;
+              expect(releaseHandler.calledOnce).to.be.true;
+              expect(finishHandler.calledOnce).to.be.true;
+              expect(animationStartHandler.calledOnce).to.be.true;
+              expect(animationEndHandler.calledOnce).to.be.true;
+              done();
+            }, 1000);
+          }
+        );
+      });
+    });
+    describe(`Axes Custom Event Test(${type})`, function () {
+      beforeEach(() => {
+        if (type.indexOf("pointer") > -1) {
+          Simulator.setType("pointer");
+        } else {
+          Simulator.setType("touch");
+        }
+        this.inst = new Axes(
+          {
+            x: {
+              range: [0, 300],
+              bounce: 100,
+            },
+            y: {
+              range: [0, 400],
+              bounce: 100,
+            },
+          },
+          {
+            deceleration: 0.001,
+          }
+        );
+        this.el = sandbox();
+        this.el.innerHTML = `<div id="area"
         style="position:relative; border:5px solid #444; width:300px; height:400px; color:#aaa; margin:0;box-sizing:content-box; z-index:9;"></div>`;
 
-				this.holdHandler = sinon.spy();
-				this.releaseHandler = sinon.spy();
-				this.finishHandler = sinon.spy();
-				this.animationStartHandler = sinon.spy();
-				this.animationEndHandler = sinon.spy();
+        this.holdHandler = sinon.spy();
+        this.releaseHandler = sinon.spy();
+        this.finishHandler = sinon.spy();
+        this.animationStartHandler = sinon.spy();
+        this.animationEndHandler = sinon.spy();
 
-				this.input = new PanInput(this.el, {
-					inputType: type,
-				});
-				this.inst.on({
-					"hold": this.holdHandler,
-					"release": this.releaseHandler,
-					"finish": this.finishHandler,
-					"animationStart": this.animationStartHandler,
-					"animationEnd": this.animationEndHandler
-				}).connect(["x", "y"], this.input);
-			});
-			afterEach(() => {
-				if (this.inst) {
-					this.inst.destroy();
-					this.inst = null;
-				}
-				if (this.input) {
-					this.input.destroy();
-					this.input = null;
-				}
-				this.holdHandler.resetHistory();
-				this.releaseHandler.resetHistory();
-				this.finishHandler.resetHistory();
-				this.animationStartHandler.resetHistory();
-				this.animationEndHandler.resetHistory();
-				cleanup();
-			});
-			after(() => {
-				// Simulator type should be "touch" type after test complete.
-				// Otherwise this test will affect other simulation test.
-				Simulator.setType("touch");
-			})
-			it("should check slow movement test (no-velocity)", (done) => {
-				// Given
-				const changeHandler = sinon.spy();
-				this.inst.on("change", changeHandler);
+        this.input = new PanInput(this.el, {
+          inputType: type,
+        });
+        this.inst
+          .on({
+            hold: this.holdHandler,
+            release: this.releaseHandler,
+            finish: this.finishHandler,
+            animationStart: this.animationStartHandler,
+            animationEnd: this.animationEndHandler,
+          })
+          .connect(["x", "y"], this.input);
+      });
+      afterEach(() => {
+        if (this.inst) {
+          this.inst.destroy();
+          this.inst = null;
+        }
+        if (this.input) {
+          this.input.destroy();
+          this.input = null;
+        }
+        this.holdHandler.resetHistory();
+        this.releaseHandler.resetHistory();
+        this.finishHandler.resetHistory();
+        this.animationStartHandler.resetHistory();
+        this.animationEndHandler.resetHistory();
+        cleanup();
+      });
+      after(() => {
+        // Simulator type should be "touch" type after test complete.
+        // Otherwise this test will affect other simulation test.
+        Simulator.setType("touch");
+      });
+      it("should check slow movement test (no-velocity)", (done) => {
+        // Given
+        const changeHandler = sinon.spy();
+        this.inst.on("change", changeHandler);
 
-				// When
-				Simulator.gestures.pan(this.el, {
-					pos: [30, 30],
-					deltaX: 10,
-					deltaY: 10,
-					duration: 3000,
-					easing: "linear"
-				}, () => {
-					// Then
-					const holdEvent = this.holdHandler.getCall(0).args[0];
-					expect(this.holdHandler.calledOnce).to.be.true;
-					expect(holdEvent.pos.x).to.be.equal(0);
-					expect(holdEvent.pos.y).to.be.equal(0);
-					expect(holdEvent.inputEvent.isFirst).to.be.true;
-					expect(holdEvent.isTrusted).to.be.true;
-					expect(changeHandler.called).to.be.true;
-					for (let i = 0, len = changeHandler.callCount; i < len; i++) {
-						const changeEvent = changeHandler.getCall(i).args[0];
-						expect(changeEvent.holding).to.be.true;
-						expect(changeEvent.input).to.be.equal(this.input);
-						expect(changeEvent.isTrusted).to.be.true;
-						expect(changeEvent.inputEvent).to.be.not.equal(null);
-					}
-					const releaseEvent = this.releaseHandler.getCall(0).args[0];
-					expect(this.releaseHandler.calledOnce).to.be.true;
-					expect(releaseEvent.inputEvent.isFinal).to.be.true;
-					expect(releaseEvent.input).to.be.equal(this.input);
-					expect(releaseEvent.isTrusted).to.be.true;
-					expect(this.inst.get()).to.be.eql({ x: 10, y: 10 });
+        // When
+        Simulator.gestures.pan(
+          this.el,
+          {
+            pos: [30, 30],
+            deltaX: 10,
+            deltaY: 10,
+            duration: 3000,
+            easing: "linear",
+          },
+          () => {
+            // Then
+            const holdEvent = this.holdHandler.getCall(0).args[0];
+            expect(this.holdHandler.calledOnce).to.be.true;
+            expect(holdEvent.pos.x).to.be.equal(0);
+            expect(holdEvent.pos.y).to.be.equal(0);
+            expect(holdEvent.inputEvent.isFirst).to.be.true;
+            expect(holdEvent.isTrusted).to.be.true;
+            expect(changeHandler.called).to.be.true;
+            for (let i = 0, len = changeHandler.callCount; i < len; i++) {
+              const changeEvent = changeHandler.getCall(i).args[0];
+              expect(changeEvent.holding).to.be.true;
+              expect(changeEvent.input).to.be.equal(this.input);
+              expect(changeEvent.isTrusted).to.be.true;
+              expect(changeEvent.inputEvent).to.be.not.equal(null);
+            }
+            const releaseEvent = this.releaseHandler.getCall(0).args[0];
+            expect(this.releaseHandler.calledOnce).to.be.true;
+            expect(releaseEvent.inputEvent.isFinal).to.be.true;
+            expect(releaseEvent.input).to.be.equal(this.input);
+            expect(releaseEvent.isTrusted).to.be.true;
+            expect(this.inst.get()).to.be.eql({ x: 10, y: 10 });
 
-					const finishEvent = this.finishHandler.getCall(0).args[0];
-					expect(this.finishHandler.calledOnce).to.be.true;
-					expect(finishEvent.isTrusted).to.be.true;
+            const finishEvent = this.finishHandler.getCall(0).args[0];
+            expect(this.finishHandler.calledOnce).to.be.true;
+            expect(finishEvent.isTrusted).to.be.true;
 
-					expect(this.animationStartHandler.called).to.be.false;
-					expect(this.animationEndHandler.called).to.be.false;
-					done();
-				});
-			});
-			it("should check slow movement test (no-velocity), release outside", (done) => {
-				// Given
-				this.inst.on("change", (e) => {
-					if (this.animationStartHandler.called) {
-						expect(e.holding).to.be.false;
-						expect(this.inst.am.getEventInfo().input).to.be.equal(e.input);
-					} else {
-						expect(e.holding).to.be.true;
-					}
-					expect(e.input).to.be.equal(this.input);
-					expect(e.inputEvent).to.be.not.equal(null);
-					expect(e.isTrusted).to.be.true;
-				});
-				this.inst.options.maximumDuration = 200;
+            expect(this.animationStartHandler.called).to.be.false;
+            expect(this.animationEndHandler.called).to.be.false;
+            done();
+          }
+        );
+      });
+      it("should check slow movement test (no-velocity), release outside", (done) => {
+        // Given
+        this.inst.on("change", (e) => {
+          if (this.animationStartHandler.called) {
+            expect(e.holding).to.be.false;
+            expect(this.inst.animationManager.getEventInfo().input).to.be.equal(
+              e.input
+            );
+          } else {
+            expect(e.holding).to.be.true;
+          }
+          expect(e.input).to.be.equal(this.input);
+          expect(e.inputEvent).to.be.not.equal(null);
+          expect(e.isTrusted).to.be.true;
+        });
+        this.inst.options.maximumDuration = 200;
 
-				// When
-				Simulator.gestures.pan(this.el, {
-					pos: [30, 30],
-					deltaX: -50,
-					deltaY: 10,
-					duration: 3000,
-					easing: "linear"
-				}, () => {
-					// Then
-					// for test animation event
-					setTimeout(() => {
-						const holdEvent = this.holdHandler.getCall(0).args[0];
-						expect(this.holdHandler.calledOnce).to.be.true;
-						expect(holdEvent.pos.x).to.be.equal(0);
-						expect(holdEvent.pos.y).to.be.equal(0);
-						expect(holdEvent.inputEvent.isFirst).to.be.true;
-						expect(holdEvent.input).to.be.equal(this.input);
-						expect(holdEvent.isTrusted).to.be.true;
-						const releaseEvent = this.releaseHandler.getCall(0).args[0];
-						expect(this.releaseHandler.calledOnce).to.be.true;
-						expect(releaseEvent.inputEvent.isFinal).to.be.true;
-						expect(releaseEvent.input).to.be.equal(this.input);
-						expect(releaseEvent.isTrusted).to.be.true;
+        // When
+        Simulator.gestures.pan(
+          this.el,
+          {
+            pos: [30, 30],
+            deltaX: -50,
+            deltaY: 10,
+            duration: 3000,
+            easing: "linear",
+          },
+          () => {
+            // Then
+            // for test animation event
+            setTimeout(() => {
+              const holdEvent = this.holdHandler.getCall(0).args[0];
+              expect(this.holdHandler.calledOnce).to.be.true;
+              expect(holdEvent.pos.x).to.be.equal(0);
+              expect(holdEvent.pos.y).to.be.equal(0);
+              expect(holdEvent.inputEvent.isFirst).to.be.true;
+              expect(holdEvent.input).to.be.equal(this.input);
+              expect(holdEvent.isTrusted).to.be.true;
+              const releaseEvent = this.releaseHandler.getCall(0).args[0];
+              expect(this.releaseHandler.calledOnce).to.be.true;
+              expect(releaseEvent.inputEvent.isFinal).to.be.true;
+              expect(releaseEvent.input).to.be.equal(this.input);
+              expect(releaseEvent.isTrusted).to.be.true;
 
-						const result = this.inst.get();
-						expect(result.x).to.be.equal(0);
-						expect(result.y).to.be.equal(10);
-						expect(releaseEvent.duration).to.be.equal(0);
-						expect(releaseEvent.depaPos).to.deep.equal(releaseEvent.destPos);
-						const animationStartEvent = this.animationStartHandler.getCall(0).args[0];
-						expect(this.animationStartHandler.called).to.be.true;
-						expect(animationStartEvent.isTrusted).to.be.true;
-						const animationEndEvent = this.animationEndHandler.getCall(0).args[0];
-						expect(animationEndEvent.isTrusted).to.be.true;
+              const result = this.inst.get();
+              expect(result.x).to.be.equal(0);
+              expect(result.y).to.be.equal(10);
+              expect(releaseEvent.duration).to.be.equal(0);
+              expect(releaseEvent.depaPos).to.deep.equal(releaseEvent.destPos);
+              const animationStartEvent =
+                this.animationStartHandler.getCall(0).args[0];
+              expect(this.animationStartHandler.called).to.be.true;
+              expect(animationStartEvent.isTrusted).to.be.true;
+              const animationEndEvent =
+                this.animationEndHandler.getCall(0).args[0];
+              expect(animationEndEvent.isTrusted).to.be.true;
 
-						const finishEvent = this.finishHandler.getCall(0).args[0];
-						expect(this.finishHandler.called).to.be.true;
-						expect(finishEvent.isTrusted).to.be.true;
-						done();
-					}, 500);
-				});
-			});
+              const finishEvent = this.finishHandler.getCall(0).args[0];
+              expect(this.finishHandler.called).to.be.true;
+              expect(finishEvent.isTrusted).to.be.true;
+              done();
+            }, 500);
+          }
+        );
+      });
 
-			it("should check fast movement test (velocity)", (done) => {
-				// Given
-				this.inst.on("change", (e) => {
-					if (this.animationStartHandler.called) {
-						expect(e.holding).to.be.false;
-						expect(this.inst.am.getEventInfo().input).to.be.equal(e.input);
-					} else {
-						expect(e.holding).to.be.true;
-					}
-					expect(e.input).to.be.equal(this.input);
-					expect(e.inputEvent).to.be.not.equal(null);
-					expect(e.isTrusted).to.be.true;
-				});
+      it("should check fast movement test (velocity)", (done) => {
+        // Given
+        this.inst.on("change", (e) => {
+          if (this.animationStartHandler.called) {
+            expect(e.holding).to.be.false;
+            expect(this.inst.animationManager.getEventInfo().input).to.be.equal(
+              e.input
+            );
+          } else {
+            expect(e.holding).to.be.true;
+          }
+          expect(e.input).to.be.equal(this.input);
+          expect(e.inputEvent).to.be.not.equal(null);
+          expect(e.isTrusted).to.be.true;
+        });
 
-				// When
-				Simulator.gestures.pan(this.el, {
-					pos: [0, 0],
-					deltaX: 100,
-					deltaY: 100,
-					duration: 500,
-					easing: "linear"
-				}, () => {
-					// Then
-					// for test animation event
-					setTimeout(() => {
-						expect(this.holdHandler.calledOnce).to.be.true;
-						const releaseEvent = this.releaseHandler.getCall(0).args[0];
-						expect(this.releaseHandler.calledOnce).to.be.true;
-						expect(this.animationStartHandler.calledOnce).to.be.true;
-						expect(this.animationEndHandler.calledOnce).to.be.true;
-						expect(this.finishHandler.calledOnce).to.be.true;
-						expect(releaseEvent.duration).to.not.equal(0);
-						expect(releaseEvent.depaPos).to.not.equal(releaseEvent.destPos);
-						done();
-					}, 2000);
-				});
-			});
-			it("should check movement test when stop method was called in 'animationStart' event", (done) => {
-				// Given
-				const holdHandler = sinon.spy();
-				const changeHandler = sinon.spy(function (e) {
-					if (animationStartHandler.called) {
-						expect(e.holding).to.be.false;
-					} else {
-						expect(e.holding).to.be.true;
-					}
-				});
-				const releaseHandler = sinon.spy();
-				const finishHandler = sinon.spy();
-				const animationStartHandler = sinon.spy(e => {
-					e.stop();
-					setTimeout(function () {
-						e.done();
-					}, e.duration);
-				});
-				const animationEndHandler = sinon.spy(this.notPreventedFn);
-				this.inst.on({
-					"hold": holdHandler,
-					"change": changeHandler,
-					"release": releaseHandler,
-					"finish": finishHandler,
-					"animationStart": animationStartHandler,
-					"animationEnd": animationEndHandler
-				});
+        // When
+        Simulator.gestures.pan(
+          this.el,
+          {
+            pos: [0, 0],
+            deltaX: 100,
+            deltaY: 100,
+            duration: 500,
+            easing: "linear",
+          },
+          () => {
+            // Then
+            // for test animation event
+            setTimeout(() => {
+              expect(this.holdHandler.calledOnce).to.be.true;
+              const releaseEvent = this.releaseHandler.getCall(0).args[0];
+              expect(this.releaseHandler.calledOnce).to.be.true;
+              expect(this.animationStartHandler.calledOnce).to.be.true;
+              expect(this.animationEndHandler.calledOnce).to.be.true;
+              expect(this.finishHandler.calledOnce).to.be.true;
+              expect(releaseEvent.duration).to.not.equal(0);
+              expect(releaseEvent.depaPos).to.not.equal(releaseEvent.destPos);
+              done();
+            }, 2000);
+          }
+        );
+      });
+      it("should check movement test when stop method was called in 'animationStart' event", (done) => {
+        // Given
+        const holdHandler = sinon.spy();
+        const changeHandler = sinon.spy(function (e) {
+          if (animationStartHandler.called) {
+            expect(e.holding).to.be.false;
+          } else {
+            expect(e.holding).to.be.true;
+          }
+        });
+        const releaseHandler = sinon.spy();
+        const finishHandler = sinon.spy();
+        const animationStartHandler = sinon.spy((e) => {
+          e.stop();
+          setTimeout(function () {
+            e.done();
+          }, e.duration);
+        });
+        const animationEndHandler = sinon.spy(this.notPreventedFn);
+        this.inst.on({
+          hold: holdHandler,
+          change: changeHandler,
+          release: releaseHandler,
+          finish: finishHandler,
+          animationStart: animationStartHandler,
+          animationEnd: animationEndHandler,
+        });
 
-				// When
-				Simulator.gestures.pan(this.el, {
-					pos: [30, 30],
-					deltaX: 100,
-					deltaY: 100,
-					duration: 500,
-					easing: "linear"
-				}, () => {
-					// Then
-					// for test custom event
-					setTimeout(() => {
-						expect(holdHandler.calledOnce).to.be.true;
-						expect(releaseHandler.calledOnce).to.be.true;
-						expect(animationStartHandler.calledOnce).to.be.true;
-						expect(animationEndHandler.calledOnce).to.be.true;
-						expect(finishHandler.calledOnce).to.be.true;
-						done();
-					}, 1000);
-				});
-			});
+        // When
+        Simulator.gestures.pan(
+          this.el,
+          {
+            pos: [30, 30],
+            deltaX: 100,
+            deltaY: 100,
+            duration: 500,
+            easing: "linear",
+          },
+          () => {
+            // Then
+            // for test custom event
+            setTimeout(() => {
+              expect(holdHandler.calledOnce).to.be.true;
+              expect(releaseHandler.calledOnce).to.be.true;
+              expect(animationStartHandler.calledOnce).to.be.true;
+              expect(animationEndHandler.calledOnce).to.be.true;
+              expect(finishHandler.calledOnce).to.be.true;
+              done();
+            }, 1000);
+          }
+        );
+      });
 
-			it("should fire animationEnd event with isTrusted-true flag if grab while animating.", (done) => {
-				// Given
-				// When
-				let destPos;
+      it("should fire animationEnd event with isTrusted-true flag if grab while animating.", (done) => {
+        // Given
+        // When
+        let destPos;
 
-				Simulator.gestures.pan(this.el, {
-					pos: [0, 0],
-					deltaX: 300,
-					deltaY: 50,
-					duration: 100,
-					easing: "linear"
-				});
+        Simulator.gestures.pan(this.el, {
+          pos: [0, 0],
+          deltaX: 300,
+          deltaY: 50,
+          duration: 100,
+          easing: "linear",
+        });
 
-				// grab while animating
-				this.inst.on("animationStart", (e) => {
-					destPos = e.destPos;
-					Simulator.gestures.tap(this.el);
-				});
+        // grab while animating
+        this.inst.on("animationStart", (e) => {
+          destPos = e.destPos;
+          Simulator.gestures.tap(this.el);
+        });
 
-				// Then
-				this.inst.on("animationEnd", (e) => {
-					setTimeout(() => {
-						let endPos = this.inst.get();
+        // Then
+        this.inst.on("animationEnd", (e) => {
+          setTimeout(() => {
+            let endPos = this.inst.get();
 
-						expect(e.isTrusted).to.be.true;
-						expect(endPos.x !== destPos.x || endPos.y !== destPos.y).to.be.true;
-						done();
-					});
-				})
-			});
-		});
-	});
+            expect(e.isTrusted).to.be.true;
+            expect(endPos.x !== destPos.x || endPos.y !== destPos.y).to.be.true;
+            done();
+          });
+        });
+      });
+    });
+  });
 
-	describe("round final value of animation automatically by value range and dest pos", () => {
-		[
-			{ range: [0.12345, 100], destPos: 50.1234 }, // max decimal place at range[0]
-			{ range: [0, 100.123456789], destPos: 50.1234 }, // max decimal place at range[1]
-			{ range: [0, 100], destPos: 50.1234 }, // max decimal place at dest pos,
-			{ range: [0, 100], destPos: 50 }, // no decimal
-			{ range: [0, 1000], destPos: 445.17079889807155 }, // number to resolve flicking test failure.
-			{ range: [0, 1000], destPos: 240.79930795847713 }, // comparison value that works correctly.
-		].forEach((val => {
-			it(`should round final value of animation by max decimal place(${val.range[0]}, ${val.range[1]}, ${val.destPos})`, async () => {
-				this.inst = new Axes({
-					x: {
-						range: val.range
-					}
-				});
+  describe("round final value of animation automatically by value range and dest pos", () => {
+    [
+      { range: [0.12345, 100], destPos: 50.1234 }, // max decimal place at range[0]
+      { range: [0, 100.123456789], destPos: 50.1234 }, // max decimal place at range[1]
+      { range: [0, 100], destPos: 50.1234 }, // max decimal place at dest pos,
+      { range: [0, 100], destPos: 50 }, // no decimal
+      { range: [0, 1000], destPos: 445.17079889807155 }, // number to resolve flicking test failure.
+      { range: [0, 1000], destPos: 240.79930795847713 }, // comparison value that works correctly.
+    ].forEach((val) => {
+      it(`should round final value of animation by max decimal place(${val.range[0]}, ${val.range[1]}, ${val.destPos})`, async () => {
+        this.inst = new Axes({
+          x: {
+            range: val.range,
+          },
+        });
 
-				this.inst.setTo({ x: val.destPos }, 100);
-				await new Promise(res => this.inst.on("finish", res));
+        this.inst.setTo({ x: val.destPos }, 100);
+        await new Promise((res) => this.inst.on("finish", res));
 
-				expect(this.inst.get().x).to.be.equal(val.destPos);
-			});
-		}));
-	})
+        expect(this.inst.get().x).to.be.equal(val.destPos);
+      });
+    });
+  });
 
-	describe("round option", () => {
-		[100, 10, 1, 0.1, 0.01, 0.001, 0.0001, 0.00001].forEach(round => {
-			it(`should round value by option value of 1 unit (${round})`, async () => {
-				// Given, When
-				const dividables = await checkAnimatedValueIsRound(round);
+  describe("round option", () => {
+    [100, 10, 1, 0.1, 0.01, 0.001, 0.0001, 0.00001].forEach((round) => {
+      it(`should round value by option value of 1 unit (${round})`, async () => {
+        // Given, When
+        const dividables = await checkAnimatedValueIsRound(round);
 
-				// Then
-				const allDividable = dividables.every(val => val);
-				expect(allDividable).to.be.equal(true);
-			});
-		});
+        // Then
+        const allDividable = dividables.every((val) => val);
+        expect(allDividable).to.be.equal(true);
+      });
+    });
 
-		[10, 5, 0.05, 0.002, 0.0005].forEach(round => {
-			it(`should round value by option value of dividable unit (${round})`, async () => {
-				// Given, When
-				const dividables = await checkAnimatedValueIsRound(round);
+    [10, 5, 0.05, 0.002, 0.0005].forEach((round) => {
+      it(`should round value by option value of dividable unit (${round})`, async () => {
+        // Given, When
+        const dividables = await checkAnimatedValueIsRound(round);
 
-				// Then
-				const allDividable = dividables.every(val => val);
-				expect(allDividable).to.be.equal(true);
-			});
-		});
+        // Then
+        const allDividable = dividables.every((val) => val);
+        expect(allDividable).to.be.equal(true);
+      });
+    });
 
-		[3, 7, 11, 0.03, 0.007].forEach(round => {
-			it(`should round value by option value of undividable unit (${round})`, async () => {
-				// Given, When
-				const dividables = await checkAnimatedValueIsRound(round);
+    [3, 7, 11, 0.03, 0.007].forEach((round) => {
+      it(`should round value by option value of undividable unit (${round})`, async () => {
+        // Given, When
+        const dividables = await checkAnimatedValueIsRound(round);
 
-				// Then
-				const allDividable = dividables.every(val => val);
-				expect(allDividable).to.be.equal(true);
-			});
-		});
+        // Then
+        const allDividable = dividables.every((val) => val);
+        expect(allDividable).to.be.equal(true);
+      });
+    });
 
-		/**
-		 * I found delta is zero although delta is not zero
-		 * when 'round' is specified
-		 */
-		it("should fire change event with changed value / delta although round is specified", done => {
-			// Given
-			let result = [];
-			let delta = [];
-			const inst = new Axes({
-				x: {
-					range: [0, 200],
-				}
-			}, { round: 1 });
+    /**
+     * I found delta is zero although delta is not zero
+     * when 'round' is specified
+     */
+    it("should fire change event with changed value / delta although round is specified", (done) => {
+      // Given
+      let result = [];
+      let delta = [];
+      const inst = new Axes(
+        {
+          x: {
+            range: [0, 200],
+          },
+        },
+        { round: 1 }
+      );
 
-			inst.on("change", e => {
-				result.push(e.pos.x);
-				delta.push(e.delta.x);
-			});
-			// When
-			const expectPos = [30, 60, 90];
+      inst.on("change", (e) => {
+        result.push(e.pos.x);
+        delta.push(e.delta.x);
+      });
+      // When
+      const expectPos = [30, 60, 90];
 
-			expectPos.forEach(v => inst.setBy({ x: 30 }));
+      expectPos.forEach((v) => inst.setBy({ x: 30 }));
 
-			// Then
-			setTimeout(() => {
-				expect(result.length).to.be.equal(expectPos.length);
-				delta.forEach(v => expect(v).to.be.equal(30));
-				result.forEach((v, i) => expect(v).to.be.equal(expectPos[i]));
-				done();
-			}, 100);
+      // Then
+      setTimeout(() => {
+        expect(result.length).to.be.equal(expectPos.length);
+        delta.forEach((v) => expect(v).to.be.equal(30));
+        result.forEach((v, i) => expect(v).to.be.equal(expectPos[i]));
+        done();
+      }, 100);
+    });
 
-		});
+    function isDividable(dividend, divisor) {
+      // Round 'dividend / divsior' because it may has decimal error.
+      const result = roundNumber(dividend / divisor, 0.000001);
+      // Decimal place should be 0
+      return getDecimalPlace(result) === 0;
+    }
 
-		function isDividable(dividend, divisor) {
-			// Round 'dividend / divsior' because it may has decimal error.
-			const result = roundNumber(dividend / divisor, 0.000001);
-			// Decimal place should be 0
-			return getDecimalPlace(result) === 0;
-		}
+    async function checkAnimatedValueIsRound(round) {
+      // Given
+      let dividables = [];
+      const inst = new Axes(
+        {
+          x: {
+            range: [0, 200],
+          },
+        },
+        { round }
+      ).on({
+        animationStart: (e) => {
+          dividables.push(isDividable(e.destPos.x, round));
+        },
+        change: (e) => {
+          dividables.push(isDividable(e.pos.x, round));
+        },
+        finish: () => {
+          dividables.push(isDividable(inst.get().x, round));
+        },
+      });
 
-		async function checkAnimatedValueIsRound(round) {
-			// Given
-			let dividables = [];
-			const inst = new Axes({
-				x: {
-					range: [0, 200],
-				}
-			}, { round }).on({
-				"animationStart": (e) => {
-					dividables.push(isDividable(e.destPos.x, round));
-				},
-				"change": (e) => {
-					dividables.push(isDividable(e.pos.x, round));
-				},
-				"finish": () => {
-					dividables.push(isDividable(inst.get().x, round));
-				}
-			})
+      // When
+      inst.setTo({ x: 100 }, 100);
 
-			// When
-			inst.setTo({ x: 100 }, 100);
+      await new Promise((res) => setTimeout(res, 150));
+      inst.destroy();
 
-			await new Promise(res => setTimeout(res, 150));
-			inst.destroy();
-
-			return dividables;
-		}
-	});
+      return dividables;
+    }
+  });
 });

--- a/test/unit/AxisManager.spec.js
+++ b/test/unit/AxisManager.spec.js
@@ -1,48 +1,46 @@
-import {AxisManager} from "../../src/AxisManager";
+import { AxisManager } from "../../src/AxisManager";
 
-
-describe("AxisManager", function() {
-  describe("instance method", function() {
+describe("AxisManager", function () {
+  describe("instance method", function () {
     beforeEach(() => {
-      this.inst = new AxisManager( {
+      this.inst = new AxisManager({
         x: {
           range: [0, 100],
           bounce: [50, 50],
-          circular: false
+          circular: false,
         },
         y: {
           range: [0, 200],
           bounce: [0, 0],
-          circular: false
+          circular: false,
         },
         z: {
           range: [-100, 200],
           bounce: [50, 0],
-          circular: true
-        }
+          circular: true,
+        },
       });
     });
-    afterEach(() => {
-    });
-    
+    afterEach(() => {});
+
     it("should check 'moveTo' method", () => {
       // Given
       // When (all)
       let orgPos = this.inst.get();
-      let moveTo = {x: 10, y: 20, z: 30};
+      let moveTo = { x: 10, y: 20, z: 30 };
       let moved = this.inst.moveTo(moveTo);
-      
+
       // Then
       expect(moved.pos).to.be.eql(moveTo);
       expect(moved.pos).to.be.not.equal(moveTo);
       expect(moved.delta).to.be.eql({
         x: 10,
         y: 20,
-        z: 130
+        z: 130,
       });
 
-      // When (single) 
-      moveTo = {x: 30};
+      // When (single)
+      moveTo = { x: 30 };
       moved = this.inst.moveTo(moveTo);
 
       // Then
@@ -52,11 +50,11 @@ describe("AxisManager", function() {
       expect(moved.delta).to.be.eql({
         x: 20,
         y: 0,
-        z: 0
+        z: 0,
       });
 
       // When (not included)
-      moveTo = {notX: 30};
+      moveTo = { notX: 30 };
       moved = this.inst.moveTo(moveTo);
 
       // Then
@@ -67,7 +65,7 @@ describe("AxisManager", function() {
       expect(moved.delta).to.be.eql({
         x: 0,
         y: 0,
-        z: 0
+        z: 0,
       });
     });
 
@@ -76,15 +74,15 @@ describe("AxisManager", function() {
       // When
 
       // Then
-      expect(this.inst.get()).to.be.eql({x: 0, y: 0, z: -100});
+      expect(this.inst.get()).to.be.eql({ x: 0, y: 0, z: -100 });
 
       // When
-      this.inst.moveTo({x: 20, y: 40});
+      this.inst.moveTo({ x: 20, y: 40 });
 
       // Then
-      expect(this.inst.get(["x"])).to.be.eql({x : 20});
-      expect(this.inst.get(["y"])).to.be.eql({y : 40});
-      expect(this.inst.get(["z"])).to.be.eql({z : -100});
+      expect(this.inst.get(["x"])).to.be.eql({ x: 20 });
+      expect(this.inst.get(["y"])).to.be.eql({ y: 40 });
+      expect(this.inst.get(["z"])).to.be.eql({ z: -100 });
       expect(this.inst.get(["notX"])).to.be.eql({});
 
       // When (check reference)
@@ -96,73 +94,82 @@ describe("AxisManager", function() {
       expect(firstGet).to.be.not.equal(secondGet);
     });
 
-    it("should check 'every' high-order method", () => {  
+    it("should check 'every' high-order method", () => {
       // Given
       let orgPos = this.inst.get();
-      expect(orgPos).to.be.eql({x: 0, y: 0, z: -100});
+      expect(orgPos).to.be.eql({ x: 0, y: 0, z: -100 });
 
       // When
-      this.inst.moveTo({x: 20, y: 0});
-      
+      this.inst.moveTo({ x: 20, y: 0 });
+
       // Then
-      expect(this.inst.every(this.inst.get(), (v, opt, k) => v !== orgPos[k])).to.be.false;
+      expect(this.inst.every(this.inst.get(), (v, opt, k) => v !== orgPos[k]))
+        .to.be.false;
 
       // When
-      this.inst.moveTo({x: 20, y: 30, z: 0});
+      this.inst.moveTo({ x: 20, y: 30, z: 0 });
 
       // Then
-      expect(this.inst.every(this.inst.get(), (v, opt, k) => v !== orgPos[k])).to.be.true;
+      expect(this.inst.every(this.inst.get(), (v, opt, k) => v !== orgPos[k]))
+        .to.be.true;
     });
 
-
-    it("should check 'filter' high-order method", () => {  
+    it("should check 'filter' high-order method", () => {
       // Given
       let orgPos = this.inst.get();
-      expect(orgPos).to.be.eql({x: 0, y: 0, z: -100});
+      expect(orgPos).to.be.eql({ x: 0, y: 0, z: -100 });
 
       // When
-      this.inst.moveTo({x: 20, y: 0});
-      
+      this.inst.moveTo({ x: 20, y: 0 });
+
       // Then
-      expect(this.inst.filter(this.inst.get(), (v, opt, k) => v !== orgPos[k])).to.be.eql({x:20});
+      expect(
+        this.inst.filter(this.inst.get(), (v, opt, k) => v !== orgPos[k])
+      ).to.be.eql({ x: 20 });
 
       // When
-      this.inst.moveTo({x: 20, y: 30, z: 0});
+      this.inst.moveTo({ x: 20, y: 30, z: 0 });
 
       // Then
-      expect(this.inst.filter(this.inst.get(), (v, opt, k) => v !== orgPos[k])).to.be.eql({x:20, y:30, z:0});
+      expect(
+        this.inst.filter(this.inst.get(), (v, opt, k) => v !== orgPos[k])
+      ).to.be.eql({ x: 20, y: 30, z: 0 });
     });
 
-    it("should check 'map' high-order method", () => {  
+    it("should check 'map' high-order method", () => {
       // Given
       let orgPos = this.inst.get();
-      expect(orgPos).to.be.eql({x: 0, y: 0, z: -100});
+      expect(orgPos).to.be.eql({ x: 0, y: 0, z: -100 });
 
       // When
-      this.inst.moveTo({x: 20, y: 0});
-      
+      this.inst.moveTo({ x: 20, y: 0 });
+
       // Then
-      expect(this.inst.map(this.inst.get(), (v) => v + 20)).to.be.eql({x:40, y:20, z: -80});
-    });  
+      expect(this.inst.map(this.inst.get(), (v) => v + 20)).to.be.eql({
+        x: 40,
+        y: 20,
+        z: -80,
+      });
+    });
 
-    it("should check 'isOutside' method", () => {  
+    it("should check 'isOutside' method", () => {
       // Given
       // When
       let orgPos = this.inst.get();
-      expect(orgPos).to.be.eql({x: 0, y: 0, z: -100});
+      expect(orgPos).to.be.eql({ x: 0, y: 0, z: -100 });
 
       // Then
       expect(this.inst.isOutside()).to.be.false;
 
       // When
-      this.inst.moveTo({x: -50});
+      this.inst.moveTo({ x: -50 });
 
       // Then
       expect(this.inst.isOutside()).to.be.true;
       expect(this.inst.isOutside(["y", "z"])).to.be.false;
-      
+
       // When
-      this.inst.moveTo({x: 50});
+      this.inst.moveTo({ x: 50 });
 
       // Then
       expect(this.inst.isOutside()).to.be.false;

--- a/test/unit/Coordinate.spec.js
+++ b/test/unit/Coordinate.spec.js
@@ -1,139 +1,204 @@
 import * as Coordinate from "../../src/Coordinate";
 
+describe("Coordinate", function () {
+  describe("getInsidePosition", function () {
+    it("should return inner position", () => {
+      // Given
+      // When
+      let range = [0, 100];
+      let circular = [false, false];
 
-describe("Coordinate", function() {
-  describe("getInsidePosition", function() {
-      it("should return inner position", () => {
-          // Given
-          // When
-          let range = [0, 100];
-          let circular = [false, false];
+      // Then
+      expect(Coordinate.getInsidePosition(0, range, circular)).to.be.equal(0);
+      expect(Coordinate.getInsidePosition(-1, range, circular)).to.be.equal(0);
+      expect(Coordinate.getInsidePosition(50, range, circular)).to.be.equal(50);
+      expect(Coordinate.getInsidePosition(101, range, circular)).to.be.equal(
+        100
+      );
 
-          // Then
-          expect(Coordinate.getInsidePosition(0, range, circular)).to.be.equal(0);
-          expect(Coordinate.getInsidePosition(-1, range, circular)).to.be.equal(0);
-          expect(Coordinate.getInsidePosition(50, range, circular)).to.be.equal(50);
-          expect(Coordinate.getInsidePosition(101, range, circular)).to.be.equal(100);
-          
-          // When
-          circular = [true, true];
+      // When
+      circular = [true, true];
 
-          // Then
-          expect(Coordinate.getInsidePosition(0, range, circular)).to.be.equal(0);
-          expect(Coordinate.getInsidePosition(-1, range, circular)).to.be.equal(0);
-          expect(Coordinate.getInsidePosition(40, range, circular)).to.be.equal(40);
-          expect(Coordinate.getInsidePosition(140, range, circular)).to.be.equal(100);
-      });
+      // Then
+      expect(Coordinate.getInsidePosition(0, range, circular)).to.be.equal(0);
+      expect(Coordinate.getInsidePosition(-1, range, circular)).to.be.equal(0);
+      expect(Coordinate.getInsidePosition(40, range, circular)).to.be.equal(40);
+      expect(Coordinate.getInsidePosition(140, range, circular)).to.be.equal(
+        100
+      );
+    });
 
-      it("should return inner position with bounce", () => {
-          // Given
-          // When
-          let range = [0, 100];
-          let circular = [false, false];
-          let bounce = [50, 100];
+    it("should return inner position with bounce", () => {
+      // Given
+      // When
+      let range = [0, 100];
+      let circular = [false, false];
+      let bounce = [50, 100];
 
-          // Then
-          expect(Coordinate.getInsidePosition(0, range, circular, bounce)).to.be.equal(0);
-          expect(Coordinate.getInsidePosition(-1, range, circular, bounce)).to.be.equal(-1);
-          expect(Coordinate.getInsidePosition(-50, range, circular, bounce)).to.be.equal(-50);
-          expect(Coordinate.getInsidePosition(-51, range, circular, bounce)).to.be.equal(-50);
-          expect(Coordinate.getInsidePosition(50, range, circular, bounce)).to.be.equal(50);
-          expect(Coordinate.getInsidePosition(101, range, circular, bounce)).to.be.equal(101);
-          expect(Coordinate.getInsidePosition(200, range, circular, bounce)).to.be.equal(200);
-          expect(Coordinate.getInsidePosition(201, range, circular, bounce)).to.be.equal(200);
-          
-          // When
-          circular = [true, true];
+      // Then
+      expect(
+        Coordinate.getInsidePosition(0, range, circular, bounce)
+      ).to.be.equal(0);
+      expect(
+        Coordinate.getInsidePosition(-1, range, circular, bounce)
+      ).to.be.equal(-1);
+      expect(
+        Coordinate.getInsidePosition(-50, range, circular, bounce)
+      ).to.be.equal(-50);
+      expect(
+        Coordinate.getInsidePosition(-51, range, circular, bounce)
+      ).to.be.equal(-50);
+      expect(
+        Coordinate.getInsidePosition(50, range, circular, bounce)
+      ).to.be.equal(50);
+      expect(
+        Coordinate.getInsidePosition(101, range, circular, bounce)
+      ).to.be.equal(101);
+      expect(
+        Coordinate.getInsidePosition(200, range, circular, bounce)
+      ).to.be.equal(200);
+      expect(
+        Coordinate.getInsidePosition(201, range, circular, bounce)
+      ).to.be.equal(200);
 
-          // Then
-          expect(Coordinate.getInsidePosition(0, range, circular, bounce)).to.be.equal(0);
-          expect(Coordinate.getInsidePosition(-1, range, circular, bounce)).to.be.equal(0);
-          expect(Coordinate.getInsidePosition(-50, range, circular, bounce)).to.be.equal(0);
-          expect(Coordinate.getInsidePosition(-51, range, circular, bounce)).to.be.equal(0);
-          expect(Coordinate.getInsidePosition(50, range, circular, bounce)).to.be.equal(50);
-          expect(Coordinate.getInsidePosition(101, range, circular, bounce)).to.be.equal(100);
-          expect(Coordinate.getInsidePosition(200, range, circular, bounce)).to.be.equal(100);
-          expect(Coordinate.getInsidePosition(201, range, circular, bounce)).to.be.equal(100);
-      });
+      // When
+      circular = [true, true];
+
+      // Then
+      expect(
+        Coordinate.getInsidePosition(0, range, circular, bounce)
+      ).to.be.equal(0);
+      expect(
+        Coordinate.getInsidePosition(-1, range, circular, bounce)
+      ).to.be.equal(0);
+      expect(
+        Coordinate.getInsidePosition(-50, range, circular, bounce)
+      ).to.be.equal(0);
+      expect(
+        Coordinate.getInsidePosition(-51, range, circular, bounce)
+      ).to.be.equal(0);
+      expect(
+        Coordinate.getInsidePosition(50, range, circular, bounce)
+      ).to.be.equal(50);
+      expect(
+        Coordinate.getInsidePosition(101, range, circular, bounce)
+      ).to.be.equal(100);
+      expect(
+        Coordinate.getInsidePosition(200, range, circular, bounce)
+      ).to.be.equal(100);
+      expect(
+        Coordinate.getInsidePosition(201, range, circular, bounce)
+      ).to.be.equal(100);
+    });
   });
 
-  describe("isOutside", function() {
-      it("should check if pos is outside", () => {
-          // Given
-          // When
-          let range = [0, 100];
+  describe("isOutside", function () {
+    it("should check if pos is outside", () => {
+      // Given
+      // When
+      let range = [0, 100];
 
-          // Then
-          expect(Coordinate.isOutside(0, range)).to.false;
-          expect(Coordinate.isOutside(50, range)).to.false;
-          expect(Coordinate.isOutside(100, range)).to.false;
-          expect(Coordinate.isOutside(-1, range)).to.true;
-          expect(Coordinate.isOutside(101, range)).to.true;
-      });
+      // Then
+      expect(Coordinate.isOutside(0, range)).to.false;
+      expect(Coordinate.isOutside(50, range)).to.false;
+      expect(Coordinate.isOutside(100, range)).to.false;
+      expect(Coordinate.isOutside(-1, range)).to.true;
+      expect(Coordinate.isOutside(101, range)).to.true;
+    });
   });
 
-  describe("isCircularable", function() {
-      it("should check if pos is circularable", () => {
-          // Given
-          // When
-          let range = [0, 100];
-          let circular = [false, false];
+  describe("isCircularable", function () {
+    it("should check if pos is circularable", () => {
+      // Given
+      // When
+      let range = [0, 100];
+      let circular = [false, false];
 
-          // Then
-          expect(Coordinate.isCircularable(0, range, circular)).to.false;
-          expect(Coordinate.isCircularable(50, range, circular)).to.false;
-          expect(Coordinate.isCircularable(100, range, circular)).to.false;
-          expect(Coordinate.isCircularable(-1, range, circular)).to.false;
-          expect(Coordinate.isCircularable(101, range, circular)).to.false;
+      // Then
+      expect(Coordinate.isCircularable(0, range, circular)).to.false;
+      expect(Coordinate.isCircularable(50, range, circular)).to.false;
+      expect(Coordinate.isCircularable(100, range, circular)).to.false;
+      expect(Coordinate.isCircularable(-1, range, circular)).to.false;
+      expect(Coordinate.isCircularable(101, range, circular)).to.false;
 
-          // When
-          circular = [true, true];
-          
-          // Then
-          expect(Coordinate.isCircularable(0, range, circular)).to.false;
-          expect(Coordinate.isCircularable(50, range, circular)).to.false;
-          expect(Coordinate.isCircularable(100, range, circular)).to.false;
-          expect(Coordinate.isCircularable(-1, range, circular)).to.true;
-          expect(Coordinate.isCircularable(101, range, circular)).to.true;
-      });
+      // When
+      circular = [true, true];
+
+      // Then
+      expect(Coordinate.isCircularable(0, range, circular)).to.false;
+      expect(Coordinate.isCircularable(50, range, circular)).to.false;
+      expect(Coordinate.isCircularable(100, range, circular)).to.false;
+      expect(Coordinate.isCircularable(-1, range, circular)).to.true;
+      expect(Coordinate.isCircularable(101, range, circular)).to.true;
+    });
   });
 
-  describe("getCirculatedPos", function() {
-      it("should calculate position circular", () => {
-          // Given
-          // When
-          let circularOption = [true, true];
-          let range = [0, 100];
+  describe("getCirculatedPos", function () {
+    it("should calculate position circular", () => {
+      // Given
+      // When
+      let circularOption = [true, true];
+      let range = [0, 100];
 
-          // Then
-          expect(Coordinate.getCirculatedPos(100, range, circularOption)).to.equal(100);
-          expect(Coordinate.getCirculatedPos(0, range, circularOption)).to.equal(0);
-          expect(Coordinate.getCirculatedPos(101, range, circularOption)).to.equal(1);
-          expect(Coordinate.getCirculatedPos(-1, range, circularOption)).to.equal(99);
-          expect(Coordinate.getCirculatedPos(110, range, circularOption)).to.equal(10);
-          expect(Coordinate.getCirculatedPos(-110, range, circularOption)).to.equal(90);
+      // Then
+      expect(Coordinate.getCirculatedPos(100, range, circularOption)).to.equal(
+        100
+      );
+      expect(Coordinate.getCirculatedPos(0, range, circularOption)).to.equal(0);
+      expect(Coordinate.getCirculatedPos(101, range, circularOption)).to.equal(
+        1
+      );
+      expect(Coordinate.getCirculatedPos(-1, range, circularOption)).to.equal(
+        99
+      );
+      expect(Coordinate.getCirculatedPos(110, range, circularOption)).to.equal(
+        10
+      );
+      expect(Coordinate.getCirculatedPos(-110, range, circularOption)).to.equal(
+        90
+      );
 
-          // include negative value (Sphere)
-          range = [-180, 180];
+      // include negative value (Sphere)
+      range = [-180, 180];
 
-          // Then
-          expect(Coordinate.getCirculatedPos(180, range, circularOption)).to.equal(180);
-          expect(Coordinate.getCirculatedPos(-180, range, circularOption)).to.equal(-180);
-          expect(Coordinate.getCirculatedPos(181, range, circularOption)).to.equal(-179);
-          expect(Coordinate.getCirculatedPos(-181, range, circularOption)).to.equal(179);
-          expect(Coordinate.getCirculatedPos(190, range, circularOption)).to.equal(-170);
-          expect(Coordinate.getCirculatedPos(-200, range, circularOption)).to.equal(160);
+      // Then
+      expect(Coordinate.getCirculatedPos(180, range, circularOption)).to.equal(
+        180
+      );
+      expect(Coordinate.getCirculatedPos(-180, range, circularOption)).to.equal(
+        -180
+      );
+      expect(Coordinate.getCirculatedPos(181, range, circularOption)).to.equal(
+        -179
+      );
+      expect(Coordinate.getCirculatedPos(-181, range, circularOption)).to.equal(
+        179
+      );
+      expect(Coordinate.getCirculatedPos(190, range, circularOption)).to.equal(
+        -170
+      );
+      expect(Coordinate.getCirculatedPos(-200, range, circularOption)).to.equal(
+        160
+      );
 
-          // // circular option false
-          circularOption = [false, false];
-          range = [0, 100];
+      // // circular option false
+      circularOption = [false, false];
+      range = [0, 100];
 
-          // Then
-          expect(Coordinate.getCirculatedPos(100, range, circularOption)).to.equal(100);
-          expect(Coordinate.getCirculatedPos(0, range, circularOption)).to.equal(0);
-          expect(Coordinate.getCirculatedPos(101, range, circularOption)).to.equal(101);
-          expect(Coordinate.getCirculatedPos(-1, range, circularOption)).to.equal(-1);
-          expect(Coordinate.getCirculatedPos(110, range, circularOption)).to.equal(110);
-      });
+      // Then
+      expect(Coordinate.getCirculatedPos(100, range, circularOption)).to.equal(
+        100
+      );
+      expect(Coordinate.getCirculatedPos(0, range, circularOption)).to.equal(0);
+      expect(Coordinate.getCirculatedPos(101, range, circularOption)).to.equal(
+        101
+      );
+      expect(Coordinate.getCirculatedPos(-1, range, circularOption)).to.equal(
+        -1
+      );
+      expect(Coordinate.getCirculatedPos(110, range, circularOption)).to.equal(
+        110
+      );
+    });
   });
-})
+});

--- a/test/unit/InputObserver.spec.js
+++ b/test/unit/InputObserver.spec.js
@@ -1,287 +1,276 @@
-import { InputObserver } from "../../src/InputObserver";
-import { AnimationManager } from "../../src/AnimationManager";
 import Axes from "../../src/Axes";
-import { AxisManager } from "../../src/AxisManager";
-import { InterruptManager } from "../../src/InterruptManager";
-import { EventManager } from "../../src/EventManager";
-import Component from "@egjs/component";
-import { doesNotThrow } from "assert";
 
 describe("InputObserver", function () {
-	describe("observer test", function () {
-		beforeEach(() => {
-			this.axis = {
-				x: {
-					range: [0, 100],
-					bounce: [50, 50],
-					circular: false
-				},
-				y: {
-					range: [0, 200],
-					bounce: [0, 0],
-					circular: false
-				},
-				z: {
-					range: [-100, 200],
-					bounce: [50, 0],
-					circular: true
-				}
-			};
-			this.options = {
-				deceleration: 0.0001,
-				maximumDuration: 2000,
-				minimumDuration: 0
-			};
-			this.axes = new Axes(this.axis, this.options);
-			this.axm = this.axes.axm;
-			this.am = this.axes.am;
-			this.inst = this.axes.io;
-		});
-		afterEach(() => {
-		});
+  describe("observer test", function () {
+    beforeEach(() => {
+      this.axis = {
+        x: {
+          range: [0, 100],
+          bounce: [50, 50],
+          circular: false,
+        },
+        y: {
+          range: [0, 200],
+          bounce: [0, 0],
+          circular: false,
+        },
+        z: {
+          range: [-100, 200],
+          bounce: [50, 0],
+          circular: true,
+        },
+      };
+      this.options = {
+        deceleration: 0.0001,
+        maximumDuration: 2000,
+        minimumDuration: 0,
+      };
+      this.axes = new Axes(this.axis, this.options);
+      this.axisManager = this.axes.axisManager;
+      this.animationManager = this.axes.animationManager;
+      this.inst = this.axes.inputObserver;
+    });
+    afterEach(() => {});
 
-		it("should check 'get' method", () => {
-			// Given
-			const inputType = {
-				axes: ["y"]
-			};
+    it("should check 'get' method", () => {
+      // Given
+      const inputType = {
+        axes: ["y"],
+      };
 
-			// When/Then
-			expect(this.inst.get(inputType)).to.be.eql({ "y": 0 });
+      // When/Then
+      expect(this.inst.get(inputType)).to.be.eql({ y: 0 });
 
-			// When
-			this.inst.axm.moveTo({ x: 10, y: 20, z: 30 });
+      // When
+      this.inst._axisManager.moveTo({ x: 10, y: 20, z: 30 });
 
-			// Then
-			expect(this.inst.get(inputType)).to.be.eql({ "y": 20 });
-		});
-		it("should check 'change' method", () => {
-			// Given
-			const inputType = {
-				axes: ["y"]
-			};
+      // Then
+      expect(this.inst.get(inputType)).to.be.eql({ y: 20 });
+    });
+    it("should check 'change' method", () => {
+      // Given
+      const inputType = {
+        axes: ["y"],
+      };
 
+      // When/Then
+      expect(this.inst.get(inputType)).to.be.eql({ y: 0 });
 
-			// When/Then
-			expect(this.inst.get(inputType)).to.be.eql({ "y": 0 });
+      // When
+      this.inst.change(inputType, {}, {});
+      expect(this.inst.get(inputType)).to.be.not.eql({ y: 200 });
 
-			// When
-			this.inst.change(inputType, {}, {});
-			expect(this.inst.get(inputType)).to.be.not.eql({ "y": 200 });
+      this.inst.hold(inputType, {});
+      this.inst.change(inputType, {}, { y: 250 });
 
-			this.inst.hold(inputType, {});
-			this.inst.change(inputType, {}, { y: 250 });
+      // Then
+      expect(this.inst.get(inputType)).to.be.eql({ y: 200 });
+    });
+    [1, -1].forEach((direction) => {
+      it(`should check delta that dragged out of bounce area(direction: ${direction})`, (done) => {
+        // Given
+        // start pos
+        let depaPos = direction > 0 ? 200 : 0;
 
-			// Then
-			expect(this.inst.get(inputType)).to.be.eql({ "y": 200 });
-		});
-		[1, -1].forEach(direction => {
-			it(`should check delta that dragged out of bounce area(direction: ${direction})`, done => {
-				// Given
-				// start pos
-				let depaPos = direction > 0 ? 200 : 0;
+        this.axes.setTo({ y: depaPos }, 0);
+        this.axes.on("change", ({ delta }) => {
+          // Then
+          expect(delta.y).to.be.equals(0);
+        });
+        this.axes.on("finish", () => {
+          done();
+        });
 
-				this.axes.setTo({ y: depaPos }, 0);
-				this.axes.on("change", ({ delta }) => {
-					// Then
-					expect(delta.y).to.be.equals(0);
-				});
-				this.axes.on("finish", () => {
-					done();
-				});
+        // When
+        const inputType = {
+          axes: ["y"],
+        };
+        const sign = direction > 0 ? 1 : -1;
+        this.inst.hold(inputType);
+        // The last y position should be zero and neither should Delta.
+        // y goes to zero without bounce.
+        this.inst.change(inputType, {}, { y: sign * 10 });
+        this.inst.change(inputType, {}, { y: sign * 20 });
+        this.inst.change(inputType, {}, { y: sign * 30 });
+        this.inst.change(inputType, {}, { y: sign * 40 });
+        this.inst.release(inputType, {}, [0, 0, 0]);
+      });
 
-				// When
-				const inputType = {
-					axes: ["y"]
-				};
-				const sign = direction > 0 ? 1 : -1;
-				this.inst.hold(inputType);
-				// The last y position should be zero and neither should Delta.
-				// y goes to zero without bounce.
-				this.inst.change(inputType, {}, { y: sign * 10 });
-				this.inst.change(inputType, {}, { y: sign * 20 });
-				this.inst.change(inputType, {}, { y: sign * 30 });
-				this.inst.change(inputType, {}, { y: sign * 40 });
-				this.inst.release(inputType);
-			});
+      it(`should check delta that dragged bounce area (direction: ${direction})`, (done) => {
+        // Given
+        // start pos
+        let depaPos = direction > 0 ? 100 : 0;
 
-			it(`should check delta that dragged bounce area (direction: ${direction})`, done => {
-				// Given
-				// start pos
-				let depaPos = direction > 0 ? 100 : 0;
+        this.axes.setTo({ x: depaPos }, 0);
 
-				this.axes.setTo({ x: depaPos }, 0);
+        let isFirstTime = true;
+        this.axes.on("change", ({ delta }) => {
+          // Then
+          if (isFirstTime) {
+            // bounce area
+            isFirstTime = false;
+            return;
+          }
+          // out of bounce area
+          expect(delta.x).to.be.equals(0);
+        });
+        this.axes.on("finish", () => {
+          done();
+        });
 
-				let isFirstTime = true;
-				this.axes.on("change", ({ delta }) => {
-					// Then
-					if (isFirstTime) {
-						// bounce area
-						isFirstTime = false;
-						return;
-					}
-					// out of bounce area
-					expect(delta.x).to.be.equals(0);
-				});
-				this.axes.on("finish", () => {
-					done();
-				});
+        // When
+        const inputType = {
+          axes: ["x"],
+        };
+        const sign = direction > 0 ? 1 : -1;
+        this.inst.hold(inputType);
+        // Move them approximately 150 by slope bounce to reach the end.
+        // bounce area
+        this.inst.change(inputType, {}, { x: sign * 150 });
+        // out of bounce area
+        this.inst.change(inputType, {}, { x: sign * 10 });
+        this.inst.change(inputType, {}, { x: sign * 10 });
+        this.inst.change(inputType, {}, { x: sign * 10 });
 
-				// When
-				const inputType = {
-					axes: ["x"]
-				};
-				const sign = direction > 0 ? 1 : -1;
-				this.inst.hold(inputType);
-				// Move them approximately 150 by slope bounce to reach the end.
-				// bounce area
-				this.inst.change(inputType, {}, { x: sign * 150 });
-				// out of bounce area
-				this.inst.change(inputType, {}, { x: sign * 10 });
-				this.inst.change(inputType, {}, { x: sign * 10 });
-				this.inst.change(inputType, {}, { x: sign * 10 });
+        this.axes.off("change");
+        this.inst.release(inputType, {}, [0, 0, 0]);
+      });
+      it(`should check delta that 'circular' option was enabled(direction: ${direction})`, (done) => {
+        // Given
+        // start pos
+        let depaPos = direction > 0 ? 180 : 0;
+        let destPos = direction > 0 ? 300 : -180;
+        let z = depaPos;
 
-				this.axes.off("change");
-				this.inst.release(inputType);
-			});
-			it(`should check delta that 'circular' option was enabled(direction: ${direction})`, done => {
-				// Given
-				// start pos
-				let depaPos = direction > 0 ? 180 : 0;
-				let destPos = direction > 0 ? 300 : -180;
-				let z = depaPos;
+        this.axes.setTo({ z: depaPos }, 0);
+        this.axes.on("change", ({ pos, delta }) => {
+          // Then
+          // Find the value as approximated as possible due to floating decimal point problems.
 
-				this.axes.setTo({ z: depaPos }, 0);
-				this.axes.on("change", ({ pos, delta }) => {
-					// Then
-					// Find the value as approximated as possible due to floating decimal point problems.
+          if (direction > 0 && pos.z < 180) {
+            // range[0] + range[1] = 300 loop for right
+            // It is not less than 0 inclusive. z >= 0
+            expect(delta.z).to.be.not.lt(0);
+            expect(delta.z + z).to.be.closeTo(300 + pos.z, 0.0000001);
+            z = 300 + pos.z;
+          } else if (direction < 0 && pos.z > 0) {
+            // range[0] + range[1] = 300 loop for left
+            // It is not greater than 0 inclusive. z <= 0
+            expect(delta.z).to.be.not.gt(0);
+            expect(delta.z + z).to.be.closeTo(-300 + pos.z, 0.0000001);
+            z = -300 + pos.z;
+          } else {
+            expect(delta.z + z).to.be.closeTo(pos.z, 0.0000001);
+            z = pos.z;
+          }
+        });
+        this.axes.on("finish", () => {
+          done();
+        });
 
-					if (direction > 0 && pos.z < 180) {
-						// range[0] + range[1] = 300 loop for right
-						// It is not less than 0 inclusive. z >= 0
-						expect(delta.z).to.be.not.lt(0);
-						expect(delta.z + z).to.be.closeTo(300 + pos.z, 0.0000001);
-						z = 300 + pos.z;
-					} else if (direction < 0 && pos.z > 0) {
-						// range[0] + range[1] = 300 loop for left
-						// It is not greater than 0 inclusive. z <= 0
-						expect(delta.z).to.be.not.gt(0);
-						expect(delta.z + z).to.be.closeTo(-300 + pos.z, 0.0000001);
-						z = -300 + pos.z;
-					} else {
-						expect(delta.z + z).to.be.closeTo(pos.z, 0.0000001);
-						z = pos.z;
-					}
-				});
-				this.axes.on("finish", () => {
-					done();
-				});
+        // When
+        // The last y position should be zero and neither should Delta.
+        this.axes.setTo({ z: destPos }, 300);
+      });
+    });
+    it("should check delta that there is no bounce and the position goes to zero.", (done) => {
+      // Given
+      const inputType = {
+        axes: ["y"],
+      };
+      // start pos
+      let y = 50;
+      this.axes.setTo({ y: 50 }, 0);
+      this.axes.on("change", ({ pos, delta }) => {
+        // Then
+        // Find the value as approximated as possible due to floating decimal point problems.
+        expect(delta.y + y).to.be.closeTo(pos.y, 0.0000001);
 
-				// When
-				// The last y position should be zero and neither should Delta.
-				this.axes.setTo({ z: destPos }, 300);
-			});
-		});
-		it("should check delta that there is no bounce and the position goes to zero.", done => {
-			// Given
-			const inputType = {
-				axes: ["y"]
-			};
-			// start pos
-			let y = 50;
-			this.axes.setTo({ y: 50 }, 0);
-			this.axes.on("change", ({ pos, delta }) => {
-				// Then
-				// Find the value as approximated as possible due to floating decimal point problems.
-				expect(delta.y + y).to.be.closeTo(pos.y, 0.0000001);
+        y = pos.y;
+      });
+      this.axes.on("finish", () => {
+        done();
+      });
 
-				y = pos.y;
-			});
-			this.axes.on("finish", () => {
-				done();
-			});
+      // When
+      // The last y position should be zero and neither should Delta.
+      this.axes.setTo({ y: 0 }, 300);
+    });
+    it("should check delta that there is circular", (done) => {
+      // Given
+      // start pos
+      let z = 0;
+      this.axes.setTo({ z: 0 }, 0);
+      this.axes.on("change", ({ delta }) => {
+        z += delta.z;
+        // Delta is high if the speed is too fast.
+        expect(Math.abs(delta.z)).to.be.below(60);
+      });
+      this.axes.on("finish", () => {
+        expect(z).to.be.closeTo(1000, 0.001);
+        done();
+      });
 
-			// When
-			// The last y position should be zero and neither should Delta.
-			this.axes.setTo({ y: 0 }, 300);
-		});
-		it("should check delta that there is circular", done => {
-			// Given
-			// start pos
-			let z = 0;
-			this.axes.setTo({ z: 0 }, 0);
-			this.axes.on("change", ({ delta }) => {
-				z += delta.z;
-				// Delta is high if the speed is too fast.
-				expect(Math.abs(delta.z)).to.be.below(60);
-			});
-			this.axes.on("finish", () => {
-				expect(z).to.be.closeTo(1000, 0.001);
-				done();
-			});
+      // When
+      const inputType = {
+        axes: ["z"],
+      };
+      this.inst.hold(inputType);
+      // 40 * 25
+      for (let i = 0; i < 25; ++i) {
+        this.inst.change(inputType, {}, { z: 40 });
+      }
+      this.inst.release(inputType, {}, [0, 0, 0]);
+    });
+    it("should check delta that there is no bounce and the position is out", (done) => {
+      // Given
+      const inputType = {
+        axes: ["y"],
+      };
+      // start pos
+      let y = 50;
+      this.axes.setTo({ y: 50 }, 0);
+      this.axes.on("change", ({ pos, delta }) => {
+        // Then
+        // Find the value as approximated as possible due to floating decimal point problems.
+        expect(delta.y + 50).to.be.closeTo(pos.y, 0.0000001);
+      });
+      this.axes.on("finish", () => {
+        done();
+      });
 
+      // When
 
-			// When
-			const inputType = {
-				axes: ["z"]
-			};
-			this.inst.hold(inputType);
-			// 40 * 25
-			for (let i = 0; i < 25; ++i) {
-				this.inst.change(inputType, {}, { z: 40 });
-			}
-			this.inst.release(inputType);
-		});
-		it("should check delta that there is no bounce and the position is out", done => {
-			// Given
-			const inputType = {
-				axes: ["y"]
-			};
-			// start pos
-			let y = 50;
-			this.axes.setTo({ y: 50 }, 0);
-			this.axes.on("change", ({ pos, delta }) => {
-				// Then
-				// Find the value as approximated as possible due to floating decimal point problems.
-				expect(delta.y + 50).to.be.closeTo(pos.y, 0.0000001);
-			});
-			this.axes.on("finish", () => {
-				done();
-			});
+      this.inst.hold(inputType);
+      // The last y position should be zero and neither should Delta.
+      // y goes to zero without bounce.
+      this.inst.change(inputType, {}, { y: -60 });
+      this.inst.release(inputType, {}, [0, 0, 0]);
+    });
+    it("should check delta that there is bounce and the position is out", (done) => {
+      // Given
+      const inputType = {
+        axes: ["x"],
+      };
 
-			// When
+      // start pos
+      let x = 50;
+      this.axes.setTo({ x: 50 }, 0);
+      this.axes.on("change", ({ pos, delta }) => {
+        // Then
+        // Find the value as approximated as possible due to floating decimal point problems.
+        expect(delta.x + x).to.be.closeTo(pos.x, 0.0000001);
+        x = pos.x;
+      });
+      this.axes.on("finish", () => {
+        done();
+      });
 
-			this.inst.hold(inputType);
-			// The last y position should be zero and neither should Delta.
-			// y goes to zero without bounce.
-			this.inst.change(inputType, {}, { y: -60 });
-			this.inst.release(inputType);
-		});
-		it("should check delta that there is bounce and the position is out", done => {
-			// Given
-			const inputType = {
-				axes: ["x"]
-			};
-
-			// start pos
-			let x = 50;
-			this.axes.setTo({ x: 50 }, 0);
-			this.axes.on("change", ({ pos, delta }) => {
-				// Then
-				// Find the value as approximated as possible due to floating decimal point problems.
-				expect(delta.x + x).to.be.closeTo(pos.x, 0.0000001);
-				x = pos.x;
-			});
-			this.axes.on("finish", () => {
-				done();
-			});
-
-			// When
-			this.inst.hold(inputType);
-			// x bounces by -10 and returns to zero.
-			this.inst.change(inputType, {}, { x: -60 });
-			this.inst.release(inputType);
-		});
-
-	});
+      // When
+      this.inst.hold(inputType);
+      // x bounces by -10 and returns to zero.
+      this.inst.change(inputType, {}, { x: -60 });
+      this.inst.release(inputType, {}, [0, 0, 0]);
+    });
+  });
 });

--- a/test/unit/inputType/InputType.spec.js
+++ b/test/unit/inputType/InputType.spec.js
@@ -1,34 +1,38 @@
-import {TouchMouseInput, PointerEventInput,TouchInput , MouseInput} from "@egjs/hammerjs";
-import {createHammer, convertInputType} from "../../../src/inputType/InputType";
-import {DIRECTION} from "../../../src/const";
 import InputInjector from "inject-loader!../../../src/inputType/InputType";
+import EventInjector from "inject-loader!../../../src/eventInput/EventInput";
+
+import { MouseEventInput } from "../../../src/eventInput/MouseEventInput";
+import { PointerEventInput } from "../../../src/eventInput/PointerEventInput";
+import { TouchEventInput } from "../../../src/eventInput/TouchEventInput";
+import { TouchMouseEventInput } from "../../../src/eventInput/TouchMouseEventInput";
 
 describe("InputType", () => {
   describe("SUPPORT_TOUCH mocking", function() {
     it("should check convertInputType when supporting touch", () => {
       // Given
-      const MockInputInjector = InputInjector();
+      const MockEventInjector = EventInjector();
+      const MockInputInjector = InputInjector({
+		  "../eventInput/EventInput": MockEventInjector,
+	  });
 
-      MockInputInjector.SUPPORT_TOUCH = true;
-      MockInputInjector.SUPPORT_POINTER_EVENTS = true;
+      MockEventInjector.SUPPORT_TOUCH = true;
+      MockEventInjector.SUPPORT_POINTER_EVENTS = true;
       // When
       let inputType = ["pointer", "touch", "mouse" ];
       // Then
-      expect(TouchMouseInput).to.be.ok;
-      expect(PointerEventInput).to.be.ok;
-      expect(MockInputInjector.convertInputType(inputType)).to.be.equal(PointerEventInput);
-      MockInputInjector.SUPPORT_POINTER_EVENTS = false;
-      
-      expect(MockInputInjector.convertInputType(inputType)).to.be.equal(TouchMouseInput);
+      expect(MockInputInjector.convertInputType(inputType) instanceof PointerEventInput).to.be.equal(true);
+      MockEventInjector.SUPPORT_POINTER_EVENTS = false;
+
+      expect(MockInputInjector.convertInputType(inputType) instanceof TouchMouseEventInput).to.be.equal(true);
       // When
       inputType = [ "touch" ];
       // Then
-      expect(MockInputInjector.convertInputType(inputType)).to.be.equal(TouchInput);
+      expect(MockInputInjector.convertInputType(inputType) instanceof TouchEventInput).to.be.equal(true);
 
-    // When
+	  // When
       inputType = [ "mouse" ];
       // Then
-      expect(MockInputInjector.convertInputType(inputType)).to.be.equal(MouseInput);
+      expect(MockInputInjector.convertInputType(inputType) instanceof MouseEventInput).to.be.equal(true);
 
       // When
       inputType = [ ];
@@ -39,13 +43,16 @@ describe("InputType", () => {
 
     it("should check convertInputType when not supporting touch", () => {
       // Given
-      const MockInputInjector = InputInjector();
-      MockInputInjector.SUPPORT_TOUCH = false;
+      const MockEventInjector = EventInjector();
+      const MockInputInjector = InputInjector({
+		  "../eventInput/EventInput": MockEventInjector,
+	  });
+      MockEventInjector.SUPPORT_TOUCH = false;
 
       // When
       let inputType = [ "touch", "mouse" ];
       // Then
-      expect(MockInputInjector.convertInputType(inputType)).to.be.equal(MouseInput);
+      expect(MockInputInjector.convertInputType(inputType) instanceof MouseEventInput).to.be.equal(true);
 
       // When
       inputType = [ "touch" ];
@@ -55,12 +62,12 @@ describe("InputType", () => {
       // When
       inputType = [ "mouse" ];
       // Then
-      expect(MockInputInjector.convertInputType(inputType)).to.be.equal(MouseInput);
+      expect(MockInputInjector.convertInputType(inputType) instanceof MouseEventInput).to.be.equal(true);
 
       // When
       inputType = [ ];
       // Then
       expect(MockInputInjector.convertInputType(inputType)).to.be.null;
-    });    
+    });
   });
 });

--- a/test/unit/inputType/MoveKeyInput.spec.js
+++ b/test/unit/inputType/MoveKeyInput.spec.js
@@ -20,7 +20,7 @@ describe("MoveKeyInput", () => {
     it("should check status after disconnect", () => {
       // Given
       this.inst.connect({});
-      
+
       // When
       this.inst.disconnect();
 
@@ -32,7 +32,7 @@ describe("MoveKeyInput", () => {
     it("should check status after destroy", () => {
       // Given
       this.inst.connect({});
-      
+
       // When
       this.inst.destroy();
 
@@ -69,27 +69,27 @@ describe("MoveKeyInput", () => {
       // Given
       // When
       // Then
-      expect(this.inst.isEnable()).to.be.false;
+      expect(this.inst.isEnabled()).to.be.false;
 
       // When
       this.inst.disable();
 
       // Then
-      expect(this.inst.isEnable()).to.be.false;
+      expect(this.inst.isEnabled()).to.be.false;
 
       // When
       this.inst.enable();
 
       // Then
-      expect(this.inst.isEnable()).to.be.true;
+      expect(this.inst.isEnabled()).to.be.true;
 
       // When (after connection)
       this.inst.connect(this.observer);
       this.inst.enable();
 
       // Then
-      expect(this.inst.isEnable()).to.be.true;
-    }); 
+      expect(this.inst.isEnabled()).to.be.true;
+    });
   });
 
   describe("No axes keydown event test", function() {
@@ -98,7 +98,7 @@ describe("MoveKeyInput", () => {
       this.el = document.createElement("div");
       this.elBody.appendChild(this.el);
 
-      this.input = new MoveKeyInput(this.el); 
+      this.input = new MoveKeyInput(this.el);
       this.inst = new Axes({
         x: {
             range: [10, 120]
@@ -146,7 +146,7 @@ describe("MoveKeyInput", () => {
       this.el = document.createElement("div");
       this.elBody.appendChild(this.el);
 
-      this.input = new MoveKeyInput(this.el); 
+      this.input = new MoveKeyInput(this.el);
       this.inst = new Axes({
         x: {
             range: [10, 120]
@@ -206,7 +206,7 @@ describe("MoveKeyInput", () => {
         expect(changeTriggered).to.be.false;
         done();
       });
-      
+
     });
 
     // left
@@ -256,17 +256,17 @@ describe("MoveKeyInput", () => {
             this.inst.on("change", change);
 
             // When / Then
-            expect(this.input._isHolded).to.be.false;
+            expect(this.input._holding).to.be.false;
             TestHelper.key(this.el, "keydown", rightKeyCode, e => {
-              expect(this.input._isHolded).to.be.true;
+              expect(this.input._holding).to.be.true;
               expect(hold.callCount).to.be.equal(1);
 
                 // Then
               expect(change.calledOnce).to.be.true;
-              
+
 
               TestHelper.key(this.el, "keydown", rightKeyCode, e => {
-                expect(this.input._isHolded).to.be.true;
+                expect(this.input._holding).to.be.true;
                 expect(hold.callCount).to.be.equal(1);
                 done();
               });
@@ -294,18 +294,18 @@ describe("MoveKeyInput", () => {
             this.inst.on("hold", hold);
             this.inst.on("change", change);
 
-            expect(this.input._isHolded).to.be.false;
+            expect(this.input._holding).to.be.false;
             // When
             TestHelper.key(this.el, "keydown", upKeyCode, e => {
-              expect(this.input._isHolded).to.be.true;
+              expect(this.input._holding).to.be.true;
               expect(hold.callCount).to.be.equal(1);
 
                 // Then
               expect(change.calledOnce).to.be.true;
-              
+
 
               TestHelper.key(this.el, "keydown", upKeyCode, e => {
-                expect(this.input._isHolded).to.be.true;
+                expect(this.input._holding).to.be.true;
                 expect(hold.callCount).to.be.equal(1);
                 done();
               });
@@ -329,7 +329,7 @@ describe("MoveKeyInput", () => {
                 keyCode: keyCode
             };
             this.input.options.scale[1] = -1;
-            
+
             // When
             TestHelper.key(this.el, "keydown", downKeyCode);
 
@@ -350,12 +350,12 @@ describe("MoveKeyInput", () => {
           const downKeyCode = {
               keyCode: keyCode
           };
-          
+
 
           this.inst.on("hold", holdHandler);
           this.inst.on("change", changeHandler);
           this.inst.on("release", releaseHandler);
-          
+
           // When
           TestHelper.key(this.el, "keydown", downKeyCode);
 
@@ -393,7 +393,7 @@ describe("MoveKeyInput", () => {
                 done();
               }, 100);
             });
-          }, 20);		
+          }, 20);
         });
       });
     });

--- a/test/unit/inputType/PanInput.spec.js
+++ b/test/unit/inputType/PanInput.spec.js
@@ -1,48 +1,48 @@
-import {PanInput, getDirectionByAngle, getNextOffset, useDirection} from "../../../src/inputType/PanInput";
-import {PinchInput} from "../../../src/inputType/PinchInput";
-import {UNIQUEKEY} from "../../../src/inputType/InputType";
 import {
-  DIRECTION_ALL, DIRECTION_HORIZONTAL,
-  DIRECTION_NONE, DIRECTION_VERTICAL} from "../../../src/const";
+  PanInput,
+  getDirectionByAngle,
+  useDirection,
+} from "../../../src/inputType/PanInput";
+import { PinchInput } from "../../../src/inputType/PinchInput";
+import {
+  DIRECTION_ALL,
+  DIRECTION_HORIZONTAL,
+  DIRECTION_NONE,
+  DIRECTION_VERTICAL,
+} from "../../../src/const";
 
 describe("PanInput", () => {
-  describe("when hammer instance is shared", function() {
+  describe("when hammer instance is shared", function () {
     beforeEach(() => {
       this.el = sandbox();
       this.inst1 = new PanInput(this.el, {
         inputType: ["touch", "mouse"],
       });
       this.inst2 = new PinchInput(this.el);
-      this.inst1.mapAxes(["x1","y1"]);
+      this.inst1.mapAxes(["x1", "y1"]);
       this.inst2.mapAxes(["x2"]);
       const observer = {
         get() {
           return {
-            x: 10
-          }
+            x: 10,
+          };
         },
         release() {},
         hold() {},
         change() {},
         options: {
-          deceleration: 0.0001
-        }
+          deceleration: 0.0001,
+        },
       };
       this.inst1.connect(observer);
-      this.inst2.hammer = this.inst1.hammer;
       this.inst2.connect(observer);
 
-      this.beforePanstart = this.inst1.hammer.handlers["panstart"][0];
-      this.beforePinchstart = this.inst2.hammer.handlers["pinchstart"][0];
+      this.beforePanstart = this.inst1._onPanstart;
+      this.beforePinchstart = this.inst2._onPinchStart;
       this.onPanstart = sinon.spy(this.beforePanstart);
       this.onPinchstart = sinon.spy(this.beforePinchstart);
-      this.inst1.hammer.handlers["panstart"][0] = this.onPanstart;
-      this.inst2.hammer.handlers["pinchstart"][0] = this.onPinchstart;
     });
     afterEach(() => {
-      this.inst1.hammer.handlers["panstart"][0] = this.beforePanstart;
-      this.inst2.hammer.handlers["pinchstart"][0] = this.beforePinchstart;
-
       if (this.inst1) {
         this.inst1.destroy();
         this.inst1 = null;
@@ -57,31 +57,38 @@ describe("PanInput", () => {
       // Given
 
       // When
-      expect(this.inst1.hammer).to.be.equal(this.inst2.hammer);
       expect(this.inst1.element).to.be.equal(this.inst2.element);
 
       // When
-      Simulator.gestures.pan(this.el, {
+      Simulator.gestures.pan(
+        this.el,
+        {
           pos: [0, 0],
           deltaX: 50,
           deltaY: 50,
           duration: 200,
-          easing: "linear"
-      }, () => {
+          easing: "linear",
+        },
+        () => {
           // Then
           expect(this.onPanstart.called).to.be.true;
           expect(this.onPinchstart.called).to.be.false;
 
-          Simulator.gestures.pinch(this.el, {
+          Simulator.gestures.pinch(
+            this.el,
+            {
               duration: 500,
-              scale: 0.5
-          }, () => {
+              scale: 0.5,
+            },
+            () => {
               // Then
               expect(this.onPanstart.callCount).to.be.equal(1);
               expect(this.onPinchstart.callCount).to.be.equal(1);
               done();
-          });
-      });
+            }
+          );
+        }
+      );
     });
     it("should check multi dettached event (pan/pinch)", (done) => {
       // Given
@@ -91,30 +98,38 @@ describe("PanInput", () => {
       expect(this.inst1.element).to.be.equal(this.inst2.element);
 
       // When
-      Simulator.gestures.pan(this.el, {
+      Simulator.gestures.pan(
+        this.el,
+        {
           pos: [0, 0],
           deltaX: 50,
           deltaY: 50,
           duration: 200,
-          easing: "linear"
-      }, () => {
+          easing: "linear",
+        },
+        () => {
           // Then
           expect(this.onPanstart.called).to.be.false;
           expect(this.onPanstart.called).to.be.false;
 
-          Simulator.gestures.pinch(this.el, {
+          Simulator.gestures.pinch(
+            this.el,
+            {
               duration: 500,
-              scale: 0.5
-          }, () => {
+              scale: 0.5,
+            },
+            () => {
               // Then
               expect(this.onPanstart.called).to.be.false;
               expect(this.onPanstart.called).to.be.false;
               done();
-          });
-      });
+            }
+          );
+        }
+      );
     });
   });
-  describe("instance method", function() {
+  describe("instance method", function () {
     beforeEach(() => {
       this.inst = new PanInput(sandbox());
     });
@@ -156,17 +171,14 @@ describe("PanInput", () => {
     });
     it("should check status after disconnect", () => {
       // Given
-      const beforeHammer = this.inst.hammer;
       this.inst.connect({});
 
       // When
       this.inst.disconnect();
 
       // Then
-      expect(beforeHammer).to.be.not.exist;
       expect(this.observer).to.be.not.exist;
       expect(this.inst.element).to.be.exist;
-      expect(UNIQUEKEY in this.inst.element).to.be.true;
       expect(this.inst._direction).to.be.equal(DIRECTION_NONE);
     });
     it("should check status after destroy", () => {
@@ -178,45 +190,32 @@ describe("PanInput", () => {
       this.inst.destroy();
 
       // Then
-      expect(this.inst.hammer).to.be.not.exist;
       expect(this.inst.element).to.be.not.exist;
       expect(this.observer).to.be.not.exist;
-      expect(UNIQUEKEY in beforeEl).to.be.false;
       expect(this.inst._direction).to.be.equal(DIRECTION_NONE);
 
       this.inst = null;
     });
-    it("should check connect when hammer instance is null and element has key property", () => {
-      // Given
-      this.inst.element[UNIQUEKEY] = "someting";
-
-      // When
-      expect(this.inst.hammer).to.be.not.exist;
-      this.inst.connect({});
-
-      // Then
-      expect(this.inst.hammer).to.be.exist;
-    });
   });
-  describe("enable/disable", function() {
+  describe("enable/disable", function () {
     beforeEach(() => {
       this.el = sandbox();
       this.inst = new PanInput(this.el, {
         inputType: ["touch", "mouse"],
       });
-      this.inst.mapAxes(["x1","y1"]);
+      this.inst.mapAxes(["x1", "y1"]);
       this.observer = {
         get() {
           return {
-            x: 10
-          }
+            x: 10,
+          };
         },
         release() {},
         hold() {},
         change() {},
         options: {
-          deceleration: 0.0001
-        }
+          deceleration: 0.0001,
+        },
       };
     });
     afterEach(() => {
@@ -227,85 +226,80 @@ describe("PanInput", () => {
       cleanup();
     });
 
-    it("should check value of `enable/disalbe` methods", () => {
+    it("should check value of `enable/disable` methods", () => {
       // Given
       // When
       // Then
-      expect(this.inst.isEnable()).to.be.false;
+      expect(this.inst.isEnabled()).to.be.false;
+
+      // When
+      this.inst.enable();
+
+      // Then
+      expect(this.inst.isEnabled()).to.be.true;
 
       // When
       this.inst.disable();
 
       // Then
-      expect(this.inst.isEnable()).to.be.false;
-
-      // When (hammer is not exist)
-      this.inst.enable();
-
-      // Then
-      expect(this.inst.hammer).to.be.not.exist;
-      expect(this.inst.isEnable()).to.be.false;
-
-      // When (hammer is exist)
-      this.inst.connect(this.observer);
-      this.inst.enable();
-
-      // Then
-      expect(this.inst.hammer).to.be.exist;
-      expect(this.inst.isEnable()).to.be.true;
+      expect(this.inst.isEnabled()).to.be.false;
     });
     it("should check event when enable method is called", (done) => {
       // Given
       this.inst.connect(this.observer);
-      const beforeHandler = this.inst.hammer.handlers["panstart"][0];
+      const beforeHandler = this.inst._onPanstart;
 
       // When
-      expect(this.inst.isEnable()).to.be.true;
+      expect(this.inst.isEnabled()).to.be.true;
       const onPanEndHandler = sinon.spy(beforeHandler);
-      this.inst.hammer.handlers["panstart"][0] = onPanEndHandler;
 
       // When
-      Simulator.gestures.pan(this.el, {
+      Simulator.gestures.pan(
+        this.el,
+        {
           pos: [0, 0],
           deltaX: 50,
           deltaY: 50,
           duration: 200,
-          easing: "linear"
-      }, () => {
+          easing: "linear",
+        },
+        () => {
           // Then
           expect(onPanEndHandler.called).to.be.true;
-          this.inst.hammer.handlers["panstart"][0] = beforeHandler;
           done();
-      });
+        }
+      );
     });
     it("should check event when disable method is called", (done) => {
       // Given
       this.inst.connect(this.observer);
-      const beforeHandler = this.inst.hammer.handlers["panstart"][0];
+      const beforeHandler = this.inst._onPanstart;
       // When
 
       const onPanEndHandler = sinon.spy(beforeHandler);
-      this.inst.hammer.handlers["panstart"][0] = onPanEndHandler;
-      expect(this.inst.isEnable()).to.be.true;
+      expect(this.inst.isEnabled()).to.be.true;
       this.inst.disable();
 
       // When
-      Simulator.gestures.pan(this.el, {
+      Simulator.gestures.pan(
+        this.el,
+        {
           pos: [0, 0],
           deltaX: 50,
           deltaY: 50,
           duration: 200,
-          easing: "linear"
-      }, () => {
+          easing: "linear",
+        },
+        () => {
           // Then
           expect(onPanEndHandler.called).to.be.false;
-          this.inst.hammer.handlers["panstart"][0] = beforeHandler;
           done();
-      });
+        }
+      );
     });
   });
 
-  describe("static method", function() {
+  describe("static method", function () {
     it("should check user's direction", () => {
       //Given
       // When thresholdAngle = 45
@@ -335,47 +329,92 @@ describe("PanInput", () => {
       expect(getDirectionByAngle(0, 100)).to.be.equal(DIRECTION_NONE);
     });
 
-    it("should check 'getNextOffset' method", () => {
-      // 0.001
-      expect(getNextOffset([1.5, 1], 0.001)).to.be.eql([1352.0817282989958, 901.3878188659972]);
-      expect(getNextOffset([1, 1.5], 0.001)).to.be.eql([901.3878188659972, 1352.0817282989958]);
-
-      // 0.01
-      expect(getNextOffset([1.5, 1], 0.01)).to.be.eql([135.20817282989958, 90.13878188659973]);
-      expect(getNextOffset([1, 1.5], 0.01)).to.be.eql([90.13878188659973, 135.20817282989958]);
-    });
-
     it("should check 'useDirection' method", () => {
       // DIRECTION_HORIZONTAL
       expect(useDirection(DIRECTION_HORIZONTAL, DIRECTION_ALL)).to.be.true;
-      expect(useDirection(DIRECTION_HORIZONTAL, DIRECTION_HORIZONTAL)).to.be.true;
-      expect(useDirection(DIRECTION_HORIZONTAL, DIRECTION_VERTICAL)).to.be.false;
+      expect(useDirection(DIRECTION_HORIZONTAL, DIRECTION_HORIZONTAL)).to.be
+        .true;
+      expect(useDirection(DIRECTION_HORIZONTAL, DIRECTION_VERTICAL)).to.be
+        .false;
 
       // DIRECTION_VERTICAL
       expect(useDirection(DIRECTION_VERTICAL, DIRECTION_ALL)).to.be.true;
-      expect(useDirection(DIRECTION_VERTICAL, DIRECTION_HORIZONTAL)).to.be.false;
+      expect(useDirection(DIRECTION_VERTICAL, DIRECTION_HORIZONTAL)).to.be
+        .false;
       expect(useDirection(DIRECTION_VERTICAL, DIRECTION_VERTICAL)).to.be.true;
     });
 
     it("should check 'useDirection' method (using userDirection)", () => {
       // DIRECTION_HORIZONTAL
-      expect(useDirection(DIRECTION_HORIZONTAL, DIRECTION_ALL, DIRECTION_HORIZONTAL)).to.be.true;
-      expect(useDirection(DIRECTION_HORIZONTAL, DIRECTION_ALL, DIRECTION_VERTICAL)).to.be.true;
-      expect(useDirection(DIRECTION_HORIZONTAL, DIRECTION_HORIZONTAL, DIRECTION_HORIZONTAL)).to.be.true;
-      expect(useDirection(DIRECTION_HORIZONTAL, DIRECTION_HORIZONTAL, DIRECTION_VERTICAL)).to.be.false;
-      expect(useDirection(DIRECTION_HORIZONTAL, DIRECTION_VERTICAL, DIRECTION_HORIZONTAL)).to.be.false;
-      expect(useDirection(DIRECTION_HORIZONTAL, DIRECTION_VERTICAL, DIRECTION_VERTICAL)).to.be.false;
+      expect(
+        useDirection(DIRECTION_HORIZONTAL, DIRECTION_ALL, DIRECTION_HORIZONTAL)
+      ).to.be.true;
+      expect(
+        useDirection(DIRECTION_HORIZONTAL, DIRECTION_ALL, DIRECTION_VERTICAL)
+      ).to.be.true;
+      expect(
+        useDirection(
+          DIRECTION_HORIZONTAL,
+          DIRECTION_HORIZONTAL,
+          DIRECTION_HORIZONTAL
+        )
+      ).to.be.true;
+      expect(
+        useDirection(
+          DIRECTION_HORIZONTAL,
+          DIRECTION_HORIZONTAL,
+          DIRECTION_VERTICAL
+        )
+      ).to.be.false;
+      expect(
+        useDirection(
+          DIRECTION_HORIZONTAL,
+          DIRECTION_VERTICAL,
+          DIRECTION_HORIZONTAL
+        )
+      ).to.be.false;
+      expect(
+        useDirection(
+          DIRECTION_HORIZONTAL,
+          DIRECTION_VERTICAL,
+          DIRECTION_VERTICAL
+        )
+      ).to.be.false;
 
       // DIRECTION_VERTICAL
-      expect(useDirection(DIRECTION_VERTICAL, DIRECTION_ALL, DIRECTION_HORIZONTAL)).to.be.true;
-      expect(useDirection(DIRECTION_VERTICAL, DIRECTION_ALL, DIRECTION_VERTICAL)).to.be.true;
-      expect(useDirection(DIRECTION_VERTICAL, DIRECTION_HORIZONTAL, DIRECTION_HORIZONTAL)).to.be.false;
-      expect(useDirection(DIRECTION_VERTICAL, DIRECTION_HORIZONTAL, DIRECTION_VERTICAL)).to.be.false;
-      expect(useDirection(DIRECTION_VERTICAL, DIRECTION_VERTICAL, DIRECTION_HORIZONTAL)).to.be.false;
-      expect(useDirection(DIRECTION_VERTICAL, DIRECTION_VERTICAL, DIRECTION_VERTICAL)).to.be.true;
+      expect(
+        useDirection(DIRECTION_VERTICAL, DIRECTION_ALL, DIRECTION_HORIZONTAL)
+      ).to.be.true;
+      expect(
+        useDirection(DIRECTION_VERTICAL, DIRECTION_ALL, DIRECTION_VERTICAL)
+      ).to.be.true;
+      expect(
+        useDirection(
+          DIRECTION_VERTICAL,
+          DIRECTION_HORIZONTAL,
+          DIRECTION_HORIZONTAL
+        )
+      ).to.be.false;
+      expect(
+        useDirection(
+          DIRECTION_VERTICAL,
+          DIRECTION_HORIZONTAL,
+          DIRECTION_VERTICAL
+        )
+      ).to.be.false;
+      expect(
+        useDirection(
+          DIRECTION_VERTICAL,
+          DIRECTION_VERTICAL,
+          DIRECTION_HORIZONTAL
+        )
+      ).to.be.false;
+      expect(
+        useDirection(DIRECTION_VERTICAL, DIRECTION_VERTICAL, DIRECTION_VERTICAL)
+      ).to.be.true;
     });
   });
-  describe("options test", function() {
+  describe("options test", function () {
     beforeEach(() => {
       this.inst = new PanInput(sandbox());
     });
@@ -385,33 +424,6 @@ describe("PanInput", () => {
         this.inst = null;
       }
       cleanup();
-    });
-    it("should check hammerManager default Options", () => {
-      // Given
-      expect(this.inst.options.hammerManagerOptions).to.be.eql({
-        cssProps: {
-          userSelect: "none",
-          touchSelect: "none",
-          touchCallout: "none",
-          userDrag: "none",
-        }
-      });
-
-      // When
-      this.inst.connect({});
-
-      // Then
-      expect(this.inst.element.style.userSelect).to.be.equal("none");
-    });
-    it("should check hammerManager Options", () => {
-      // Given
-      this.inst.options.hammerManagerOptions.cssProps.userSelect = "auto";
-
-      // When
-      this.inst.connect({});
-
-      // Then
-      expect(this.inst.element.style.userSelect).to.be.equal("auto");
     });
   });
 });

--- a/test/unit/inputType/PinchInput.spec.js
+++ b/test/unit/inputType/PinchInput.spec.js
@@ -1,241 +1,219 @@
-import Hammer from "@egjs/hammerjs";
 import Axes from "../../../src/Axes.ts";
 import { PinchInput } from "../../../src/inputType/PinchInput";
-import { UNIQUEKEY } from "../../../src/inputType/InputType";
 
 describe("PinchInput", () => {
-	describe("instance method", function () {
-		beforeEach(() => {
-			this.inst = new PinchInput(sandbox());
-		});
-		afterEach(() => {
-			if (this.inst) {
-				this.inst.destroy();
-				this.inst = null;
-			}
-			cleanup();
-		});
-		it("should check status after disconnect", () => {
-			// Given
-			const beforeHammer = this.inst.hammer;
-			this.inst.connect({});
+  describe("instance method", function () {
+    beforeEach(() => {
+      this.inst = new PinchInput(sandbox());
+    });
+    afterEach(() => {
+      if (this.inst) {
+        this.inst.destroy();
+        this.inst = null;
+      }
+      cleanup();
+    });
+    it("should check status after disconnect", () => {
+      // Given
+      this.inst.connect({});
 
-			// When
-			this.inst.disconnect();
+      // When
+      this.inst.disconnect();
 
-			// Then
-			expect(beforeHammer).to.be.not.exist;
-			expect(this.observer).to.be.not.exist;
-			expect(this.inst.element).to.be.exist;
-			expect(UNIQUEKEY in this.inst.element).to.be.true;
-			expect(this._prev).to.be.not.exist;
-		});
-		it("should check status after destroy", () => {
-			// Given
-			this.inst.connect({});
+      // Then
+      expect(this.observer).to.be.not.exist;
+      expect(this.inst.element).to.be.exist;
+    });
+    it("should check status after destroy", () => {
+      // Given
+      this.inst.connect({});
 
-			// When
-			this.inst.destroy();
+      // When
+      this.inst.destroy();
 
-			// Then
-			expect(this.inst.hammer).to.be.not.exist;
-			expect(this.inst.element).to.be.not.exist;
-			expect(this.observer).to.be.not.exist;
-			expect(this._prev).to.be.not.exist;
+      // Then
+      expect(this.inst.element).to.be.not.exist;
+      expect(this.observer).to.be.not.exist;
 
-			this.inst = null;
-		});
-	});
-	describe("enable/disable", function () {
-		beforeEach(() => {
-			this.el = sandbox();
-			this.inst = new PinchInput(this.el, { inputType: ["touch"] });
-			this.inst.mapAxes(["x"]);
-			this.observer = {
-				get() {
-					return {
-						x: 10
-					}
-				},
-				release() { },
-				hold() { },
-				change() { },
-				options: {
-					deceleration: 0.0001
-				}
-			};
-		});
-		afterEach(() => {
-			if (this.inst) {
-				this.inst.destroy();
-				this.inst = null;
-			}
-			cleanup();
-		});
+      this.inst = null;
+    });
+  });
+  describe("enable/disable", function () {
+    beforeEach(() => {
+      this.el = sandbox();
+      this.inst = new PinchInput(this.el, { inputType: ["touch"] });
+      this.inst.mapAxes(["x"]);
+      this.observer = {
+        get() {
+          return {
+            x: 10,
+          };
+        },
+        release() {},
+        hold() {},
+        change() {},
+        options: {
+          deceleration: 0.0001,
+        },
+      };
+    });
+    afterEach(() => {
+      if (this.inst) {
+        this.inst.destroy();
+        this.inst = null;
+      }
+      cleanup();
+    });
 
-		it("should check value of `enable/disalbe` methods", () => {
-			// Given
-			// When
-			// Then
-			expect(this.inst.isEnable()).to.be.false;
+    it("should check value of `enable/disable` methods", () => {
+      // Given
+      // When
+      // Then
+      expect(this.inst.isEnabled()).to.be.false;
 
-			// When
-			this.inst.disable();
+      // When
+      this.inst.disable();
 
-			// Then
-			expect(this.inst.isEnable()).to.be.false;
+      // Then
+      expect(this.inst.isEnabled()).to.be.false;
 
-			// When (hammer is not exist)
-			this.inst.enable();
+      // When
+      this.inst.enable();
 
-			// Then
-			expect(this.inst.hammer).to.be.not.exist;
-			expect(this.inst.isEnable()).to.be.false;
+      // Then
+      expect(this.inst.isEnabled()).to.be.true;
 
-			// When (hammer is exist)
-			this.inst.connect(this.observer);
-			this.inst.enable();
+      // When
+      this.inst.disable();
 
-			// Then
-			expect(this.inst.hammer).to.be.exist;
-			expect(this.inst.isEnable()).to.be.true;
-		});
-		it("should check event when enable method is called", (done) => {
-			// Given
-			this.inst.connect(this.observer);
-			const beforeHandler = this.inst.hammer.handlers["pinchend"][0];
+      // Then
+      expect(this.inst.isEnabled()).to.be.false;
+    });
+    it("should check event when enable method is called", (done) => {
+      // Given
+      this.inst.connect(this.observer);
+      const beforeHandler = this.inst._onPinchStart;
 
-			// When
-			expect(this.inst.isEnable()).to.be.true;
-			const onPinchEndHandler = sinon.spy(beforeHandler);
-			this.inst.hammer.handlers["pinchend"][0] = onPinchEndHandler;
+      // When
+      expect(this.inst.isEnabled()).to.be.true;
+      const onPinchEndHandler = sinon.spy(beforeHandler);
 
-			// When
-			Simulator.gestures.pinch(this.el, {
-				duration: 500,
-				scale: 0.5
-			}, () => {
-				// Then
-				expect(onPinchEndHandler.called).to.be.true;
-				this.inst.hammer.handlers["pinchend"][0] = beforeHandler;
-				done();
-			});
-		});
-		it("should check event when disable method is called", (done) => {
-			// Given
-			this.inst.connect(this.observer);
-			const beforeHandler = this.inst.hammer.handlers["pinchend"][0];
-			// When
+      // When
+      Simulator.gestures.pinch(
+        this.el,
+        {
+          duration: 500,
+          scale: 0.5,
+        },
+        () => {
+          // Then
+          expect(onPinchEndHandler.called).to.be.true;
+          done();
+        }
+      );
+    });
+    it("should check event when disable method is called", (done) => {
+      // Given
+      this.inst.connect(this.observer);
+      const beforeHandler = this.inst._onPinchStart;
+      // When
 
-			const onPinchEndHandler = sinon.spy(beforeHandler);
-			this.inst.hammer.handlers["pinchend"][0] = onPinchEndHandler;
-			expect(this.inst.isEnable()).to.be.true;
-			this.inst.disable();
+      const onPinchEndHandler = sinon.spy(beforeHandler);
+      expect(this.inst.isEnabled()).to.be.true;
+      this.inst.disable();
 
-			// When
-			Simulator.gestures.pinch(this.el, {
-				duration: 500,
-				scale: 0.5
-			}, () => {
-				// Then
-				expect(onPinchEndHandler.called).to.be.false;
-				this.inst.hammer.handlers["pinchend"][0] = beforeHandler;
-				done();
-			});
-		});
-	});
+      // When
+      Simulator.gestures.pinch(
+        this.el,
+        {
+          duration: 500,
+          scale: 0.5,
+        },
+        () => {
+          // Then
+          expect(onPinchEndHandler.called).to.be.false;
+          done();
+        }
+      );
+    });
+  });
 
-	describe("offset value", function () {
-		beforeEach(() => {
-			this.el = sandbox();
-			this.input = new PinchInput(this.el, { inputType: ["touch"] });
-			this.inst = new Axes({
-				x: {
-					range: [10, 120]
-				}
-			}, { round: 1 }, {
-					x: 50
-				});
-			this.inst.connect(["x"], this.input);
-		});
-		afterEach(() => {
-			if (this.ins) {
-				this.inst.destroy();
-				this.inst = null;
-			}
-			if (this.input) {
-				this.input.destroy();
-				this.input = null;
-			}
-			cleanup();
-		});
+  describe("offset value", function () {
+    beforeEach(() => {
+      this.el = sandbox();
+      this.input = new PinchInput(this.el, { inputType: ["touch"] });
+      this.inst = new Axes(
+        {
+          x: {
+            range: [10, 120],
+          },
+        },
+        { round: 1 },
+        {
+          x: 50,
+        }
+      );
+      this.inst.connect(["x"], this.input);
+    });
+    afterEach(() => {
+      if (this.ins) {
+        this.inst.destroy();
+        this.inst = null;
+      }
+      if (this.input) {
+        this.input.destroy();
+        this.input = null;
+      }
+      cleanup();
+    });
 
-		it("The offset value should be returned using the position value when the hold event is triggered.", (done) => {
-			// Given
-			this.input.options.scale = 1;
-			// When
-			Simulator.gestures.pinch(this.el, {
-				duration: 500,
-				scale: 1.1
-			}, () => {
-				// Then
-				expect(this.inst.get(['x']).x).to.be.equal(55);
-				done();
-			});
-		});
+    it("The offset value should be returned using the position value when the hold event is triggered.", (done) => {
+      // Given
+      this.input.options.scale = 1;
+      // When
+      Simulator.gestures.pinch(
+        this.el,
+        {
+          duration: 500,
+          scale: 1.1,
+        },
+        () => {
+          // Then
+          expect(this.inst.get(["x"]).x).to.be.equal(55);
+          done();
+        }
+      );
+    });
 
-		it("The offset value should apply scale option", (done) => {
-			// Given
-			this.input.options.scale = 1;
-			// When
-			Simulator.gestures.pinch(this.el, {
-				duration: 500,
-				scale: 0.9
-			}, () => {
-				// Then
-				expect(this.inst.get(['x']).x).to.be.equal(45);
-				done();
-			});
-		});
-	});
+    it("The offset value should apply scale option", (done) => {
+      // Given
+      this.input.options.scale = 1;
+      // When
+      Simulator.gestures.pinch(
+        this.el,
+        {
+          duration: 500,
+          scale: 0.9,
+        },
+        () => {
+          // Then
+          expect(this.inst.get(["x"]).x).to.be.equal(45);
+          done();
+        }
+      );
+    });
+  });
 
-	describe("options test", function () {
-		beforeEach(() => {
-			this.inst = new PinchInput(sandbox());
-		});
-		afterEach(() => {
-			if (this.inst) {
-				this.inst.destroy();
-				this.inst = null;
-			}
-			cleanup();
-		});
-		it("should check hammerManager default Options", () => {
-			// Given
-			expect(this.inst.options.hammerManagerOptions).to.be.eql({
-				cssProps: {
-					userSelect: "none",
-					touchSelect: "none",
-					touchCallout: "none",
-					userDrag: "none",
-				}
-			});
-
-			// When
-			this.inst.connect({});
-
-			// Then
-			expect(this.inst.element.style.userSelect).to.be.equal("none");
-		});
-		it("should check hammerManager Options", () => {
-			// Given
-			this.inst.options.hammerManagerOptions.cssProps.userSelect = "auto";
-
-			// When
-			this.inst.connect({});
-
-			// Then
-			expect(this.inst.element.style.userSelect).to.be.equal("auto");
-		});
-	});
+  describe("options test", function () {
+    beforeEach(() => {
+      this.inst = new PinchInput(sandbox());
+    });
+    afterEach(() => {
+      if (this.inst) {
+        this.inst.destroy();
+        this.inst = null;
+      }
+      cleanup();
+    });
+  });
 });

--- a/test/unit/inputType/RotatePanInput.spec.js
+++ b/test/unit/inputType/RotatePanInput.spec.js
@@ -3,295 +3,284 @@ import { RotatePanInput } from "../../../src/inputType/RotatePanInput";
 import TestHelper from "./TestHelper";
 
 describe("RotatePanInput", () => {
-	let el;
-	let input;
-	let axes;
-	let clock;
+  let el;
+  let input;
+  let axes;
+  let clock;
 
-	async function testPanMove(MOVES) {
-		const resultAngles = [];
+  async function testPanMove(MOVES) {
+    const resultAngles = [];
 
-		for (let i = 0; i < MOVES.length; i++) {
-			const currAxes = MOVES[i].axes ? MOVES[i].axes : axes;
-			const currEl = MOVES[i].target ? MOVES[i].target : el;
+    for (let i = 0; i < MOVES.length; i++) {
+      const currAxes = MOVES[i].axes ? MOVES[i].axes : axes;
+      const currEl = MOVES[i].target ? MOVES[i].target : el;
 
-			currAxes.setTo({angle: 0});
+      currAxes.setTo({ angle: 0 });
 
-			await TestHelper.panOnElement(currEl, MOVES[i], {clock});
+      await TestHelper.panOnElement(currEl, MOVES[i], { clock });
 
-			resultAngles.push(currAxes.get()["angle"]);
-		};
+      resultAngles.push(currAxes.get()["angle"]);
+    }
 
-		// Then
-		resultAngles.forEach((angle, i) => {
-			expect(angle).to.be.closeTo(MOVES[i].expectedAngle, 0.001);
-		});
-	}
+    // Then
+    resultAngles.forEach((angle, i) => {
+      expect(angle).to.be.closeTo(MOVES[i].expectedAngle, 1);
+    });
+  }
 
-	beforeEach(() => {
-		clock = sinon.useFakeTimers();
+  beforeEach(() => {
+    clock = sinon.useFakeTimers();
 
-		el = sandbox();
-		el.style.position = "absolute";
-		el.style.left = "0px";
-		el.style.width = "201px";
-		el.style.height = "201px";
-		el.style.backgroundColor = "yellow";
+    el = sandbox();
+    el.style.position = "absolute";
+    el.style.left = "0px";
+    el.style.width = "201px";
+    el.style.height = "201px";
+    el.style.backgroundColor = "yellow";
 
-		input = new RotatePanInput(el, {
-			inputType: ["touch", "mouse"],
-		});
+    input = new RotatePanInput(el, {
+      inputType: ["touch", "mouse"],
+    });
 
-		axes = new Axes({
-			angle: {
-				range: [-360, 360]
-			}
-		}).on("change", (e) => {
-			// console.log("changed anlge:", e.pos.angle);
-		});
+    axes = new Axes({
+      angle: {
+        range: [-360, 360],
+      },
+    });
 
-		axes.connect("angle", input);
-		axes.setTo({"angle": 0});
-	});
+    axes.connect("angle", input);
+    axes.setTo({ angle: 0 });
+  });
 
-	afterEach(() => {
-		clock.restore();
+  afterEach(() => {
+    clock.restore();
 
-		if (axes) {
-			axes.destroy();
-			axes = null;
-		}
-		cleanup();
-	});
+    if (axes) {
+      axes.destroy();
+      axes = null;
+    }
+    cleanup();
+  });
 
-	it("should change angle by distance", async () => {
-		// Given, When
-		// width & height is 201px, 1px is pixel for axis
-		// First I tested with 200px, therefore mid point(axis) is 99.5px,
-		// But 99.5px is assumed as 100px on Chrome test. So each quadrant has different size.
-		// It's not intend.
-		const MOVE_HORIZONTALLY_HALF_AT_TOP = {
-			pos: [100, 0],	// Mid index of width 201 is 100 (201 - 1 / 2 )
-			deltaX: 100,		// Until 200
-			deltaY: 0,
-			duration: 2000,
-			expectedAngle: 45
-		};
+  it("should change angle by distance", async () => {
+    // Given, When
+    // width & height is 201px, 1px is pixel for axis
+    // First I tested with 200px, therefore mid point(axis) is 99.5px,
+    // But 99.5px is assumed as 100px on Chrome test. So each quadrant has different size.
+    // It's not intend.
+    const MOVE_HORIZONTALLY_HALF_AT_TOP = {
+      pos: [100, 0], // Mid index of width 201 is 100 (201 - 1 / 2 )
+      deltaX: 100, // Until 200
+      deltaY: 0,
+      duration: 2000,
+      expectedAngle: 45,
+    };
 
-		const MOVE_HORIZONTALLY_FULL_AT_TOP = {
-			pos: [0, 0],
-			deltaX: 200,
-			deltaY: 0,
-			duration: 3000,
-			expectedAngle: 90
-		};
+    const MOVE_HORIZONTALLY_FULL_AT_TOP = {
+      pos: [0, 0],
+      deltaX: 200,
+      deltaY: 0,
+      duration: 3000,
+      expectedAngle: 90,
+    };
 
-		const MOVE_VERTICALLY_HALF_AT_LEFT = {
-			pos: [0, 0],
-			deltaX: 0,
-			deltaY: 100,
-			duration: 2000,
-			expectedAngle: -45
-		};
+    const MOVE_VERTICALLY_HALF_AT_LEFT = {
+      pos: [0, 0],
+      deltaX: 0,
+      deltaY: 100,
+      duration: 2000,
+      expectedAngle: -45,
+    };
 
-		const MOVE_VERTICALLY_HALF_AT_RIGHT = {
-			pos: [200, 0],
-			deltaX: 0,
-			deltaY: 100,
-			duration: 2000,
-			expectedAngle: 45
-		};
+    const MOVE_VERTICALLY_HALF_AT_RIGHT = {
+      pos: [200, 0],
+      deltaX: 0,
+      deltaY: 100,
+      duration: 2000,
+      expectedAngle: 45,
+    };
 
-		const MOVES = [
-			MOVE_HORIZONTALLY_HALF_AT_TOP,
-			MOVE_HORIZONTALLY_FULL_AT_TOP,
-			MOVE_VERTICALLY_HALF_AT_LEFT,
-			MOVE_VERTICALLY_HALF_AT_RIGHT
-		];
+    const MOVES = [
+      MOVE_HORIZONTALLY_HALF_AT_TOP,
+      MOVE_HORIZONTALLY_FULL_AT_TOP,
+      MOVE_VERTICALLY_HALF_AT_LEFT,
+      MOVE_VERTICALLY_HALF_AT_RIGHT,
+    ];
 
-		await testPanMove(MOVES);
-	});
+    await testPanMove(MOVES);
+  });
 
-	it("should return angle correctly when crossing the axis boundaries", async () => {
-		const RADIUS = 100;
-		const MOVE_HORIZONTALLY_HALF_AT_TOP = {
-			pos: [50, 0],	// Mid index of width 201 is 100 (201 - 1 / 2 )
-			deltaX: 100,		// Until 200
-			deltaY: 0,
-			duration: 2000,
-			expectedAngle: Math.atan2(100 / 2, RADIUS) * 2 * 180 / Math.PI
-		};
-		const MOVE_HORIZONTALLY_HALF_AT_BOTTOM = {
-			pos: [50, 200],	// Mid index of width 201 is 100 (201 - 1 / 2 )
-			deltaX: 100,		// Until 200
-			deltaY: 0,
-			duration: 2000,
-			expectedAngle: -Math.atan2(100 / 2, RADIUS) * 2 * 180 / Math.PI
-		};
-		const MOVE_VERTICALLY_HALF_AT_LEFT = {
-			pos: [0, 50],	// Mid index of width 201 is 100 (201 - 1 / 2 )
-			deltaX: 0,		// Until 200
-			deltaY: 100,
-			duration: 2000,
-			expectedAngle: -Math.atan2(100 / 2, RADIUS) * 2 * 180 / Math.PI
-		};
-		const MOVE_VERTICALLY_HALF_AT_RIGHT = {
-			pos: [200, 50],	// Mid index of width 201 is 100 (201 - 1 / 2 )
-			deltaX: 0,		// Until 200
-			deltaY: 100,
-			duration: 2000,
-			expectedAngle: Math.atan2(100 / 2, RADIUS) * 2 * 180 / Math.PI
-		};
+  it("should return angle correctly when crossing the axis boundaries", async () => {
+    const RADIUS = 100;
+    const MOVE_HORIZONTALLY_HALF_AT_TOP = {
+      pos: [50, 0], // Mid index of width 201 is 100 (201 - 1 / 2 )
+      deltaX: 100, // Until 200
+      deltaY: 0,
+      duration: 2000,
+      expectedAngle: (Math.atan2(100 / 2, RADIUS) * 2 * 180) / Math.PI,
+    };
+    const MOVE_HORIZONTALLY_HALF_AT_BOTTOM = {
+      pos: [50, 200], // Mid index of width 201 is 100 (201 - 1 / 2 )
+      deltaX: 100, // Until 200
+      deltaY: 0,
+      duration: 2000,
+      expectedAngle: (-Math.atan2(100 / 2, RADIUS) * 2 * 180) / Math.PI,
+    };
+    const MOVE_VERTICALLY_HALF_AT_LEFT = {
+      pos: [0, 50], // Mid index of width 201 is 100 (201 - 1 / 2 )
+      deltaX: 0, // Until 200
+      deltaY: 100,
+      duration: 2000,
+      expectedAngle: (-Math.atan2(100 / 2, RADIUS) * 2 * 180) / Math.PI,
+    };
+    const MOVE_VERTICALLY_HALF_AT_RIGHT = {
+      pos: [200, 50], // Mid index of width 201 is 100 (201 - 1 / 2 )
+      deltaX: 0, // Until 200
+      deltaY: 100,
+      duration: 2000,
+      expectedAngle: (Math.atan2(100 / 2, RADIUS) * 2 * 180) / Math.PI,
+    };
 
-		const MOVES = [
-			MOVE_HORIZONTALLY_HALF_AT_TOP,
-			MOVE_HORIZONTALLY_HALF_AT_BOTTOM,
-			MOVE_VERTICALLY_HALF_AT_LEFT,
-			MOVE_VERTICALLY_HALF_AT_RIGHT
-		];
+    const MOVES = [
+      MOVE_HORIZONTALLY_HALF_AT_TOP,
+      MOVE_HORIZONTALLY_HALF_AT_BOTTOM,
+      MOVE_VERTICALLY_HALF_AT_LEFT,
+      MOVE_VERTICALLY_HALF_AT_RIGHT,
+    ];
 
-		// Then
-		await testPanMove(MOVES);
-	});
+    // Then
+    await testPanMove(MOVES);
+  });
 
-	it("should be animated by release speed", async () => {
-		// Mouse speed cannot be acquired when fakeTimer is working.
-		clock.restore();
+  it("should be animated by release speed", async () => {
+    // Mouse speed cannot be acquired when fakeTimer is working.
+    clock.restore();
 
-		// Given, When
-		const MOVE_HORIZONTALLY_SLOW = {
-			pos: [50, 0],	// Mid index of width 201 is 100 (201 - 1 / 2 )
-			deltaX: 100,		// Until 200
-			deltaY: 0,
-			duration: 2000
-		};
-		const MOVE_HORIZONTALLY_FAST = {
-			pos: [50, 0],	// Mid index of width 201 is 100 (201 - 1 / 2 )
-			deltaX: 100,		// Until 200
-			deltaY: 0,
-			duration: 1000
-		};
-		const MOVES = [
-			MOVE_HORIZONTALLY_SLOW,
-			MOVE_HORIZONTALLY_FAST
-		];
+    // Given, When
+    const MOVE_HORIZONTALLY_SLOW = {
+      pos: [50, 0], // Mid index of width 201 is 100 (201 - 1 / 2 )
+      deltaX: 100, // Until 200
+      deltaY: 0,
+      duration: 2000,
+    };
+    const MOVE_HORIZONTALLY_FAST = {
+      pos: [50, 0], // Mid index of width 201 is 100 (201 - 1 / 2 )
+      deltaX: 100, // Until 200
+      deltaY: 0,
+      duration: 1000,
+    };
+    const MOVES = [MOVE_HORIZONTALLY_SLOW, MOVE_HORIZONTALLY_FAST];
 
-		const resultAngles = [];
-		for (let i = 0; i < MOVES.length; i++) {
-			axes.setTo({angle: 0});
+    const resultAngles = [];
+    for (let i = 0; i < MOVES.length; i++) {
+      axes.setTo({ angle: 0 });
 
-			await TestHelper.panOnElement(el, MOVES[i], {clock});
+      await TestHelper.panOnElement(el, MOVES[i], { clock });
 
-			resultAngles.push(axes.get()["angle"]);
-		};
+      resultAngles.push(axes.get()["angle"]);
+    }
 
-		// Then
-		expect(resultAngles[0] < resultAngles[1]).to.be.true;
-	});
+    // Then
+    expect(resultAngles[0] < resultAngles[1]).to.be.true;
+  });
 
-	it("should return correct angle by area size.", async () => {
-		const smElement = sandbox();
-		smElement.style.position = "absolute";
-		smElement.style.left = "0px";
-		smElement.style.top = "300px";
-		smElement.style.width = "101px";
-		smElement.style.height = "101px";
-		smElement.style.backgroundColor = "yellow";
+  it("should return correct angle by area size.", async () => {
+    const smElement = sandbox();
+    smElement.style.position = "absolute";
+    smElement.style.left = "0px";
+    smElement.style.top = "300px";
+    smElement.style.width = "101px";
+    smElement.style.height = "101px";
+    smElement.style.backgroundColor = "yellow";
 
-		const smInput = new RotatePanInput(smElement, {
-			inputType: ["touch", "mouse"],
-		});
+    const smInput = new RotatePanInput(smElement, {
+      inputType: ["touch", "mouse"],
+    });
 
-		const smAxes = new Axes({
-			angle: {
-				range: [-360, 360]
-			}
-		});
+    const smAxes = new Axes({
+      angle: {
+        range: [-360, 360],
+      },
+    });
 
-		smAxes.connect("angle", smInput);
-		smAxes.setTo({"angle": 0});
+    smAxes.connect("angle", smInput);
+    smAxes.setTo({ angle: 0 });
 
-		axes.setTo({angle: 0});
+    axes.setTo({ angle: 0 });
 
-		// When
-		const MOVE_HORIZONTALLY_ON_BIG = {
-			axes: axes,
-			target: el,
-			pos: [100, 0],	// Mid index of width 201 is 100 (201 - 1 / 2 )
-			deltaX: 100,		// Until 200
-			deltaY: 0,
-			duration: 2000,
-			expectedAngle: 45
-		};
+    // When
+    const MOVE_HORIZONTALLY_ON_BIG = {
+      axes: axes,
+      target: el,
+      pos: [100, 0], // Mid index of width 201 is 100 (201 - 1 / 2 )
+      deltaX: 100, // Until 200
+      deltaY: 0,
+      duration: 2000,
+      expectedAngle: 45,
+    };
 
-		const MOVE_HORIZONTALLY_ON_SMALL = {
-			axes: smAxes,
-			target: smElement,
-			pos: [50, 0],	// Mid index of width 101 is 50 (101 - 1 / 2 )
-			deltaX: 50,		// Until 100
-			deltaY: 0,
-			duration: 2000,
-			expectedAngle: 45
-		};
+    const MOVE_HORIZONTALLY_ON_SMALL = {
+      axes: smAxes,
+      target: smElement,
+      pos: [50, 0], // Mid index of width 101 is 50 (101 - 1 / 2 )
+      deltaX: 50, // Until 100
+      deltaY: 0,
+      duration: 2000,
+      expectedAngle: 45,
+    };
 
-		const MOVES = [
-			MOVE_HORIZONTALLY_ON_BIG,
-			MOVE_HORIZONTALLY_ON_SMALL
-		];
+    const MOVES = [MOVE_HORIZONTALLY_ON_BIG, MOVE_HORIZONTALLY_ON_SMALL];
 
-		// Then
-		await testPanMove(MOVES);
-	});
+    // Then
+    await testPanMove(MOVES);
+  });
 
-	it("should return correct angle by responsive", async () => {
-		const resultAngles = [];
-		const MOVE_HORIZONTALLY_ON_BIG = {
-			axes: axes,
-			target: el,
-			pos: [100, 0],	// Mid index of width 201 is 100 (201 - 1 / 2 )
-			deltaX: 100,		// Until 200
-			deltaY: 0,
-			duration: 2000,
-			expectedAngle: 45
-		};
+  it("should return correct angle by responsive", async () => {
+    const resultAngles = [];
+    const MOVE_HORIZONTALLY_ON_BIG = {
+      axes: axes,
+      target: el,
+      pos: [100, 0], // Mid index of width 201 is 100 (201 - 1 / 2 )
+      deltaX: 100, // Until 200
+      deltaY: 0,
+      duration: 2000,
+      expectedAngle: 45,
+    };
 
-		axes.setTo({angle: 0});
+    axes.setTo({ angle: 0 });
 
-		await TestHelper.panOnElement(el, MOVE_HORIZONTALLY_ON_BIG, {clock});
+    await TestHelper.panOnElement(el, MOVE_HORIZONTALLY_ON_BIG, { clock });
 
-		resultAngles.push(axes.get()["angle"]);
+    resultAngles.push(axes.get()["angle"]);
 
-		// When
-		/**
-		 * element size is change.
-		 */
-		el.style.width = "101px";
-		el.style.height = "101px";
+    // When
+    /**
+     * element size is change.
+     */
+    el.style.width = "101px";
+    el.style.height = "101px";
 
-		const MOVE_HORIZONTALLY_ON_SMALL = {
-			axes: axes,
-			target: el,
-			pos: [50, 0],	// Mid index of width 101 is 50 (101 - 1 / 2 )
-			deltaX: 50,		// Until 100
-			deltaY: 0,
-			duration: 2000,
-			expectedAngle: 45
-		};
+    const MOVE_HORIZONTALLY_ON_SMALL = {
+      axes: axes,
+      target: el,
+      pos: [50, 0], // Mid index of width 101 is 50 (101 - 1 / 2 )
+      deltaX: 50, // Until 100
+      deltaY: 0,
+      duration: 2000,
+      expectedAngle: 45,
+    };
 
-		axes.setTo({angle: 0});
+    axes.setTo({ angle: 0 });
 
-		await TestHelper.panOnElement(el, MOVE_HORIZONTALLY_ON_SMALL, {clock});
+    await TestHelper.panOnElement(el, MOVE_HORIZONTALLY_ON_SMALL, { clock });
 
-		resultAngles.push(axes.get()["angle"]);
+    resultAngles.push(axes.get()["angle"]);
 
-		const MOVES = [
-			MOVE_HORIZONTALLY_ON_BIG,
-			MOVE_HORIZONTALLY_ON_SMALL
-		];
+    const MOVES = [MOVE_HORIZONTALLY_ON_BIG, MOVE_HORIZONTALLY_ON_SMALL];
 
-		// Then
-		resultAngles.forEach((angle, i) => {
-			expect(angle).to.be.closeTo(MOVES[i].expectedAngle, 0.001);
-		});
-	});
+    // Then
+    resultAngles.forEach((angle, i) => {
+      expect(angle).to.be.closeTo(MOVES[i].expectedAngle, 1);
+    });
+  });
 });

--- a/test/unit/inputType/WheelInput.spec.js
+++ b/test/unit/inputType/WheelInput.spec.js
@@ -1,13 +1,11 @@
-import Hammer from "@egjs/hammerjs";
 import TestHelper from "./TestHelper";
 import Axes from "../../../src/Axes.ts";
-import {WheelInput} from "../../../src/inputType/WheelInput";
-import {UNIQUEKEY} from "../../../src/inputType/InputType";
+import { WheelInput } from "../../../src/inputType/WheelInput";
 
 describe("WheelInput", () => {
-  describe("instance method", function() {
+  describe("instance method", function () {
     beforeEach(() => {
-      this.inst = new WheelInput(sandbox());
+      this.inst = new WheelInput(sandbox(), { releaseDelay: 50 });
     });
     afterEach(() => {
       if (this.inst) {
@@ -41,20 +39,20 @@ describe("WheelInput", () => {
       expect(this._timer).to.be.not.exist;
 
       this.inst = null;
-		});
+    });
   });
-  describe("enable/disable", function() {
+  describe("enable/disable", function () {
     beforeEach(() => {
       this.el = sandbox();
-      this.inst = new WheelInput(this.el);
+      this.inst = new WheelInput(this.el, { releaseDelay: 50 });
       this.inst.mapAxes(["x"]);
       this.observer = {
         release() {},
         hold() {},
         change() {},
         options: {
-          deceleration: 0.0001
-        }
+          deceleration: 0.0001,
+        },
       };
     });
     afterEach(() => {
@@ -69,85 +67,99 @@ describe("WheelInput", () => {
       // Given
       // When
       // Then
-      expect(this.inst.isEnable()).to.be.false;
+      expect(this.inst.isEnabled()).to.be.false;
 
       // When
       this.inst.disable();
 
       // Then
-      expect(this.inst.isEnable()).to.be.false;
+      expect(this.inst.isEnabled()).to.be.false;
 
       // When
       this.inst.enable();
 
       // Then
-      expect(this.inst.isEnable()).to.be.true;
+      expect(this.inst.isEnabled()).to.be.true;
 
       // When (after connection)
       this.inst.connect(this.observer);
       this.inst.enable();
 
       // Then
-      expect(this.inst.isEnable()).to.be.true;
+      expect(this.inst.isEnabled()).to.be.true;
     });
-	});
+  });
 
-	describe("simple wheel event test", function() {
-		beforeEach(() => {
-			this.el = sandbox();
-			this.input = new WheelInput(this.el);
-			this.inst = new Axes({
-				x: {
-					range: [10, 120]
-				}
-			});
-			this.inst.connect(["x"], this.input);
-		});
+  describe("simple wheel event test", function () {
+    beforeEach(() => {
+      this.el = sandbox();
+      this.input = new WheelInput(this.el, { releaseDelay: 50 });
+      this.inst = new Axes(
+        {
+          x: {
+            range: [10, 120],
+          },
+        },
+        {
+          maximumDuration: 30,
+        }
+      );
+      this.inst.connect(["x"], this.input);
+    });
 
-		afterEach(() => {
-			this.el = null;
-			if (this.inst) {
-				this.inst.destroy();
-				this.inst = null;
-			}
-			if (this.input) {
-				this.input.destroy();
-				this.input = null;
-			}
-			cleanup();
-		});
+    afterEach(() => {
+      this.el = null;
+      if (this.inst) {
+        this.inst.destroy();
+        this.inst = null;
+      }
+      if (this.input) {
+        this.input.destroy();
+        this.input = null;
+      }
+      cleanup();
+    });
 
-		it("should cleanup timer when it is detached/destroy (after firing wheel event)", done => {
-			// Given
-			const deltaY = 300;
-			// When
-			// 1. Scroll
-			TestHelper.wheelVertical(this.el, deltaY, () => {
-				// 2. detach & destroy wheel input
-				this.inst.disconnect(this.input);
-				this.input.destroy();
-				this.input = null;
-				// 3. create new wheel input
-				this.input = new WheelInput(this.el);
-				this.inst.connect(["x"], this.input);
+    it("should cleanup timer when it is detached/destroy (after firing wheel event)", (done) => {
+      // Given
+      const deltaY = 300;
+      // When
+      // 1. Scroll
+      TestHelper.wheelVertical(this.el, deltaY, () => {
+        // 2. detach & destroy wheel input
+        this.inst.disconnect(this.input);
+        this.input.destroy();
+        this.input = null;
+        // 3. create new wheel input
+        this.input = new WheelInput(this.el, { releaseDelay: 50 });
+        this.inst.connect(["x"], this.input);
 
-				// Then -> script error should not be occur.
-				setTimeout(done, 50);
-			});
-		});
-	});
+        // Then -> script error should not be occur.
+        setTimeout(done, 50);
+      });
+    });
+  });
 
-  [1,2,4].forEach(function(scale) {
-    [true, false].forEach(function(useNormalized) {
-      describe(`wheel event test(useNormalized: ${useNormalized})`, function() {
+  [1, 2, 4].forEach(function (scale) {
+    [true, false].forEach(function (useNormalized) {
+      describe(`wheel event test(useNormalized: ${useNormalized})`, function () {
         beforeEach(() => {
           this.el = sandbox();
-          this.input = new WheelInput(this.el, {useNormalized: useNormalized, scale: scale});
-          this.inst = new Axes({
-            x: {
-              range: [10, 120]
-            }
+          this.input = new WheelInput(this.el, {
+            useNormalized: useNormalized,
+            scale: scale,
+            releaseDelay: 50,
           });
+          this.inst = new Axes(
+            {
+              x: {
+                range: [10, 120],
+              },
+            },
+            {
+              maximumDuration: 0,
+            }
+          );
           this.inst.connect(["x"], this.input);
         });
 
@@ -163,21 +175,21 @@ describe("WheelInput", () => {
           }
           cleanup();
         });
-        [-1,-3,-5,-9].forEach(d => {
-          it(`should check delta test (delta: ${d}, useNormalized: ${useNormalized})`, done => {
-            this.inst.on("change", ({pos, delta}) => {
-                if (delta.x === 0) {
-                  return;
-                }
+        [-1, -3, -5, -9].forEach((d) => {
+          it(`should check delta test (delta: ${d}, useNormalized: ${useNormalized})`, (done) => {
+            this.inst.on("change", ({ pos, delta }) => {
+              if (delta.x === 0) {
+                return;
+              }
               const sign = 1;
-              expect(delta.x).to.be.equals(scale * (useNormalized ? sign : (sign * Math.abs(d))));
+              expect(delta.x).to.be.equals(
+                scale * (useNormalized ? sign : sign * Math.abs(d))
+              );
             });
-            this.inst.on("release", e => {
+            this.inst.on("release", (e) => {
               done();
             });
-            TestHelper.wheelVertical(this.el, d, () => {
-
-            });
+            TestHelper.wheelVertical(this.el, d, () => {});
           });
         });
         it("no event triggering when disconnected", (done) => {
@@ -185,8 +197,7 @@ describe("WheelInput", () => {
           const deltaY = 1;
           let changeTriggered = false;
 
-          this.inst
-          .on("change", () => {
+          this.inst.on("change", () => {
             changeTriggered = true;
           });
           this.inst.disconnect();
@@ -204,8 +215,7 @@ describe("WheelInput", () => {
           const deltaY = 0;
           let changeTriggered = false;
 
-          this.inst
-          .on("change", () => {
+          this.inst.on("change", () => {
             changeTriggered = true;
           });
 
@@ -219,32 +229,41 @@ describe("WheelInput", () => {
 
         it("triggering order test", (done) => {
           // Given
-          const deltaY = 1;
+          const deltaY = -1;
           const eventLog = [];
-          const eventLogAnswer = ["hold", "change", "change", "release"];
 
           this.inst
-          .on("hold", () => {
-            eventLog.push("hold");
-          }).on("change", () => {
-            eventLog.push("change");
-          }).on("release", () => {
-            eventLog.push("release");
-          });
+            .on("hold", () => {
+              eventLog.push("hold");
+            })
+            .on("change", () => {
+              eventLog.push("change");
+            })
+            .on("release", () => {
+              eventLog.push("release");
+            });
 
           // When
           TestHelper.wheelVertical(this.el, deltaY, () => {
-            setTimeout(()=> {
+            setTimeout(() => {
               TestHelper.wheelVertical(this.el, deltaY, () => {
-                setTimeout(()=> {
+                setTimeout(() => {
                   // Then
-                  expect(eventLog).to.be.deep.equal(eventLogAnswer);
+                  eventLog.forEach((log, index) => {
+                    if (index === 0) {
+                      expect(eventLog[index]).to.be.deep.equal("hold");
+                    } else if (index === eventLog.length - 1) {
+                      expect(eventLog[index]).to.be.deep.equal("release");
+                    } else {
+                      expect(eventLog[index]).to.be.deep.equal("change");
+                    }
+                  });
                   done();
                 }, 60);
               });
             }, 20);
           });
-				});
+        });
       });
     });
   });

--- a/test/unit/utils.spec.js
+++ b/test/unit/utils.spec.js
@@ -1,83 +1,92 @@
-import { $, toArray, equal, getDecimalPlace, roundNumber } from "../../src/utils";
+import {
+  $,
+  toArray,
+  equal,
+  getDecimalPlace,
+  roundNumber,
+} from "../../src/utils";
 
 describe("Util Test", function () {
-	beforeEach(() => {
-		this.el = sandbox();
-	});
-	afterEach(() => {
-		cleanup();
-	});
-	it("should check 'equal' method", () => {
-		// Given
-		let target1 = {
-			x: 10,
-			y: 20,
-			z: 30
-		};
-		let target2 = {
-			x: 10,
-			y: 20
-		}
+  beforeEach(() => {
+    this.el = sandbox();
+  });
+  afterEach(() => {
+    cleanup();
+  });
+  it("should check 'equal' method", () => {
+    // Given
+    let target1 = {
+      x: 10,
+      y: 20,
+      z: 30,
+    };
+    let target2 = {
+      x: 10,
+      y: 20,
+    };
 
-		// Then
-		expect(equal(target1, target2)).to.be.false;
-		expect(equal(target2, target1)).to.be.true;
-	});
-	it("should check `$` method", () => {
-		// Given
-		// When
-		const complicatedHTML = "<div class='item'><div class='thumbnail'><img class='img-rounded' src='#' /><div class='caption'><p><a href='http://www.naver.com'></a></p></div></div></div>";
-		const div = complicatedHTML; // string
-		const divs = [complicatedHTML, complicatedHTML];
+    // Then
+    expect(equal(target1, target2)).to.be.false;
+    expect(equal(target2, target1)).to.be.true;
+  });
+  it("should check `$` method", () => {
+    // Given
+    // When
+    const complicatedHTML =
+      "<div class='item'><div class='thumbnail'><img class='img-rounded' src='#' /><div class='caption'><p><a href='http://www.naver.com'></a></p></div></div></div>";
+    const div = complicatedHTML; // string
+    const divs = [complicatedHTML, complicatedHTML];
 
-		// Then
-		expect($(window)).to.be.equal(window);
-		expect($(document)).to.be.equal(document);
-		expect($(div) instanceof HTMLElement).to.be.true;
-		expect($($(div)) instanceof HTMLElement).to.be.true;
-		expect($(divs, true).length).to.be.equal(2);
-		expect($("#sandbox")).to.be.equal(this.el);
-		expect(this.el).to.be.equal(this.el);
-	});
-	it("should check `toArray` method", () => {
-		// Given
-		this.el.innerHTML = `<div>content1</div>
+    // Then
+    expect($(window)).to.be.equal(window);
+    expect($(document)).to.be.equal(document);
+    expect($(div) instanceof HTMLElement).to.be.true;
+    expect($($(div)) instanceof HTMLElement).to.be.true;
+    expect($(divs, true).length).to.be.equal(2);
+    expect($("#sandbox")).to.be.equal(this.el);
+    expect(this.el).to.be.equal(this.el);
+  });
+  it("should check `toArray` method", () => {
+    // Given
+    this.el.innerHTML = `<div>content1</div>
     <div>content2</div>
     <div>content3</div>`;
-		// When
-		const useSlice = Array.prototype.slice.call(this.el.childNodes);
+    // When
+    const useSlice = Array.prototype.slice.call(this.el.childNodes);
 
-		// Then
-		expect(toArray(this.el.childNodes)).to.be.eql(useSlice);
-	});
+    // Then
+    expect(toArray(this.el.childNodes)).to.be.eql(useSlice);
+  });
 
-	it("should roundNumber by round unit", () => {
-		// Given
-		const targetVal = 99.123456789;
-		const inputValues = [100, 10, 1, 0, 0.1, 0.01, 0.001, 0.0001];
-		const expectValues = [100, 100, 99, 0, 99.1, 99.12, 99.123, 99.1235/* round */];
-		// Ref. Same result : https://codepen.io/GreenSock/pen/mLMYwM
+  it("should roundNumber by round unit", () => {
+    // Given
+    const targetVal = 99.123456789;
+    const inputValues = [100, 10, 1, 0, 0.1, 0.01, 0.001, 0.0001];
+    const expectValues = [
+      100, 100, 99, 0, 99.1, 99.12, 99.123, 99.1235 /* round */,
+    ];
+    // Ref. Same result : https://codepen.io/GreenSock/pen/mLMYwM
 
-		// When
-		const result = inputValues.map(input => roundNumber(targetVal, input));
+    // When
+    const result = inputValues.map((input) => roundNumber(targetVal, input));
 
-		// Then
-		expectValues.forEach((expectVal, i) => {
-			expect(result[i]).to.be.equal(expectVal);
-		});
-	});
+    // Then
+    expectValues.forEach((expectVal, i) => {
+      expect(result[i]).to.be.equal(expectVal);
+    });
+  });
 
-	it("should return decimal place", () => {
-		// Given
-		const inputValues = [1e+3, 100, 10, 1, 0, 0.1, 0.01, 0.001, 0.0001, 1e-5];
-		const expectValues = [0, 0, 0, 0, 0, 1, 2, 3, 4, 5];
+  it("should return decimal place", () => {
+    // Given
+    const inputValues = [1e3, 100, 10, 1, 0, 0.1, 0.01, 0.001, 0.0001, 1e-5];
+    const expectValues = [0, 0, 0, 0, 0, 1, 2, 3, 4, 5];
 
-		// When
-		const result = inputValues.map(input => getDecimalPlace(input));
+    // When
+    const result = inputValues.map((input) => getDecimalPlace(input));
 
-		// Then
-		expectValues.forEach((expectVal, i) => {
-			expect(expectVal).to.be.equal(result[i]);
-		});
-	});
+    // Then
+    expectValues.forEach((expectVal, i) => {
+      expect(expectVal).to.be.equal(result[i]);
+    });
+  });
 });


### PR DESCRIPTION
## Details
Unit test errors caused by recent changes have been fixed.
 - Use newest method names in unit tests.
 - Update WheelInput test for smooth WheelInput.

Codes that did not match the unit test's behavior have been fixed.
 - Touch event by hammer simulator cannot be detected by `instanceof TouchEvent`, use `hasOwnProperty("touches")` instead.
 - Some subsequent event at the test may have a deltaTime of zero. Calculate velocity to zero when deltaTime is 0.
 - Fix invalid method names.
 - [IOS Safari specific gesture](https://github.com/naver/egjs-axes/blob/master/src/inputType/PanInput.ts#L286-L320) was not working properly.

The remaining errors are as follows, and they will be fixed ASAP after v3 release.
 - Test cases which uses `hammer.handlers["panstart"]` with sinon.
 - Axes custom events not working properly.