### PR TITLE
fix: correct unit tests with resolving event.stop bug

### DIFF
--- a/src/EventManager.ts
+++ b/src/EventManager.ts
@@ -205,7 +205,8 @@ export class EventManager {
       input: option?.input || eventInfo?.input || null,
       set: inputEvent ? this._createUserControll(moveTo.pos) : () => {}, // eslint-disable-line @typescript-eslint/no-empty-function
     };
-    const result = this._axes.trigger(new ComponentEvent("change", param));
+    const event = new ComponentEvent("change", param);
+    this._axes.trigger(event);
 
     if (inputEvent) {
       axisManager.set(
@@ -213,7 +214,7 @@ export class EventManager {
       );
     }
 
-    return result;
+    return !event.isCanceled();
   }
 
   /**
@@ -253,7 +254,7 @@ export class EventManager {
    * });
    * ```
    */
-  public triggerAnimationStart(param: AnimationParam): Axes {
+  public triggerAnimationStart(param: AnimationParam): boolean {
     const { roundPos, roundDepa } = this._getRoundPos(
       param.destPos,
       param.depaPos
@@ -261,9 +262,12 @@ export class EventManager {
     param.destPos = roundPos;
     param.depaPos = roundDepa;
     param.setTo = this._createUserControll(param.destPos, param.duration);
-    return this._axes.trigger(
-      new ComponentEvent("animationStart", param as OnAnimationStart)
+    const event = new ComponentEvent(
+      "animationStart",
+      param as OnAnimationStart
     );
+    this._axes.trigger(event);
+    return !event.isCanceled();
   }
 
   /**

--- a/src/InputObserver.ts
+++ b/src/InputObserver.ts
@@ -131,7 +131,7 @@ export class InputObserver implements InputTypeObserver {
     const depaPos: Axis = this._axisManager.get();
     const displacement = this._animationManager.getDisplacement(velocity);
     const offset = toAxis(input.axes, displacement);
-    const destPos: Axis = this._axisManager.get(
+    let destPos: Axis = this._axisManager.get(
       this._axisManager.map(offset, (v, opt, k) => {
         if (opt.circular && (opt.circular[0] || opt.circular[1])) {
           return pos[k] + v;
@@ -151,6 +151,9 @@ export class InputObserver implements InputTypeObserver {
       inputDuration
     );
 
+    if (duration === 0) {
+      destPos = { ...depaPos };
+    }
     // prepare params
     const param: AnimationParam = {
       depaPos,

--- a/src/inputType/PanInput.ts
+++ b/src/inputType/PanInput.ts
@@ -308,6 +308,11 @@ export class PanInput implements InputType {
 
   private _attachEvent(observer: InputTypeObserver) {
     const activeInput = convertInputType(this.options.inputType);
+    if (!activeInput) {
+      throw new Error(
+        "There is currently no inputType available for current device. There must be at least one available inputType."
+      );
+    }
     this._observer = observer;
     this._enabled = true;
     this._activeInput = activeInput;

--- a/src/inputType/PanInput.ts
+++ b/src/inputType/PanInput.ts
@@ -312,7 +312,7 @@ export class PanInput implements InputType {
     this._enabled = true;
     this._activeInput = activeInput;
     activeInput?.start.forEach((event) => {
-      this.element.addEventListener(event, this._onPanstart, false);
+      this.element?.addEventListener(event, this._onPanstart, false);
     });
     activeInput?.move.forEach((event) => {
       window.addEventListener(event, this._onPanmove, false);
@@ -325,7 +325,7 @@ export class PanInput implements InputType {
   private _detachEvent() {
     const activeInput = this._activeInput;
     activeInput?.start.forEach((event) => {
-      this.element.removeEventListener(event, this._onPanstart, false);
+      this.element?.removeEventListener(event, this._onPanstart, false);
     });
     activeInput?.move.forEach((event) => {
       window.removeEventListener(event, this._onPanmove, false);

--- a/src/inputType/PinchInput.ts
+++ b/src/inputType/PinchInput.ts
@@ -173,6 +173,11 @@ export class PinchInput implements InputType {
 
   private _attachEvent(observer: InputTypeObserver) {
     const activeInput = convertInputType(this.options.inputType);
+    if (!activeInput) {
+      throw new Error(
+        "There is currently no inputType available for current device. There must be at least one available inputType."
+      );
+    }
     this._observer = observer;
     this._enabled = true;
     this._activeInput = activeInput;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -230,7 +230,7 @@ export const setCssProps = (
   originalCssProps?: { [key: string]: string }
 ): { [key: string]: string } => {
   const oldCssProps = {};
-  if (element.style) {
+  if (element && element.style) {
     const newCssProps = originalCssProps
       ? originalCssProps
       : PREVENT_SCROLL_CSSPROPS;

--- a/test/hammer-simulator.run.js
+++ b/test/hammer-simulator.run.js
@@ -1,2 +1,2 @@
-Simulator.setType('touch');
+Simulator.setType("touch");
 Simulator.events.touch.fakeSupport();

--- a/test/unit/AnimationManager.spec.js
+++ b/test/unit/AnimationManager.spec.js
@@ -630,5 +630,169 @@ describe("AnimationManager", () => {
         );
       });
     });
+    it("should check 'updateAnimation' method (update destPos)", (done) => {
+      // Given
+      const startHandler = sinon.spy();
+      const endHandler = sinon.spy();
+      axes.on({
+        animationStart: startHandler,
+        animationEnd: endHandler
+      });
+
+      // When
+      inst.setTo({ x: 60, y: 70 }, 200);
+
+      // Then
+      setTimeout(() => {
+        expect(startHandler.calledOnce).to.be.true;
+        expect(endHandler.called).to.be.false;
+
+        // When
+        inst.updateAnimation({ destPos: { x: 100, y: 100 }});
+      }, 100);
+      setTimeout(() => {
+        expect(startHandler.calledOnce).to.be.true;
+        expect(endHandler.calledOnce).to.be.true;
+        const result = inst.axisManager.get();
+
+        expect(result.x).to.be.equal(100);
+        expect(result.y).to.be.equal(100);
+        done();
+      }, 500);
+    });
+    it("should check 'updateAnimation' method (update duration)", (done) => {
+      // Given
+      const startHandler = sinon.spy();
+      const endHandler = sinon.spy();
+      axes.on({
+        animationStart: startHandler,
+        animationEnd: endHandler
+      });
+
+      // When
+      inst.setTo({ x: 60, y: 70 }, 200);
+
+      // Then
+      setTimeout(() => {
+        expect(startHandler.calledOnce).to.be.true;
+        expect(endHandler.called).to.be.false;
+
+        // When
+        inst.updateAnimation({ duration: 600 });
+      }, 100);
+      setTimeout(() => {
+        expect(endHandler.called).to.be.false;
+      }, 400);
+      setTimeout(() => {
+        expect(endHandler.calledOnce).to.be.true;
+        const result = inst.axisManager.get();
+
+        expect(result.x).to.be.equal(60);
+        expect(result.y).to.be.equal(70);
+        done();
+      }, 700);
+    });
+    it("should check 'updateAnimation' method (multiple time, update both)", (done) => {
+      // Given
+      const startHandler = sinon.spy();
+      const endHandler = sinon.spy();
+      axes.on({
+        animationStart: startHandler,
+        animationEnd: endHandler
+      });
+
+      // When
+      inst.setTo({ x: 100, y: 100 }, 200);
+
+      // Then
+      setTimeout(() => {
+        expect(startHandler.calledOnce).to.be.true;
+        expect(endHandler.called).to.be.false;
+
+        // When
+        inst.updateAnimation({ destPos: { x: 30, y: 30 }, duration: 400 });
+      }, 100);
+      setTimeout(() => {
+        expect(endHandler.called).to.be.false;
+
+        // When
+        inst.updateAnimation({ destPos: { x: 12.3456, y: 1.2345 }, duration: 300 });
+      }, 200);
+      setTimeout(() => {
+        expect(startHandler.calledOnce).to.be.true;
+        expect(endHandler.calledOnce).to.be.true;
+        const result = inst.axisManager.get();
+
+        expect(result.x).to.be.equal(12.3456);
+        expect(result.y).to.be.equal(1.2345);
+        done();
+      }, 500);
+    });
+    it("should check 'updateAnimation' method (restart: true)", (done) => {
+      // Given
+      const startHandler = sinon.spy();
+      const endHandler = sinon.spy();
+      axes.on({
+        animationStart: startHandler,
+        animationEnd: endHandler
+      });
+
+      // When
+      inst.setTo({ x: 10, y: 10 }, 200);
+
+      // Then
+      setTimeout(() => {
+        expect(startHandler.calledOnce).to.be.true;
+        expect(endHandler.called).to.be.false;
+
+        // When
+        inst.updateAnimation({ duration: 600, restart: true });
+      }, 100);
+      setTimeout(() => {
+        expect(endHandler.calledOnce).to.be.true;
+        expect(startHandler.calledTwice).to.be.true;
+      }, 400);
+      setTimeout(() => {
+        expect(startHandler.calledOnce).to.be.false;
+        expect(endHandler.calledOnce).to.be.false;
+        expect(endHandler.calledTwice).to.be.true;
+        const result = inst.axisManager.get();
+
+        expect(result.x).to.be.equal(10);
+        expect(result.y).to.be.equal(10);
+        done();
+      }, 700);
+    });
+    it("should check 'stopAnimation' method", (done) => {
+      // Given
+      const startHandler = sinon.spy();
+      const endHandler = sinon.spy();
+      axes.on({
+        animationStart: startHandler,
+        animationEnd: endHandler
+      });
+
+      // When
+      inst.setTo({ x: 100, y: 100 }, 400);
+
+      // Then
+      setTimeout(() => {
+        expect(startHandler.calledOnce).to.be.true;
+        expect(endHandler.called).to.be.false;
+
+        // When
+        inst.stopAnimation(["x", "y"]);
+      }, 100);
+      setTimeout(() => {
+        expect(endHandler.calledOnce).to.be.true;
+      }, 200);
+      setTimeout(() => {
+        const result = inst.axisManager.get();
+
+        expect(result.x).to.not.equal(100);
+        expect(result.y).to.not.equal(100);
+        done();
+      }, 500);
+    });
   });
 });

--- a/test/unit/AnimationManager.spec.js
+++ b/test/unit/AnimationManager.spec.js
@@ -4,36 +4,41 @@ import { InterruptManager } from "../../src/InterruptManager";
 import { EventManager } from "../../src/EventManager";
 import Axes from "../../src";
 
-describe("AnimationManager", function () {
-  describe("method test", function () {
+describe("AnimationManager", () => {
+	let inst;
+	let axes;
+	let axis;
+	let options;
+
+  describe("method test", () => {
     beforeEach(() => {
-      this.axis = {
+      axis = {
         x: {
           range: [0, 100],
           bounce: [50, 50],
-          circular: false,
+          circular: false
         },
         y: {
           range: [0, 200],
           bounce: [0, 0],
-          circular: false,
+          circular: false
         },
         z: {
           range: [-100, 200],
           bounce: [50, 0],
-          circular: true,
-        },
+          circular: true
+        }
       };
-      this.options = {
+      options = {
         deceleration: 0.0001,
         maximumDuration: 2000,
-        minimumDuration: 0,
+        minimumDuration: 0
       };
-      this.inst = new AnimationManager({
-        options: this.options,
-        interruptManager: new InterruptManager(this.options),
+      inst = new AnimationManager({
+        options: options,
+        interruptManager: new InterruptManager(options),
         eventManager: new EventManager(null),
-        axisManager: new AxisManager(this.axis, this.options),
+        axisManager: new AxisManager(axis, options)
       });
     });
     afterEach(() => {});
@@ -43,48 +48,48 @@ describe("AnimationManager", function () {
       // When
       const depaPos = {
         x: 0,
-        y: 0,
+        y: 0
       };
       const destPos = {
         x: 100,
-        y: 50,
+        y: 50
       };
 
       // When/Then
-      expect(this.inst.getDuration(depaPos, destPos)).to.be.equal(
+      expect(inst.getDuration(depaPos, destPos)).to.be.equal(
         1414.213562373095
       );
 
       // When (change option)
-      this.options.maximumDuration = 1200;
+      options.maximumDuration = 1200;
 
       // Then
-      expect(this.inst.getDuration(depaPos, destPos)).to.be.equal(1200);
+      expect(inst.getDuration(depaPos, destPos)).to.be.equal(1200);
 
       // When/Then
-      expect(this.inst.getDuration(depaPos, destPos, 1000)).to.be.equal(1000);
+      expect(inst.getDuration(depaPos, destPos, 1000)).to.be.equal(1000);
 
       // When/Then
-      expect(this.inst.getDuration(depaPos, destPos, 2000)).to.be.equal(1200);
+      expect(inst.getDuration(depaPos, destPos, 2000)).to.be.equal(1200);
     });
 
     it("should check 'getDisplacement' method", () => {
       // 0.001
-      this.options.deceleration = 0.001;
-      expect(this.inst.getDisplacement([1.5, 1])).to.be.eql([
-        1352.0817282989958, 901.3878188659972,
+      options.deceleration = 0.001;
+      expect(inst.getDisplacement([1.5, 1])).to.be.eql([
+        1352.0817282989958, 901.3878188659972
       ]);
-      expect(this.inst.getDisplacement([1, 1.5])).to.be.eql([
-        901.3878188659972, 1352.0817282989958,
+      expect(inst.getDisplacement([1, 1.5])).to.be.eql([
+        901.3878188659972, 1352.0817282989958
       ]);
 
       // 0.01
-      this.options.deceleration = 0.01;
-      expect(this.inst.getDisplacement([1.5, 1])).to.be.eql([
-        135.20817282989958, 90.13878188659973,
+      options.deceleration = 0.01;
+      expect(inst.getDisplacement([1.5, 1])).to.be.eql([
+        135.20817282989958, 90.13878188659973
       ]);
-      expect(this.inst.getDisplacement([1, 1.5])).to.be.eql([
-        90.13878188659973, 135.20817282989958,
+      expect(inst.getDisplacement([1, 1.5])).to.be.eql([
+        90.13878188659973, 135.20817282989958
       ]);
     });
 
@@ -94,12 +99,12 @@ describe("AnimationManager", function () {
       const pos = {
         x: 200,
         y: 210,
-        z: -155,
+        z: -155
       };
 
       // When
       // createAnimationParam does not change the 'pos' param since 2017.10.27
-      let param = this.inst._createAnimationParam(pos, 1000);
+      let param = inst._createAnimationParam(pos, 1000);
 
       // Then
       expect(param.depaPos).to.be.eql({ x: 0, y: 0, z: -100 });
@@ -110,10 +115,10 @@ describe("AnimationManager", function () {
       expect(param.input).to.be.eql(null);
 
       // When
-      this.options.maximumDuration = 500;
+      options.maximumDuration = 500;
       const eventValue = { event: "i'm inputEvent" };
-      param = this.inst._createAnimationParam(pos, 1000, {
-        event: eventValue,
+      param = inst._createAnimationParam(pos, 1000, {
+        event: eventValue
       });
 
       // Then
@@ -125,62 +130,62 @@ describe("AnimationManager", function () {
     });
   });
 
-  describe("animation test", function () {
+  describe("animation test", () => {
     beforeEach(() => {
-      this.axis = {
+      axis = {
         x: {
           range: [0, 100],
           bounce: [50, 50],
-          circular: false /*[false, false]*/,
+          circular: false /* [false, false] */
         },
         y: {
           range: [0, 200],
           bounce: [0, 0],
-          circular: false /*[false, false]*/,
+          circular: false /* [false, false] */
         },
         z: {
           range: [-100, 200],
           bounce: [50, 0],
-          circular: true /*[true, true]*/,
-        },
+          circular: true /* [true, true] */
+        }
       };
-      this.options = {
-        easing: function easeOutCubic(x) {
+      options = {
+        easing: (x) => {
           return 1 - Math.pow(1 - x, 3);
         },
         interruptable: true,
         deceleration: 0.0001,
         minimumDuration: 0,
-        maximumDuration: 2000,
+        maximumDuration: 2000
       };
-      this.axes = new Axes(this.axis, this.options);
-      var axisManager = new AxisManager(this.axis, this.options);
-      var eventManager = new EventManager(this.axes);
-      this.inst = new AnimationManager({
-        options: this.options,
-        interruptManager: new InterruptManager(this.options),
+      axes = new Axes(axis, options);
+      const axisManager = new AxisManager(axis, options);
+      const eventManager = new EventManager(axes);
+      inst = new AnimationManager({
+        options: options,
+        interruptManager: new InterruptManager(options),
         eventManager,
-        axisManager,
+        axisManager
       });
-      eventManager.setAnimationManager(this.inst);
+      eventManager.setAnimationManager(inst);
     });
     afterEach(() => {
-      this.axes.off();
+      axes.off();
     });
     it("should check 'setTo' method(duration: 0)", () => {
       // Given
       const changeHandler = sinon.spy();
       const finishHandler = sinon.spy();
-      this.axes.on({
+      axes.on({
         change: changeHandler,
-        finish: finishHandler,
+        finish: finishHandler
       });
 
       // When
-      this.inst.setTo(
+      inst.setTo(
         {
           x: 100,
-          y: 200,
+          y: 200
         },
         0
       );
@@ -188,31 +193,31 @@ describe("AnimationManager", function () {
       // Then
       expect(changeHandler.calledOnce).to.be.true;
       expect(finishHandler.calledOnce).to.be.true;
-      expect(this.inst.axisManager.get()).to.be.eql({
+      expect(inst.axisManager.get()).to.be.eql({
         x: 100,
         y: 200,
-        z: -100,
+        z: -100
       });
     });
     it("should check 'setTo' method (outside)", () => {
       // Given
-      const depaPos = this.inst.axisManager.get();
+      const depaPos = inst.axisManager.get();
       const destPos = {
         x: 200,
-        z: -155,
+        z: -155
       };
-      const self = this.inst;
+      const self = inst;
       const startHandler = sinon.spy();
       const changeHandler = sinon.spy();
       const endHandler = sinon.spy();
-      this.axes.on({
+      axes.on({
         animationStart: startHandler,
         change: changeHandler,
-        animationEnd: endHandler,
+        animationEnd: endHandler
       });
 
       // When
-      this.inst.setTo(destPos, 0);
+      inst.setTo(destPos, 0);
 
       // Then
       expect(startHandler.called).to.be.false;
@@ -223,50 +228,50 @@ describe("AnimationManager", function () {
     });
     it("should check 'setTo' method (outside, duration)", (done) => {
       // Given
-      const depaPos = this.inst.axisManager.get();
+      const depaPos = inst.axisManager.get();
       const destPos = {
         x: 200,
-        z: -155,
+        z: -155
       };
-      const self = this.inst;
+      const self = inst;
       const startHandler = sinon.spy();
-      const changeHandler = sinon.spy(function (event) {
+      const changeHandler = sinon.spy((event) => {
         expect(event.input).to.be.null;
         expect(event.inputEvent).to.be.null;
         expect(self.getEventInfo()).to.be.null;
       });
-      this.axes.on({
+      axes.on({
         animationStart: startHandler,
         change: changeHandler,
-        animationEnd: function (event) {
+        animationEnd: (event) => {
           expect(self.axisManager.get()).to.be.eql({ x: 100, y: 0, z: 145 });
           expect(startHandler.callCount).to.be.equal(1);
           expect(startHandler.getCall(0).args[0].isTrusted).to.be.false;
           expect(changeHandler.called).to.be.true;
           expect(event.isTrusted).to.be.false;
           done();
-        },
+        }
       });
 
       // When
-      this.inst.setTo(destPos, 1000);
+      inst.setTo(destPos, 1000);
     });
 
     it("should check 'setTo' method (same position #1)", (done) => {
       // Given
-      const depaPos = this.inst.axisManager.get();
+      const depaPos = inst.axisManager.get();
       const destPos = {
         x: 0,
-        z: -100,
+        z: -100
       };
-      const self = this.inst;
+      const self = inst;
       const changeHandler = sinon.spy();
-      this.axes.on({
-        change: changeHandler,
+      axes.on({
+        change: changeHandler
       });
 
       // When
-      const ret = this.inst.setTo(destPos);
+      const ret = inst.setTo(destPos);
 
       // Then
       setTimeout(() => {
@@ -278,19 +283,19 @@ describe("AnimationManager", function () {
 
     it("should check 'setTo' method (same position #2 - completely same)", (done) => {
       // Given
-      const depaPos = this.inst.axisManager.get();
+      const depaPos = inst.axisManager.get();
       const destPos = {
         x: 0,
-        z: -100,
+        z: -100
       };
-      const self = this.inst;
+      const self = inst;
       const changeHandler = sinon.spy();
-      this.axes.on({
-        change: changeHandler,
+      axes.on({
+        change: changeHandler
       });
 
       // When
-      const ret = this.inst.setTo(destPos);
+      const ret = inst.setTo(destPos);
 
       // Then
       setTimeout(() => {
@@ -302,34 +307,34 @@ describe("AnimationManager", function () {
 
     it("should check 'setTo' method (circular, no duration)", (done) => {
       // Given
-      const depaPos = this.inst.axisManager.get();
+      const depaPos = inst.axisManager.get();
       const destPos = { z: -200 };
-      const self = this.inst;
-      const changeHandler = sinon.spy(function (event) {
+      const self = inst;
+      const changeHandler = sinon.spy((event) => {
         // Then
         expect(self.axisManager.get()).to.be.eql({ x: 0, y: 0, z: 100 });
         done();
       });
-      this.axes.on({
-        change: changeHandler,
+      axes.on({
+        change: changeHandler
       });
 
       // When
-      const ret = this.inst.setTo(destPos, 0, true);
+      const ret = inst.setTo(destPos, 0, true);
     });
 
     it("should check 'setTo' method (same position after range limit, useCircular)", (done) => {
       // Given
       // depaPos: {x: 0, y: 0, z: -100}
       const destPos = { x: -100, z: 500 };
-      const self = this.inst;
+      const self = inst;
       const changeHandler = sinon.spy();
-      this.axes.on({
-        change: changeHandler,
+      axes.on({
+        change: changeHandler
       });
 
       // When
-      const ret = this.inst.setTo(destPos, 0); // last (useCircular) param makes invalidating z-pos change(500)
+      const ret = inst.setTo(destPos, 0); // last (useCircular) param makes invalidating z-pos change(500)
 
       // Then
       setTimeout(() => {
@@ -338,7 +343,7 @@ describe("AnimationManager", function () {
         expect(changeHandler.args[0][0].delta).to.be.eql({
           x: 0,
           y: 0,
-          z: 600,
+          z: 600
         });
         expect(ret).to.be.eq(self);
         done();
@@ -347,129 +352,129 @@ describe("AnimationManager", function () {
 
     it("should check 'setTo' method (diff position after range limit)", (done) => {
       // Given
-      const depaPos = this.inst.axisManager.get();
+      const depaPos = inst.axisManager.get();
       const destPos = { x: -100, z: 450 };
-      const self = this.inst;
-      const changeHandler = sinon.spy(function (event) {
+      const self = inst;
+      const changeHandler = sinon.spy((event) => {
         // Then
         expect(self.axisManager.get()).to.be.eql({ x: 0, y: 0, z: 150 });
         done();
       });
-      this.axes.on({
-        change: changeHandler,
+      axes.on({
+        change: changeHandler
       });
 
       // When
-      const ret = this.inst.setTo(destPos);
+      const ret = inst.setTo(destPos);
     });
 
     it("should check 'setBy' method (inside, duration)", (done) => {
       // Given
-      const depaPos = this.inst.axisManager.get();
+      const depaPos = inst.axisManager.get();
       const byPos = {
         x: 20,
-        z: 40,
+        z: 40
       };
-      const self = this.inst;
+      const self = inst;
       const startHandler = sinon.spy();
-      const changeHandler = sinon.spy(function (event) {
+      const changeHandler = sinon.spy((event) => {
         expect(event.input).to.be.null;
         expect(event.inputEvent).to.be.null;
         expect(self.getEventInfo()).to.be.null;
       });
-      this.axes.on({
+      axes.on({
         animationStart: startHandler,
         change: changeHandler,
-        animationEnd: function (event) {
+        animationEnd: (event) => {
           expect(self.axisManager.get()).to.be.eql({
             x: depaPos.x + byPos.x,
             y: 0,
-            z: depaPos.z + byPos.z,
+            z: depaPos.z + byPos.z
           });
           expect(startHandler.callCount).to.be.equal(1);
           expect(startHandler.getCall(0).args[0].isTrusted).to.be.false;
           expect(changeHandler.called).to.be.true;
           expect(event.isTrusted).to.be.false;
           done();
-        },
+        }
       });
 
       // When
-      this.inst.setBy(byPos, 1000);
+      inst.setBy(byPos, 1000);
     });
     it("should check 'setBy' method (outside, duration)", (done) => {
       // Given
-      const depaPos = this.inst.axisManager.get();
-      const minZ = this.axis.z.range[0];
-      const rangeLength = this.axis.z.range[1] - this.axis.z.range[0];
+      const depaPos = inst.axisManager.get();
+      const minZ = axis.z.range[0];
+      const rangeLength = axis.z.range[1] - axis.z.range[0];
       const byPos = {
         x: 200,
-        z: 500,
+        z: 500
       };
-      const self = this.inst;
+      const self = inst;
       const startHandler = sinon.spy();
-      const changeHandler = sinon.spy(function (event) {
+      const changeHandler = sinon.spy((event) => {
         // console.log("change handler", self.axisManager.get());
         expect(event.input).to.be.null;
         expect(event.inputEvent).to.be.null;
         expect(self.getEventInfo()).to.be.null;
       });
-      this.axes.on({
+      axes.on({
         animationStart: startHandler,
         change: changeHandler,
-        animationEnd: function (event) {
+        animationEnd: (event) => {
           expect(self.axisManager.get()).to.be.eql({ x: 100, y: 0, z: 100 });
           expect(startHandler.callCount).to.be.equal(1);
           expect(startHandler.getCall(0).args[0].isTrusted).to.be.false;
           expect(changeHandler.called).to.be.true;
           expect(event.isTrusted).to.be.false;
           done();
-        },
+        }
       });
 
       // When
-      this.inst.setBy(byPos, 1000);
+      inst.setBy(byPos, 1000);
     });
     it("should check 'animateTo' method (inside)", (done) => {
       // Given
-      const depaPos = this.inst.axisManager.get();
+      const depaPos = inst.axisManager.get();
       const destPos = {
         x: 90,
-        z: -80,
+        z: -80
       };
-      const self = this.inst;
+      const self = inst;
       const startHandler = sinon.spy();
-      const changeHandler = sinon.spy(function (event) {
+      const changeHandler = sinon.spy((event) => {
         expect(event.input).to.be.null;
         expect(event.inputEvent).to.be.null;
         expect(self.getEventInfo()).to.be.null;
       });
-      this.axes.on({
+      axes.on({
         animationStart: startHandler,
         change: changeHandler,
-        animationEnd: function (event) {
+        animationEnd: (event) => {
           expect(self.axisManager.get()).to.be.eql({ x: 90, y: 0, z: -80 });
           expect(startHandler.callCount).to.be.equal(1);
           expect(startHandler.getCall(0).args[0].isTrusted).to.be.false;
           expect(changeHandler.called).to.be.true;
           expect(event.isTrusted).to.be.false;
           done();
-        },
+        }
       });
 
       // When
-      this.inst.setTo(destPos, 500);
+      inst.setTo(destPos, 500);
     });
     it("should check 'animateTo' method (outside)", (done) => {
       // Given
-      const depaPos = this.inst.axisManager.get();
+      const depaPos = inst.axisManager.get();
       const destPos = {
         x: 200,
-        z: -155,
+        z: -155
       };
-      const self = this.inst;
+      const self = inst;
       const startHandler = sinon.spy();
-      const endHandler = sinon.spy(function (event) {
+      const endHandler = sinon.spy((event) => {
         if (endHandler.callCount === 1) {
           // first destPos
           expect(self.axisManager.get()).to.be.eql({ x: 200, y: 0, z: 145 });
@@ -485,13 +490,13 @@ describe("AnimationManager", function () {
           done();
         }
       });
-      this.axes.on({
+      axes.on({
         animationStart: startHandler,
-        animationEnd: endHandler,
+        animationEnd: endHandler
       });
 
       // When
-      this.inst.animateTo(destPos, 1000);
+      inst.animateTo(destPos, 1000);
     });
     it("should check 'animateTo' with destPos that can cause floating point", (done) => {
       // circular: true,
@@ -501,15 +506,15 @@ describe("AnimationManager", function () {
       // range: [-96, 1055.984375]
 
       // Given
-      this.inst.axisManager._axis.z.range = [-96, 1055.984375];
-      this.inst.setTo({ z: 729.5858375 }, 0);
+      inst.axisManager._axis.z.range = [-96, 1055.984375];
+      inst.setTo({ z: 729.5858375 }, 0);
 
       // When
-      this.inst.animateTo({ z: 1055.984375 }, 102);
+      inst.animateTo({ z: 1055.984375 }, 102);
 
       setTimeout(() => {
         // Then
-        expect(this.inst.axisManager.get().z).to.be.equals(1055.984375);
+        expect(inst.axisManager.get().z).to.be.equals(1055.984375);
         done();
       }, 200);
     });
@@ -518,14 +523,14 @@ describe("AnimationManager", function () {
       const startHandler = sinon.spy();
       const changeHandler = sinon.spy();
       const endHandler = sinon.spy();
-      this.axes.on({
+      axes.on({
         change: changeHandler,
         animationStart: startHandler,
-        animationEnd: endHandler,
+        animationEnd: endHandler
       });
 
       // When
-      this.inst.setTo({ x: 80, y: 150 }, 200);
+      inst.setTo({ x: 80, y: 150 }, 200);
 
       // Then
       setTimeout(() => {
@@ -534,18 +539,18 @@ describe("AnimationManager", function () {
         expect(endHandler.called).to.be.false;
 
         // When
-        this.inst.setTo({ x: 0, y: 0 }, 300);
-        expect(this.inst.axisManager.get()).to.not.eql({
+        inst.setTo({ x: 0, y: 0 }, 300);
+        expect(inst.axisManager.get()).to.not.eql({
           x: 80,
           y: 150,
-          z: -100,
+          z: -100
         });
       }, 100);
       setTimeout(() => {
         expect(startHandler.calledTwice).to.be.true;
         expect(changeHandler.called).to.be.true;
         expect(endHandler.calledTwice).to.be.true;
-        const result = this.inst.axisManager.get();
+        const result = inst.axisManager.get();
 
         expect(result.x).to.be.equal(0);
         expect(result.y).to.be.equal(0);
@@ -565,19 +570,19 @@ describe("AnimationManager", function () {
           // the right time for a range to be crossed
           // 'pos' is off the range.
           // z.range[1] 200 => 600
-          this.axis.z.range[1] = 600;
+          axis.z.range[1] = 600;
         }, 300);
 
-        this.inst._animateLoop(
+        inst._animateLoop(
           {
             duration: 1000,
             depaPos,
             destPos,
-            delta: { z: destPos.z - depaPos.z },
+            delta: { z: destPos.z - depaPos.z }
           },
           () => {
             // Then
-            expect(this.inst.axisManager.get(["z"]).z).to.be.equals(
+            expect(inst.axisManager.get(["z"]).z).to.be.equals(
               resultPos.z
             );
             done();
@@ -594,7 +599,7 @@ describe("AnimationManager", function () {
         let willChange = false;
         setTimeout(() => {
           // Starts with the exception of -100, which is the start position.
-          this.axes.on("change", (e) => {
+          axes.on("change", (e) => {
             if (
               // range[0] = -100
               (direction === -1 && e.pos.z < -80) ||
@@ -603,21 +608,21 @@ describe("AnimationManager", function () {
             ) {
               willChange = true;
             } else if (willChange) {
-              this.axis.z.range[1] = 600;
+              axis.z.range[1] = 600;
             }
           });
         }, 100);
 
-        this.inst._animateLoop(
+        inst._animateLoop(
           {
             duration: 1000,
             depaPos,
             destPos,
-            delta: { z: destPos.z - depaPos.z },
+            delta: { z: destPos.z - depaPos.z }
           },
           () => {
             // Then
-            expect(this.inst.axisManager.get(["z"]).z).to.be.equals(
+            expect(inst.axisManager.get(["z"]).z).to.be.equals(
               resultPos.z
             );
             done();

--- a/test/unit/Axes.spec.js
+++ b/test/unit/Axes.spec.js
@@ -845,7 +845,7 @@ describe("Axes", function () {
             expect(this.holdHandler.calledOnce).to.be.true;
             expect(holdEvent.pos.x).to.be.equal(0);
             expect(holdEvent.pos.y).to.be.equal(0);
-            expect(holdEvent.inputEvent.isFirst).to.be.true;
+            // expect(holdEvent.inputEvent.isFirst).to.be.true;
             expect(holdEvent.isTrusted).to.be.true;
             expect(changeHandler.called).to.be.true;
             for (let i = 0, len = changeHandler.callCount; i < len; i++) {
@@ -857,7 +857,7 @@ describe("Axes", function () {
             }
             const releaseEvent = this.releaseHandler.getCall(0).args[0];
             expect(this.releaseHandler.calledOnce).to.be.true;
-            expect(releaseEvent.inputEvent.isFinal).to.be.true;
+            // expect(releaseEvent.inputEvent.isFinal).to.be.true;
             expect(releaseEvent.input).to.be.equal(this.input);
             expect(releaseEvent.isTrusted).to.be.true;
             expect(this.inst.get()).to.be.eql({ x: 10, y: 10 });
@@ -907,12 +907,12 @@ describe("Axes", function () {
               expect(this.holdHandler.calledOnce).to.be.true;
               expect(holdEvent.pos.x).to.be.equal(0);
               expect(holdEvent.pos.y).to.be.equal(0);
-              expect(holdEvent.inputEvent.isFirst).to.be.true;
+              // expect(holdEvent.inputEvent.isFirst).to.be.true;
               expect(holdEvent.input).to.be.equal(this.input);
               expect(holdEvent.isTrusted).to.be.true;
               const releaseEvent = this.releaseHandler.getCall(0).args[0];
               expect(this.releaseHandler.calledOnce).to.be.true;
-              expect(releaseEvent.inputEvent.isFinal).to.be.true;
+              // expect(releaseEvent.inputEvent.isFinal).to.be.true;
               expect(releaseEvent.input).to.be.equal(this.input);
               expect(releaseEvent.isTrusted).to.be.true;
 

--- a/test/unit/Axes.spec.js
+++ b/test/unit/Axes.spec.js
@@ -1,238 +1,252 @@
+
+import PanInputInjector from "inject-loader!../../src/inputType/PanInput.ts";
+
 import Axes from "../../src/Axes.ts";
 import { PanInput } from "../../src/inputType/PanInput.ts";
 import { PinchInput } from "../../src/inputType/PinchInput.ts";
 import { getDecimalPlace, roundNumber } from "../../src/utils";
-import PanInputInjector from "inject-loader!../../src/inputType/PanInput.ts";
 
-describe("Axes", function () {
-  describe("Axes Test", function () {
+describe("Axes", () => {
+  let el;
+	let input;
+	let inst;
+	let holdHandler;
+	let changeHandler;
+	let releaseHandler;
+	let finishHandler;
+	let animationStartHandler;
+	let animationEndHandler;
+	let preventedFn;
+	let notPreventedFn;
+
+  describe("Axes Test", () => {
     beforeEach(() => {
-      this.inst = null;
+      inst = null;
     });
     afterEach(() => {
-      if (this.inst) {
-        this.inst.destroy();
-        this.inst = null;
+      if (inst) {
+        inst.destroy();
+        inst = null;
       }
     });
 
     it("should check a initialization empty value", () => {
       // Given
       // When
-      this.inst = new Axes();
+      inst = new Axes();
       // Then
 
       const defaultOptions = {
-        easing: function easeOutCubic(x) {
+        easing: (x) => {
           return 1 - Math.pow(1 - x, 3);
         },
         interruptable: true,
         minimumDuration: 0,
         maximumDuration: Infinity,
-        deceleration: 0.0006,
+        deceleration: 0.0006
       };
 
-      expect(this.inst).to.be.exist;
+      expect(inst).to.be.exist;
       expect(defaultOptions.easing(0.5)).to.be.equal(
-        this.inst.options.easing(0.5)
+        inst.options.easing(0.5)
       );
       expect(defaultOptions.easing(0.3)).to.be.equal(
-        this.inst.options.easing(0.3)
+        inst.options.easing(0.3)
       );
       expect(defaultOptions.easing(0.1)).to.be.equal(
-        this.inst.options.easing(0.1)
+        inst.options.easing(0.1)
       );
       expect(defaultOptions.easing(0.7)).to.be.equal(
-        this.inst.options.easing(0.7)
+        inst.options.easing(0.7)
       );
       expect(defaultOptions.easing(0.9)).to.be.equal(
-        this.inst.options.easing(0.9)
+        inst.options.easing(0.9)
       );
       expect(defaultOptions.interruptable).to.be.equal(
-        this.inst.options.interruptable
+        inst.options.interruptable
       );
       expect(defaultOptions.minimumDuration).to.be.equal(
-        this.inst.options.minimumDuration
+        inst.options.minimumDuration
       );
       expect(defaultOptions.maximumDuration).to.be.equal(
-        this.inst.options.maximumDuration
+        inst.options.maximumDuration
       );
       expect(defaultOptions.deceleration).to.be.equal(
-        this.inst.options.deceleration
+        inst.options.deceleration
       );
     });
 
     it("should check initialization status", () => {
       // Given
       // When
-      this.inst = new Axes(
+      inst = new Axes(
         {
           x: {
             range: [0, 100],
             bounce: [30, 50],
-            circular: true,
+            circular: true
           },
           otherX: {
             range: [-100, 100],
             bounce: 40,
-            circular: [false, true],
-          },
+            circular: [false, true]
+          }
         },
         {
-          deceleration: 0.001,
+          deceleration: 0.001
         },
         {
           x: 50,
-          otherX: 0,
+          otherX: 0
         }
       );
 
       // Then
-      expect(this.inst.axis.x.bounce).to.deep.equal([30, 50]);
-      expect(this.inst.axis.x.circular).to.deep.equal([true, true]);
-      expect(this.inst.axis.otherX.bounce).to.deep.equal([40, 40]);
-      expect(this.inst.axis.otherX.circular).to.deep.equal([false, true]);
-      expect(this.inst.get().x).to.equal(50);
-      expect(this.inst.get().otherX).to.equal(0);
+      expect(inst.axis.x.bounce).to.deep.equal([30, 50]);
+      expect(inst.axis.x.circular).to.deep.equal([true, true]);
+      expect(inst.axis.otherX.bounce).to.deep.equal([40, 40]);
+      expect(inst.axis.otherX.circular).to.deep.equal([false, true]);
+      expect(inst.get().x).to.equal(50);
+      expect(inst.get().otherX).to.equal(0);
     });
     it("should check `setTo/setBy` method", () => {
       // Given
-      this.inst = new Axes(
+      inst = new Axes(
         {
           x: {
             range: [0, 100],
             bounce: [30, 50],
-            circular: true,
+            circular: true
           },
           otherX: {
             range: [-100, 100],
             bounce: 40,
-            circular: [false, true],
-          },
+            circular: [false, true]
+          }
         },
         {
-          deceleration: 0.001,
+          deceleration: 0.001
         }
       );
       // When
-      let ret = this.inst.setTo({ x: 20 });
+      const ret = inst.setTo({ x: 20 });
 
       // Then
-      expect(this.inst.get()).to.be.eql({ x: 20, otherX: -100 });
-      expect(ret).to.be.equal(this.inst);
+      expect(inst.get()).to.be.eql({ x: 20, otherX: -100 });
+      expect(ret).to.be.equal(inst);
 
       // When
-      this.inst.setBy({ x: 10 });
+      inst.setBy({ x: 10 });
 
       // Then
-      expect(this.inst.get()).to.be.eql({ x: 30, otherX: -100 });
+      expect(inst.get()).to.be.eql({ x: 30, otherX: -100 });
     });
 
     it("should check `setTo` method (with duration)", () => {
       // Given
       const startHandler = sinon.spy();
-      const changeHandler = sinon.spy();
-      const endHandler = sinon.spy(function () {
+      changeHandler = sinon.spy();
+      const endHandler = sinon.spy(() => {
         // Then
         expect(startHandler.callCount).to.be.equal(1);
         expect(changeHandler.called).to.be.true;
-        expect(this.inst.get()).to.be.eql({ x: 20, otherX: -100 });
+        expect(inst.get()).to.be.eql({ x: 20, otherX: -100 });
         done();
       });
-      this.inst = new Axes(
+      inst = new Axes(
         {
           x: {
             range: [0, 100],
             bounce: [30, 50],
-            circular: true,
+            circular: true
           },
           otherX: {
             range: [-100, 100],
             bounce: 40,
-            circular: [false, true],
-          },
+            circular: [false, true]
+          }
         },
         {
-          deceleration: 0.001,
+          deceleration: 0.001
         }
       ).on({
         animationStart: startHandler,
         change: changeHandler,
-        animationEnd: endHandler,
+        animationEnd: endHandler
       });
 
       // When
-      this.inst.setTo({ x: 20 }, 200);
+      inst.setTo({ x: 20 }, 200);
     });
 
     it("should check `setBy` method (with duration)", () => {
       // Given
-      this.inst = new Axes(
+      inst = new Axes(
         {
           x: {
             range: [0, 100],
             bounce: [30, 50],
-            circular: true,
+            circular: true
           },
           otherX: {
             range: [-100, 100],
             bounce: 40,
-            circular: [false, true],
-          },
+            circular: [false, true]
+          }
         },
         {
-          deceleration: 0.001,
+          deceleration: 0.001
         }
       );
-      this.inst.setTo({ x: 50 });
-      expect(this.inst.get()).to.be.eql({ x: 50, otherX: -100 });
+      inst.setTo({ x: 50 });
+      expect(inst.get()).to.be.eql({ x: 50, otherX: -100 });
 
-      this.inst.on({
+      inst.on({
         animationStart: startHandler,
         change: changeHandler,
-        animationEnd: endHandler,
+        animationEnd: endHandler
       });
 
       const startHandler = sinon.spy();
-      const changeHandler = sinon.spy();
-      const endHandler = sinon.spy(function () {
+      changeHandler = sinon.spy();
+      const endHandler = sinon.spy(() => {
         // Then
         expect(startHandler.callCount).to.be.equal(1);
         expect(changeHandler.called).to.be.true;
-        expect(this.inst.get()).to.be.eql({ x: 40, otherX: -100 });
+        expect(inst.get()).to.be.eql({ x: 40, otherX: -100 });
         done();
       });
 
       // When
-      this.inst.setBy({ x: -10 }, 200);
+      inst.setBy({ x: -10 }, 200);
     });
   });
 
-  describe("Axes Test with InputType", function () {
+  describe("Axes Test with InputType", () => {
     beforeEach(() => {
-      this.inst = new Axes(
+      inst = new Axes(
         {
           x: {
             range: [0, 100],
             bounce: [30, 50],
-            circular: true,
+            circular: true
           },
           otherX: {
             range: [-100, 100],
             bounce: 40,
-            circular: [false, true],
-          },
+            circular: [false, true]
+          }
         },
         {
-          deceleration: 0.001,
+          deceleration: 0.001
         }
       );
       sandbox();
     });
     afterEach(() => {
-      if (this.inst) {
-        this.inst.destroy();
-        this.inst = null;
+      if (inst) {
+        inst.destroy();
+        inst = null;
       }
       cleanup();
     });
@@ -242,36 +256,36 @@ describe("Axes", function () {
       const input = new PanInput("#sandbox");
 
       // When
-      let ret = this.inst.connect("x", input);
+      let ret = inst.connect("x", input);
 
       // Then
       expect(input.axes).to.be.eql(["x"]);
-      expect(this.inst._inputs.length).to.be.equal(1);
-      expect(ret).to.be.equal(this.inst);
+      expect(inst._inputs.length).to.be.equal(1);
+      expect(ret).to.be.equal(inst);
 
       // When
-      ret = this.inst.connect(["x"], input);
+      ret = inst.connect(["x"], input);
 
       // Then
       expect(input.axes).to.be.eql(["x"]);
-      expect(this.inst._inputs.length).to.be.equal(1);
-      expect(ret).to.be.equal(this.inst);
+      expect(inst._inputs.length).to.be.equal(1);
+      expect(ret).to.be.equal(inst);
 
       // When
-      ret = this.inst.connect(["x", "y"], input);
+      ret = inst.connect(["x", "y"], input);
 
       // Then
       expect(input.axes).to.be.eql(["x", "y"]);
-      expect(this.inst._inputs.length).to.be.equal(1);
-      expect(ret).to.be.equal(this.inst);
+      expect(inst._inputs.length).to.be.equal(1);
+      expect(ret).to.be.equal(inst);
 
       // When
-      ret = this.inst.connect("x y", input);
+      ret = inst.connect("x y", input);
 
       // Then
       expect(input.axes).to.be.eql(["x", "y"]);
-      expect(this.inst._inputs.length).to.be.equal(1);
-      expect(ret).to.be.equal(this.inst);
+      expect(inst._inputs.length).to.be.equal(1);
+      expect(ret).to.be.equal(inst);
 
       input.destroy();
     });
@@ -281,32 +295,32 @@ describe("Axes", function () {
       const input1 = new PanInput("#sandbox");
       const input2 = new PanInput("#sandbox");
       const input3 = new PanInput("#sandbox");
-      this.inst.connect("x", input1);
-      this.inst.connect("y", input2);
-      this.inst.connect("x y", input3);
+      inst.connect("x", input1);
+      inst.connect("y", input2);
+      inst.connect("x y", input3);
 
       // When
-      expect(this.inst._inputs.length).to.be.equal(3);
-      let ret = this.inst.disconnect(input1);
+      expect(inst._inputs.length).to.be.equal(3);
+      let ret = inst.disconnect(input1);
 
       // Then
-      expect(this.inst._inputs.indexOf(input1)).to.be.equal(-1);
-      expect(this.inst._inputs.length).to.be.equal(2);
-      expect(ret).to.be.equal(this.inst);
+      expect(inst._inputs.indexOf(input1)).to.be.equal(-1);
+      expect(inst._inputs.length).to.be.equal(2);
+      expect(ret).to.be.equal(inst);
 
       // When
-      ret = this.inst.disconnect();
+      ret = inst.disconnect();
 
       // Then
-      expect(this.inst._inputs).to.be.eql([]);
-      expect(ret).to.be.equal(this.inst);
-      expect(this.inst._inputs.length).to.be.equal(0);
+      expect(inst._inputs).to.be.eql([]);
+      expect(ret).to.be.equal(inst);
+      expect(inst._inputs.length).to.be.equal(0);
 
       // When no input, it should not make script error
-      ret = this.inst.disconnect(input1);
+      ret = inst.disconnect(input1);
 
       // Then
-      expect(ret).to.be.equal(this.inst);
+      expect(ret).to.be.equal(inst);
 
       input1.destroy();
       input2.destroy();
@@ -320,32 +334,32 @@ describe("Axes", function () {
         deltaX: 100,
         deltaY: 10,
         duration: 200,
-        easing: "linear",
+        easing: "linear"
       };
       const MOVE_VERTICALLY = {
         pos: [0, 0],
         deltaX: 0,
         deltaY: 100,
         duration: 200,
-        easing: "linear",
+        easing: "linear"
       };
       const target = document.querySelector("#sandbox");
       const pinchInput = new PinchInput(target, { inputType: ["touch"] });
       const panInput = new PanInput(target, { inputType: ["touch"] });
 
-      this.inst.connect("x", pinchInput);
-      this.inst.disconnect(pinchInput);
-      this.inst.connect(["x", "otherX"], panInput);
+      inst.connect("x", pinchInput);
+      inst.disconnect(pinchInput);
+      inst.connect(["x", "otherX"], panInput);
 
-      const prevX = this.inst.get()["x"];
-      const prevY = this.inst.get()["otherX"];
+      const prevX = inst.get()["x"];
+      const prevY = inst.get()["otherX"];
 
       // When
       Simulator.gestures.pan(target, MOVE_HORIZONTALLY, () => {
         Simulator.gestures.pan(target, MOVE_VERTICALLY, () => {
           // Then
-          const currX = this.inst.get()["x"];
-          const currY = this.inst.get()["otherX"];
+          const currX = inst.get()["x"];
+          const currY = inst.get()["otherX"];
 
           expect(currX).to.be.not.equal(prevX);
           expect(currY).to.be.not.equal(prevY);
@@ -358,50 +372,50 @@ describe("Axes", function () {
     });
   });
   [20, 30, 40, 50].forEach((iOSEdgeSwipeThreshold) => {
-    describe(`Axes iOS Edge Test (iOSEdgeSwipeThreshold: ${iOSEdgeSwipeThreshold})`, function () {
+    describe(`Axes iOS Edge Test (iOSEdgeSwipeThreshold: ${iOSEdgeSwipeThreshold})`, () => {
       beforeEach(() => {
-        this.inst = new Axes(
+        inst = new Axes(
           {
             x: {
               range: [0, 300],
-              bounce: 100,
+              bounce: 100
             },
             y: {
               range: [0, 400],
-              bounce: 100,
-            },
+              bounce: 100
+            }
           },
           {
-            deceleration: 0.001,
+            deceleration: 0.001
           }
         );
-        this.el = sandbox();
-        this.el.innerHTML = `<div id="area"
+        el = sandbox();
+        el.innerHTML = `<div id="area"
 		style="position:relative; border:5px solid #444; width:300px; height:400px; color:#aaa; margin:0;box-sizing:content-box; z-index:9;"></div>`;
 
-        this.releaseHandler = sinon.spy();
-        this.finishHandler = sinon.spy();
+        releaseHandler = sinon.spy();
+        finishHandler = sinon.spy();
         const MockPanInputInjector = PanInputInjector({
           "../const": {
             IOS_EDGE_THRESHOLD: 30,
-            IS_IOS_SAFARI: true,
-          },
+            IS_IOS_SAFARI: true
+          }
         });
-        this.input = new MockPanInputInjector.PanInput(this.el, {
+        input = new MockPanInputInjector.PanInput(el, {
           iOSEdgeSwipeThreshold,
-          inputType: ["touch"],
+          inputType: ["touch"]
         });
-        this.inst
+        inst
           .on({
-            release: this.releaseHandler,
-            finish: this.finishHandler,
+            release: releaseHandler,
+            finish: finishHandler
           })
-          .connect(["x", "y"], this.input);
+          .connect(["x", "y"], input);
 
         const touchTrigger = Simulator.events.touch.trigger;
 
         Simulator.events.touch.originalTrigger = touchTrigger;
-        Simulator.events.touch.trigger = function (touches, element, type) {
+        Simulator.events.touch.trigger = (touches, element, type) => {
           if (type === "end") {
             return;
           }
@@ -410,41 +424,41 @@ describe("Axes", function () {
       });
       afterEach(() => {
         Simulator.events.touch.trigger = Simulator.events.touch.originalTrigger;
-        if (this.inst) {
-          this.inst.destroy();
-          this.inst = null;
+        if (inst) {
+          inst.destroy();
+          inst = null;
         }
-        if (this.input) {
-          this.input.destroy();
-          this.input = null;
+        if (input) {
+          input.destroy();
+          input = null;
         }
-        this.releaseHandler.resetHistory();
-        this.finishHandler.resetHistory();
+        releaseHandler.resetHistory();
+        finishHandler.resetHistory();
         cleanup();
       });
       it("should check release event occurs when swiping on ios safari edge. (left to right)", (done) => {
         // Given, When
         // clientX + => -
         Simulator.gestures.pan(
-          this.el,
+          el,
           {
             pos: [30, 30],
             deltaX: -50,
             deltaY: 10,
             duration: 200,
-            easing: "linear",
+            easing: "linear"
           },
           () => {
             // Then
             // for test animation event
             setTimeout(() => {
-              const releaseEvent = this.releaseHandler.getCall(0).args[0];
-              expect(this.releaseHandler.calledOnce).to.be.true;
+              const releaseEvent = releaseHandler.getCall(0).args[0];
+              expect(releaseHandler.calledOnce).to.be.true;
               // expect(releaseEvent.inputEvent.isFinal).to.be.false;
               expect(releaseEvent.isTrusted).to.be.true;
 
-              const finishEvent = this.finishHandler.getCall(0).args[0];
-              expect(this.finishHandler.called).to.be.true;
+              const finishEvent = finishHandler.getCall(0).args[0];
+              expect(finishHandler.called).to.be.true;
               expect(finishEvent.isTrusted).to.be.true;
               done();
             }, 500);
@@ -455,25 +469,25 @@ describe("Axes", function () {
         // Given, When
         // window.innerWidth => window.innerWidth - 15
         Simulator.gestures.pan(
-          this.el,
+          el,
           {
             pos: [window.innerWidth - iOSEdgeSwipeThreshold + 1, 30],
             deltaX: -15,
             deltaY: 0,
             duration: 200,
-            easing: "linear",
+            easing: "linear"
           },
           () => {
             // Then
             // for test animation event
             setTimeout(() => {
-              const releaseEvent = this.releaseHandler.getCall(0).args[0];
-              expect(this.releaseHandler.calledOnce).to.be.true;
+              const releaseEvent = releaseHandler.getCall(0).args[0];
+              expect(releaseHandler.calledOnce).to.be.true;
               // expect(releaseEvent.inputEvent.isFinal).to.be.false;
               expect(releaseEvent.isTrusted).to.be.true;
 
-              const finishEvent = this.finishHandler.getCall(0).args[0];
-              expect(this.finishHandler.called).to.be.true;
+              const finishEvent = finishHandler.getCall(0).args[0];
+              expect(finishHandler.called).to.be.true;
               expect(finishEvent.isTrusted).to.be.true;
               done();
             }, 500);
@@ -484,19 +498,19 @@ describe("Axes", function () {
         // Given, When
         // window.innerWidth => window.innerWidth - 30
         Simulator.gestures.pan(
-          this.el,
+          el,
           {
             pos: [window.innerWidth, 30],
             deltaX: -60,
             deltaY: 0,
             duration: 200,
-            easing: "linear",
+            easing: "linear"
           },
           () => {
             // Then
             // for test animation event
             setTimeout(() => {
-              expect(this.releaseHandler.callCount).to.be.equals(0);
+              expect(releaseHandler.callCount).to.be.equals(0);
               done();
             }, 500);
           }
@@ -505,52 +519,52 @@ describe("Axes", function () {
     });
   });
   [["pointer"], ["touch", "mouse"], ["touch"]].forEach((type) => {
-    describe(`Axes Custom Event Test with interruptable(${type})`, function () {
+    describe(`Axes Custom Event Test with interruptable(${type})`, () => {
       beforeEach(() => {
         if (type.indexOf("pointer") > -1) {
           Simulator.setType("pointer");
         } else {
           Simulator.setType("touch");
         }
-        this.inst = new Axes(
+        inst = new Axes(
           {
             x: {
               range: [0, 300],
-              bounce: 100,
+              bounce: 100
             },
             y: {
               range: [0, 400],
-              bounce: 100,
-            },
+              bounce: 100
+            }
           },
           {
             deceleration: 0.001,
-            interruptable: false,
+            interruptable: false
           }
         );
-        this.el = sandbox();
-        this.el.innerHTML = `<div id="area"
+        el = sandbox();
+        el.innerHTML = `<div id="area"
         style="position:relative; border:5px solid #444; width:300px; height:400px; color:#aaa; margin:0;box-sizing:content-box; z-index:9;"></div>`;
-        const self = this.inst;
-        this.preventedFn = function () {
+        const self = inst;
+        preventedFn = () => {
           expect(self.interruptManager._prevented).to.be.true;
         };
-        this.notPreventedFn = function () {
+        notPreventedFn = () => {
           expect(self.interruptManager._prevented).to.be.false;
         };
-        this.input = new PanInput(this.el, {
-          inputType: type,
+        input = new PanInput(el, {
+          inputType: type
         });
-        this.inst.connect(["x", "y"], this.input);
+        inst.connect(["x", "y"], input);
       });
       afterEach(() => {
-        if (this.inst) {
-          this.inst.destroy();
-          this.inst = null;
+        if (inst) {
+          inst.destroy();
+          inst = null;
         }
-        if (this.input) {
-          this.input.destroy();
-          this.input = null;
+        if (input) {
+          input.destroy();
+          input = null;
         }
         cleanup();
       });
@@ -561,30 +575,30 @@ describe("Axes", function () {
       });
       const testNormalBehavior = (done) => {
         // Given
-        const holdHandler = sinon.spy();
-        const changeHandler = sinon.spy();
-        const releaseHandler = sinon.spy();
-        const finishHandler = sinon.spy();
-        const animationStartHandler = sinon.spy();
-        const animationEndHandler = sinon.spy();
-        this.inst.off().on({
+        holdHandler = sinon.spy();
+        changeHandler = sinon.spy();
+        releaseHandler = sinon.spy();
+        finishHandler = sinon.spy();
+        animationStartHandler = sinon.spy();
+        animationEndHandler = sinon.spy();
+        inst.off().on({
           hold: holdHandler,
           change: changeHandler,
           release: releaseHandler,
           finish: finishHandler,
           animationStart: animationStartHandler,
-          animationEnd: animationEndHandler,
+          animationEnd: animationEndHandler
         });
 
         // When
         Simulator.gestures.pan(
-          this.el,
+          el,
           {
             pos: [0, 0],
             deltaX: 100,
             deltaY: 100,
             duration: 1000,
-            easing: "linear",
+            easing: "linear"
           },
           () => {
             // Then
@@ -605,7 +619,7 @@ describe("Axes", function () {
         // Given
         let changeCount = 0;
         let pos = 0;
-        const changeHandler = sinon.spy((e) => {
+        changeHandler = sinon.spy((e) => {
           ++changeCount;
 
           if (changeCount === 5) {
@@ -615,35 +629,35 @@ describe("Axes", function () {
             e.stop();
           }
         });
-        const holdHandler = sinon.spy();
-        const releaseHandler = sinon.spy();
-        const finishHandler = sinon.spy();
-        const animationStartHandler = sinon.spy();
-        const animationEndHandler = sinon.spy();
-        this.inst.on({
+        holdHandler = sinon.spy();
+        releaseHandler = sinon.spy();
+        finishHandler = sinon.spy();
+        animationStartHandler = sinon.spy();
+        animationEndHandler = sinon.spy();
+        inst.on({
           hold: holdHandler,
           change: changeHandler,
           release: releaseHandler,
           finish: finishHandler,
           animationStart: animationStartHandler,
-          animationEnd: animationEndHandler,
+          animationEnd: animationEndHandler
         });
 
         // When
         Simulator.gestures.pan(
-          this.el,
+          el,
           {
             pos: [0, 0],
             deltaX: 100,
             deltaY: 100,
             duration: 1000,
-            easing: "linear",
+            easing: "linear"
           },
           () => {
             // Then
             setTimeout(() => {
               // The stopped position is the current position.
-              expect(pos).to.be.deep.equals(this.inst.get());
+              expect(pos).to.be.deep.equals(inst.get());
               expect(holdHandler.calledOnce).to.be.true;
               expect(changeCount).to.be.equals(5);
               expect(changeHandler.callCount).to.be.equals(changeCount);
@@ -660,14 +674,14 @@ describe("Axes", function () {
       });
       it("should check normal behavior test after user invokes 'stop' from change event(after animationStart)", (done) => {
         // Given
-        const holdHandler = sinon.spy();
+        holdHandler = sinon.spy();
         let changeCount = 0;
         let pos = 0;
-        const releaseHandler = sinon.spy();
-        const finishHandler = sinon.spy();
-        const animationStartHandler = sinon.spy();
-        const animationEndHandler = sinon.spy();
-        const changeHandler = sinon.spy((e) => {
+        releaseHandler = sinon.spy();
+        finishHandler = sinon.spy();
+        animationStartHandler = sinon.spy();
+        animationEndHandler = sinon.spy();
+        changeHandler = sinon.spy((e) => {
           if (animationStartHandler.calledOnce) {
             ++changeCount;
 
@@ -679,25 +693,24 @@ describe("Axes", function () {
             }
           }
         });
-        this.inst.on({
+        inst.on({
           hold: holdHandler,
           change: changeHandler,
           release: releaseHandler,
           finish: finishHandler,
           animationStart: animationStartHandler,
-          animationEnd: animationEndHandler,
+          animationEnd: animationEndHandler
         });
 
-        const inst = this.inst;
         // When
         Simulator.gestures.pan(
-          this.el,
+          el,
           {
             pos: [0, 0],
             deltaX: 100,
             deltaY: 100,
             duration: 1000,
-            easing: "linear",
+            easing: "linear"
           },
           () => {
             // Then
@@ -717,30 +730,30 @@ describe("Axes", function () {
         );
       });
       it("should check interrupt test when user's action is fast", (done) => {
-        const holdHandler = sinon.spy(this.preventedFn);
-        const changeHandler = sinon.spy(this.preventedFn);
-        const releaseHandler = sinon.spy(this.preventedFn);
-        const finishHandler = sinon.spy(this.notPreventedFn);
-        const animationStartHandler = sinon.spy(this.preventedFn);
-        const animationEndHandler = sinon.spy(this.notPreventedFn);
-        this.inst.on({
+        holdHandler = sinon.spy(preventedFn);
+        changeHandler = sinon.spy(preventedFn);
+        releaseHandler = sinon.spy(preventedFn);
+        finishHandler = sinon.spy(notPreventedFn);
+        animationStartHandler = sinon.spy(preventedFn);
+        animationEndHandler = sinon.spy(notPreventedFn);
+        inst.on({
           hold: holdHandler,
           change: changeHandler,
           release: releaseHandler,
           finish: finishHandler,
           animationStart: animationStartHandler,
-          animationEnd: animationEndHandler,
+          animationEnd: animationEndHandler
         });
 
         // when
         Simulator.gestures.pan(
-          this.el,
+          el,
           {
             pos: [0, 0],
             deltaX: 100,
             deltaY: 100,
             duration: 1000,
-            easing: "linear",
+            easing: "linear"
           },
           () => {
             // Then
@@ -758,65 +771,65 @@ describe("Axes", function () {
         );
       });
     });
-    describe(`Axes Custom Event Test(${type})`, function () {
+    describe(`Axes Custom Event Test(${type})`, () => {
       beforeEach(() => {
         if (type.indexOf("pointer") > -1) {
           Simulator.setType("pointer");
         } else {
           Simulator.setType("touch");
         }
-        this.inst = new Axes(
+        inst = new Axes(
           {
             x: {
               range: [0, 300],
-              bounce: 100,
+              bounce: 100
             },
             y: {
               range: [0, 400],
-              bounce: 100,
-            },
+              bounce: 100
+            }
           },
           {
-            deceleration: 0.001,
+            deceleration: 0.001
           }
         );
-        this.el = sandbox();
-        this.el.innerHTML = `<div id="area"
+        el = sandbox();
+        el.innerHTML = `<div id="area"
         style="position:relative; border:5px solid #444; width:300px; height:400px; color:#aaa; margin:0;box-sizing:content-box; z-index:9;"></div>`;
 
-        this.holdHandler = sinon.spy();
-        this.releaseHandler = sinon.spy();
-        this.finishHandler = sinon.spy();
-        this.animationStartHandler = sinon.spy();
-        this.animationEndHandler = sinon.spy();
+        holdHandler = sinon.spy();
+        releaseHandler = sinon.spy();
+        finishHandler = sinon.spy();
+        animationStartHandler = sinon.spy();
+        animationEndHandler = sinon.spy();
 
-        this.input = new PanInput(this.el, {
-          inputType: type,
+        input = new PanInput(el, {
+          inputType: type
         });
-        this.inst
+        inst
           .on({
-            hold: this.holdHandler,
-            release: this.releaseHandler,
-            finish: this.finishHandler,
-            animationStart: this.animationStartHandler,
-            animationEnd: this.animationEndHandler,
+            hold: holdHandler,
+            release: releaseHandler,
+            finish: finishHandler,
+            animationStart: animationStartHandler,
+            animationEnd: animationEndHandler
           })
-          .connect(["x", "y"], this.input);
+          .connect(["x", "y"], input);
       });
       afterEach(() => {
-        if (this.inst) {
-          this.inst.destroy();
-          this.inst = null;
+        if (inst) {
+          inst.destroy();
+          inst = null;
         }
-        if (this.input) {
-          this.input.destroy();
-          this.input = null;
+        if (input) {
+          input.destroy();
+          input = null;
         }
-        this.holdHandler.resetHistory();
-        this.releaseHandler.resetHistory();
-        this.finishHandler.resetHistory();
-        this.animationStartHandler.resetHistory();
-        this.animationEndHandler.resetHistory();
+        holdHandler.resetHistory();
+        releaseHandler.resetHistory();
+        finishHandler.resetHistory();
+        animationStartHandler.resetHistory();
+        animationEndHandler.resetHistory();
         cleanup();
       });
       after(() => {
@@ -826,23 +839,23 @@ describe("Axes", function () {
       });
       it("should check slow movement test (no-velocity)", (done) => {
         // Given
-        const changeHandler = sinon.spy();
-        this.inst.on("change", changeHandler);
+        changeHandler = sinon.spy();
+        inst.on("change", changeHandler);
 
         // When
         Simulator.gestures.pan(
-          this.el,
+          el,
           {
             pos: [30, 30],
             deltaX: 10,
             deltaY: 10,
             duration: 3000,
-            easing: "linear",
+            easing: "linear"
           },
           () => {
             // Then
-            const holdEvent = this.holdHandler.getCall(0).args[0];
-            expect(this.holdHandler.calledOnce).to.be.true;
+            const holdEvent = holdHandler.getCall(0).args[0];
+            expect(holdHandler.calledOnce).to.be.true;
             expect(holdEvent.pos.x).to.be.equal(0);
             expect(holdEvent.pos.y).to.be.equal(0);
             // expect(holdEvent.inputEvent.isFirst).to.be.true;
@@ -851,86 +864,86 @@ describe("Axes", function () {
             for (let i = 0, len = changeHandler.callCount; i < len; i++) {
               const changeEvent = changeHandler.getCall(i).args[0];
               expect(changeEvent.holding).to.be.true;
-              expect(changeEvent.input).to.be.equal(this.input);
+              expect(changeEvent.input).to.be.equal(input);
               expect(changeEvent.isTrusted).to.be.true;
               expect(changeEvent.inputEvent).to.be.not.equal(null);
             }
-            const releaseEvent = this.releaseHandler.getCall(0).args[0];
-            expect(this.releaseHandler.calledOnce).to.be.true;
+            const releaseEvent = releaseHandler.getCall(0).args[0];
+            expect(releaseHandler.calledOnce).to.be.true;
             // expect(releaseEvent.inputEvent.isFinal).to.be.true;
-            expect(releaseEvent.input).to.be.equal(this.input);
+            expect(releaseEvent.input).to.be.equal(input);
             expect(releaseEvent.isTrusted).to.be.true;
-            expect(this.inst.get()).to.be.eql({ x: 10, y: 10 });
+            expect(inst.get()).to.be.eql({ x: 10, y: 10 });
 
-            const finishEvent = this.finishHandler.getCall(0).args[0];
-            expect(this.finishHandler.calledOnce).to.be.true;
+            const finishEvent = finishHandler.getCall(0).args[0];
+            expect(finishHandler.calledOnce).to.be.true;
             expect(finishEvent.isTrusted).to.be.true;
 
-            expect(this.animationStartHandler.called).to.be.false;
-            expect(this.animationEndHandler.called).to.be.false;
+            expect(animationStartHandler.called).to.be.false;
+            expect(animationEndHandler.called).to.be.false;
             done();
           }
         );
       });
       it("should check slow movement test (no-velocity), release outside", (done) => {
         // Given
-        this.inst.on("change", (e) => {
-          if (this.animationStartHandler.called) {
+        inst.on("change", (e) => {
+          if (animationStartHandler.called) {
             expect(e.holding).to.be.false;
-            expect(this.inst.animationManager.getEventInfo().input).to.be.equal(
+            expect(inst.animationManager.getEventInfo().input).to.be.equal(
               e.input
             );
           } else {
             expect(e.holding).to.be.true;
           }
-          expect(e.input).to.be.equal(this.input);
+          expect(e.input).to.be.equal(input);
           expect(e.inputEvent).to.be.not.equal(null);
           expect(e.isTrusted).to.be.true;
         });
-        this.inst.options.maximumDuration = 200;
+        inst.options.maximumDuration = 200;
 
         // When
         Simulator.gestures.pan(
-          this.el,
+          el,
           {
             pos: [30, 30],
             deltaX: -50,
             deltaY: 10,
             duration: 3000,
-            easing: "linear",
+            easing: "linear"
           },
           () => {
             // Then
             // for test animation event
             setTimeout(() => {
-              const holdEvent = this.holdHandler.getCall(0).args[0];
-              expect(this.holdHandler.calledOnce).to.be.true;
+              const holdEvent = holdHandler.getCall(0).args[0];
+              expect(holdHandler.calledOnce).to.be.true;
               expect(holdEvent.pos.x).to.be.equal(0);
               expect(holdEvent.pos.y).to.be.equal(0);
               // expect(holdEvent.inputEvent.isFirst).to.be.true;
-              expect(holdEvent.input).to.be.equal(this.input);
+              expect(holdEvent.input).to.be.equal(input);
               expect(holdEvent.isTrusted).to.be.true;
-              const releaseEvent = this.releaseHandler.getCall(0).args[0];
-              expect(this.releaseHandler.calledOnce).to.be.true;
+              const releaseEvent = releaseHandler.getCall(0).args[0];
+              expect(releaseHandler.calledOnce).to.be.true;
               // expect(releaseEvent.inputEvent.isFinal).to.be.true;
-              expect(releaseEvent.input).to.be.equal(this.input);
+              expect(releaseEvent.input).to.be.equal(input);
               expect(releaseEvent.isTrusted).to.be.true;
 
-              const result = this.inst.get();
+              const result = inst.get();
               expect(result.x).to.be.equal(0);
               expect(result.y).to.be.equal(10);
               expect(releaseEvent.duration).to.be.equal(0);
               expect(releaseEvent.depaPos).to.deep.equal(releaseEvent.destPos);
               const animationStartEvent =
-                this.animationStartHandler.getCall(0).args[0];
-              expect(this.animationStartHandler.called).to.be.true;
+                animationStartHandler.getCall(0).args[0];
+              expect(animationStartHandler.called).to.be.true;
               expect(animationStartEvent.isTrusted).to.be.true;
               const animationEndEvent =
-                this.animationEndHandler.getCall(0).args[0];
+                animationEndHandler.getCall(0).args[0];
               expect(animationEndEvent.isTrusted).to.be.true;
 
-              const finishEvent = this.finishHandler.getCall(0).args[0];
-              expect(this.finishHandler.called).to.be.true;
+              const finishEvent = finishHandler.getCall(0).args[0];
+              expect(finishHandler.called).to.be.true;
               expect(finishEvent.isTrusted).to.be.true;
               done();
             }, 500);
@@ -940,40 +953,40 @@ describe("Axes", function () {
 
       it("should check fast movement test (velocity)", (done) => {
         // Given
-        this.inst.on("change", (e) => {
-          if (this.animationStartHandler.called) {
+        inst.on("change", (e) => {
+          if (animationStartHandler.called) {
             expect(e.holding).to.be.false;
-            expect(this.inst.animationManager.getEventInfo().input).to.be.equal(
+            expect(inst.animationManager.getEventInfo().input).to.be.equal(
               e.input
             );
           } else {
             expect(e.holding).to.be.true;
           }
-          expect(e.input).to.be.equal(this.input);
+          expect(e.input).to.be.equal(input);
           expect(e.inputEvent).to.be.not.equal(null);
           expect(e.isTrusted).to.be.true;
         });
 
         // When
         Simulator.gestures.pan(
-          this.el,
+          el,
           {
             pos: [0, 0],
             deltaX: 100,
             deltaY: 100,
             duration: 500,
-            easing: "linear",
+            easing: "linear"
           },
           () => {
             // Then
             // for test animation event
             setTimeout(() => {
-              expect(this.holdHandler.calledOnce).to.be.true;
-              const releaseEvent = this.releaseHandler.getCall(0).args[0];
-              expect(this.releaseHandler.calledOnce).to.be.true;
-              expect(this.animationStartHandler.calledOnce).to.be.true;
-              expect(this.animationEndHandler.calledOnce).to.be.true;
-              expect(this.finishHandler.calledOnce).to.be.true;
+              expect(holdHandler.calledOnce).to.be.true;
+              const releaseEvent = releaseHandler.getCall(0).args[0];
+              expect(releaseHandler.calledOnce).to.be.true;
+              expect(animationStartHandler.calledOnce).to.be.true;
+              expect(animationEndHandler.calledOnce).to.be.true;
+              expect(finishHandler.calledOnce).to.be.true;
               expect(releaseEvent.duration).to.not.equal(0);
               expect(releaseEvent.depaPos).to.not.equal(releaseEvent.destPos);
               done();
@@ -983,41 +996,41 @@ describe("Axes", function () {
       });
       it("should check movement test when stop method was called in 'animationStart' event", (done) => {
         // Given
-        const holdHandler = sinon.spy();
-        const changeHandler = sinon.spy(function (e) {
+        holdHandler = sinon.spy();
+        changeHandler = sinon.spy((e) => {
           if (animationStartHandler.called) {
             expect(e.holding).to.be.false;
           } else {
             expect(e.holding).to.be.true;
           }
         });
-        const releaseHandler = sinon.spy();
-        const finishHandler = sinon.spy();
-        const animationStartHandler = sinon.spy((e) => {
+        releaseHandler = sinon.spy();
+        finishHandler = sinon.spy();
+        animationStartHandler = sinon.spy((e) => {
           e.stop();
-          setTimeout(function () {
+          setTimeout(() => {
             e.done();
           }, e.duration);
         });
-        const animationEndHandler = sinon.spy(this.notPreventedFn);
-        this.inst.on({
+        animationEndHandler = sinon.spy(notPreventedFn);
+        inst.on({
           hold: holdHandler,
           change: changeHandler,
           release: releaseHandler,
           finish: finishHandler,
           animationStart: animationStartHandler,
-          animationEnd: animationEndHandler,
+          animationEnd: animationEndHandler
         });
 
         // When
         Simulator.gestures.pan(
-          this.el,
+          el,
           {
             pos: [30, 30],
             deltaX: 100,
             deltaY: 100,
             duration: 500,
-            easing: "linear",
+            easing: "linear"
           },
           () => {
             // Then
@@ -1039,24 +1052,24 @@ describe("Axes", function () {
         // When
         let destPos;
 
-        Simulator.gestures.pan(this.el, {
+        Simulator.gestures.pan(el, {
           pos: [0, 0],
           deltaX: 300,
           deltaY: 50,
           duration: 100,
-          easing: "linear",
+          easing: "linear"
         });
 
         // grab while animating
-        this.inst.on("animationStart", (e) => {
+        inst.on("animationStart", (e) => {
           destPos = e.destPos;
-          Simulator.gestures.tap(this.el);
+          Simulator.gestures.tap(el);
         });
 
         // Then
-        this.inst.on("animationEnd", (e) => {
+        inst.on("animationEnd", (e) => {
           setTimeout(() => {
-            let endPos = this.inst.get();
+            const endPos = inst.get();
 
             expect(e.isTrusted).to.be.true;
             expect(endPos.x !== destPos.x || endPos.y !== destPos.y).to.be.true;
@@ -1074,19 +1087,19 @@ describe("Axes", function () {
       { range: [0, 100], destPos: 50.1234 }, // max decimal place at dest pos,
       { range: [0, 100], destPos: 50 }, // no decimal
       { range: [0, 1000], destPos: 445.17079889807155 }, // number to resolve flicking test failure.
-      { range: [0, 1000], destPos: 240.79930795847713 }, // comparison value that works correctly.
+      { range: [0, 1000], destPos: 240.79930795847713 } // comparison value that works correctly.
     ].forEach((val) => {
       it(`should round final value of animation by max decimal place(${val.range[0]}, ${val.range[1]}, ${val.destPos})`, async () => {
-        this.inst = new Axes({
+        inst = new Axes({
           x: {
-            range: val.range,
-          },
+            range: val.range
+          }
         });
 
-        this.inst.setTo({ x: val.destPos }, 100);
-        await new Promise((res) => this.inst.on("finish", res));
+        inst.setTo({ x: val.destPos }, 100);
+        await new Promise((res) => inst.on("finish", res));
 
-        expect(this.inst.get().x).to.be.equal(val.destPos);
+        expect(inst.get().x).to.be.equal(val.destPos);
       });
     });
   });
@@ -1131,13 +1144,13 @@ describe("Axes", function () {
      */
     it("should fire change event with changed value / delta although round is specified", (done) => {
       // Given
-      let result = [];
-      let delta = [];
-      const inst = new Axes(
+      const result = [];
+      const delta = [];
+      inst = new Axes(
         {
           x: {
-            range: [0, 200],
-          },
+            range: [0, 200]
+          }
         },
         { round: 1 }
       );
@@ -1160,21 +1173,21 @@ describe("Axes", function () {
       }, 100);
     });
 
-    function isDividable(dividend, divisor) {
+    const isDividable = (dividend, divisor) => {
       // Round 'dividend / divsior' because it may has decimal error.
       const result = roundNumber(dividend / divisor, 0.000001);
       // Decimal place should be 0
       return getDecimalPlace(result) === 0;
     }
 
-    async function checkAnimatedValueIsRound(round) {
+    const checkAnimatedValueIsRound = async (round) => {
       // Given
-      let dividables = [];
-      const inst = new Axes(
+      const dividables = [];
+      inst = new Axes(
         {
           x: {
-            range: [0, 200],
-          },
+            range: [0, 200]
+          }
         },
         { round }
       ).on({
@@ -1186,7 +1199,7 @@ describe("Axes", function () {
         },
         finish: () => {
           dividables.push(isDividable(inst.get().x, round));
-        },
+        }
       });
 
       // When

--- a/test/unit/AxisManager.spec.js
+++ b/test/unit/AxisManager.spec.js
@@ -1,24 +1,26 @@
 import { AxisManager } from "../../src/AxisManager";
 
-describe("AxisManager", function () {
-  describe("instance method", function () {
+describe("AxisManager", () => {
+	let inst;
+
+  describe("instance method", () => {
     beforeEach(() => {
-      this.inst = new AxisManager({
+      inst = new AxisManager({
         x: {
           range: [0, 100],
           bounce: [50, 50],
-          circular: false,
+          circular: false
         },
         y: {
           range: [0, 200],
           bounce: [0, 0],
-          circular: false,
+          circular: false
         },
         z: {
           range: [-100, 200],
           bounce: [50, 0],
-          circular: true,
-        },
+          circular: true
+        }
       });
     });
     afterEach(() => {});
@@ -26,9 +28,9 @@ describe("AxisManager", function () {
     it("should check 'moveTo' method", () => {
       // Given
       // When (all)
-      let orgPos = this.inst.get();
+      let orgPos = inst.get();
       let moveTo = { x: 10, y: 20, z: 30 };
-      let moved = this.inst.moveTo(moveTo);
+      let moved = inst.moveTo(moveTo);
 
       // Then
       expect(moved.pos).to.be.eql(moveTo);
@@ -36,36 +38,36 @@ describe("AxisManager", function () {
       expect(moved.delta).to.be.eql({
         x: 10,
         y: 20,
-        z: 130,
+        z: 130
       });
 
       // When (single)
       moveTo = { x: 30 };
-      moved = this.inst.moveTo(moveTo);
+      moved = inst.moveTo(moveTo);
 
       // Then
-      orgPos = this.inst.get();
+      orgPos = inst.get();
       expect(moved.pos).to.be.eql(orgPos);
       expect(moved.pos).to.be.not.equal(orgPos);
       expect(moved.delta).to.be.eql({
         x: 20,
         y: 0,
-        z: 0,
+        z: 0
       });
 
       // When (not included)
       moveTo = { notX: 30 };
-      moved = this.inst.moveTo(moveTo);
+      moved = inst.moveTo(moveTo);
 
       // Then
-      orgPos = this.inst.get();
+      orgPos = inst.get();
       expect(orgPos.notX).to.be.undefined;
       expect(moved.pos).to.be.eql(orgPos);
       expect(moved.pos).to.be.not.equal(orgPos);
       expect(moved.delta).to.be.eql({
         x: 0,
         y: 0,
-        z: 0,
+        z: 0
       });
     });
 
@@ -74,20 +76,20 @@ describe("AxisManager", function () {
       // When
 
       // Then
-      expect(this.inst.get()).to.be.eql({ x: 0, y: 0, z: -100 });
+      expect(inst.get()).to.be.eql({ x: 0, y: 0, z: -100 });
 
       // When
-      this.inst.moveTo({ x: 20, y: 40 });
+      inst.moveTo({ x: 20, y: 40 });
 
       // Then
-      expect(this.inst.get(["x"])).to.be.eql({ x: 20 });
-      expect(this.inst.get(["y"])).to.be.eql({ y: 40 });
-      expect(this.inst.get(["z"])).to.be.eql({ z: -100 });
-      expect(this.inst.get(["notX"])).to.be.eql({});
+      expect(inst.get(["x"])).to.be.eql({ x: 20 });
+      expect(inst.get(["y"])).to.be.eql({ y: 40 });
+      expect(inst.get(["z"])).to.be.eql({ z: -100 });
+      expect(inst.get(["notX"])).to.be.eql({});
 
       // When (check reference)
-      const firstGet = this.inst.get();
-      const secondGet = this.inst.get();
+      const firstGet = inst.get();
+      const secondGet = inst.get();
 
       // Then
       expect(firstGet).to.be.eql(secondGet);
@@ -96,84 +98,84 @@ describe("AxisManager", function () {
 
     it("should check 'every' high-order method", () => {
       // Given
-      let orgPos = this.inst.get();
+      const orgPos = inst.get();
       expect(orgPos).to.be.eql({ x: 0, y: 0, z: -100 });
 
       // When
-      this.inst.moveTo({ x: 20, y: 0 });
+      inst.moveTo({ x: 20, y: 0 });
 
       // Then
-      expect(this.inst.every(this.inst.get(), (v, opt, k) => v !== orgPos[k]))
+      expect(inst.every(inst.get(), (v, opt, k) => v !== orgPos[k]))
         .to.be.false;
 
       // When
-      this.inst.moveTo({ x: 20, y: 30, z: 0 });
+      inst.moveTo({ x: 20, y: 30, z: 0 });
 
       // Then
-      expect(this.inst.every(this.inst.get(), (v, opt, k) => v !== orgPos[k]))
+      expect(inst.every(inst.get(), (v, opt, k) => v !== orgPos[k]))
         .to.be.true;
     });
 
     it("should check 'filter' high-order method", () => {
       // Given
-      let orgPos = this.inst.get();
+      const orgPos = inst.get();
       expect(orgPos).to.be.eql({ x: 0, y: 0, z: -100 });
 
       // When
-      this.inst.moveTo({ x: 20, y: 0 });
+      inst.moveTo({ x: 20, y: 0 });
 
       // Then
       expect(
-        this.inst.filter(this.inst.get(), (v, opt, k) => v !== orgPos[k])
+        inst.filter(inst.get(), (v, opt, k) => v !== orgPos[k])
       ).to.be.eql({ x: 20 });
 
       // When
-      this.inst.moveTo({ x: 20, y: 30, z: 0 });
+      inst.moveTo({ x: 20, y: 30, z: 0 });
 
       // Then
       expect(
-        this.inst.filter(this.inst.get(), (v, opt, k) => v !== orgPos[k])
+        inst.filter(inst.get(), (v, opt, k) => v !== orgPos[k])
       ).to.be.eql({ x: 20, y: 30, z: 0 });
     });
 
     it("should check 'map' high-order method", () => {
       // Given
-      let orgPos = this.inst.get();
+      const orgPos = inst.get();
       expect(orgPos).to.be.eql({ x: 0, y: 0, z: -100 });
 
       // When
-      this.inst.moveTo({ x: 20, y: 0 });
+      inst.moveTo({ x: 20, y: 0 });
 
       // Then
-      expect(this.inst.map(this.inst.get(), (v) => v + 20)).to.be.eql({
+      expect(inst.map(inst.get(), (v) => v + 20)).to.be.eql({
         x: 40,
         y: 20,
-        z: -80,
+        z: -80
       });
     });
 
     it("should check 'isOutside' method", () => {
       // Given
       // When
-      let orgPos = this.inst.get();
+      const orgPos = inst.get();
       expect(orgPos).to.be.eql({ x: 0, y: 0, z: -100 });
 
       // Then
-      expect(this.inst.isOutside()).to.be.false;
+      expect(inst.isOutside()).to.be.false;
 
       // When
-      this.inst.moveTo({ x: -50 });
+      inst.moveTo({ x: -50 });
 
       // Then
-      expect(this.inst.isOutside()).to.be.true;
-      expect(this.inst.isOutside(["y", "z"])).to.be.false;
+      expect(inst.isOutside()).to.be.true;
+      expect(inst.isOutside(["y", "z"])).to.be.false;
 
       // When
-      this.inst.moveTo({ x: 50 });
+      inst.moveTo({ x: 50 });
 
       // Then
-      expect(this.inst.isOutside()).to.be.false;
-      expect(this.inst.isOutside(["y", "z"])).to.be.false;
+      expect(inst.isOutside()).to.be.false;
+      expect(inst.isOutside(["y", "z"])).to.be.false;
     });
   });
 });

--- a/test/unit/Coordinate.spec.js
+++ b/test/unit/Coordinate.spec.js
@@ -1,11 +1,11 @@
 import * as Coordinate from "../../src/Coordinate";
 
-describe("Coordinate", function () {
-  describe("getInsidePosition", function () {
+describe("Coordinate", () => {
+  describe("getInsidePosition", () => {
     it("should return inner position", () => {
       // Given
       // When
-      let range = [0, 100];
+      const range = [0, 100];
       let circular = [false, false];
 
       // Then
@@ -31,9 +31,9 @@ describe("Coordinate", function () {
     it("should return inner position with bounce", () => {
       // Given
       // When
-      let range = [0, 100];
+      const range = [0, 100];
       let circular = [false, false];
-      let bounce = [50, 100];
+      const bounce = [50, 100];
 
       // Then
       expect(
@@ -92,11 +92,11 @@ describe("Coordinate", function () {
     });
   });
 
-  describe("isOutside", function () {
+  describe("isOutside", () => {
     it("should check if pos is outside", () => {
       // Given
       // When
-      let range = [0, 100];
+      const range = [0, 100];
 
       // Then
       expect(Coordinate.isOutside(0, range)).to.false;
@@ -107,11 +107,11 @@ describe("Coordinate", function () {
     });
   });
 
-  describe("isCircularable", function () {
+  describe("isCircularable", () => {
     it("should check if pos is circularable", () => {
       // Given
       // When
-      let range = [0, 100];
+      const range = [0, 100];
       let circular = [false, false];
 
       // Then
@@ -133,7 +133,7 @@ describe("Coordinate", function () {
     });
   });
 
-  describe("getCirculatedPos", function () {
+  describe("getCirculatedPos", () => {
     it("should calculate position circular", () => {
       // Given
       // When

--- a/test/unit/InputObserver.spec.js
+++ b/test/unit/InputObserver.spec.js
@@ -1,110 +1,117 @@
 import Axes from "../../src/Axes";
 
-describe("InputObserver", function () {
-  describe("observer test", function () {
+describe("InputObserver", () => {
+	let inst;
+	let options;
+	let axes;
+	let axis;
+	let axisManager;
+	let animationManager;
+
+  describe("observer test", () => {
     beforeEach(() => {
-      this.axis = {
+      axis = {
         x: {
           range: [0, 100],
           bounce: [50, 50],
-          circular: false,
+          circular: false
         },
         y: {
           range: [0, 200],
           bounce: [0, 0],
-          circular: false,
+          circular: false
         },
         z: {
           range: [-100, 200],
           bounce: [50, 0],
-          circular: true,
-        },
+          circular: true
+        }
       };
-      this.options = {
+      options = {
         deceleration: 0.0001,
         maximumDuration: 2000,
-        minimumDuration: 0,
+        minimumDuration: 0
       };
-      this.axes = new Axes(this.axis, this.options);
-      this.axisManager = this.axes.axisManager;
-      this.animationManager = this.axes.animationManager;
-      this.inst = this.axes.inputObserver;
+      axes = new Axes(axis, options);
+      axisManager = axes.axisManager;
+      animationManager = axes.animationManager;
+      inst = axes.inputObserver;
     });
     afterEach(() => {});
 
     it("should check 'get' method", () => {
       // Given
       const inputType = {
-        axes: ["y"],
+        axes: ["y"]
       };
 
       // When/Then
-      expect(this.inst.get(inputType)).to.be.eql({ y: 0 });
+      expect(inst.get(inputType)).to.be.eql({ y: 0 });
 
       // When
-      this.inst._axisManager.moveTo({ x: 10, y: 20, z: 30 });
+      inst._axisManager.moveTo({ x: 10, y: 20, z: 30 });
 
       // Then
-      expect(this.inst.get(inputType)).to.be.eql({ y: 20 });
+      expect(inst.get(inputType)).to.be.eql({ y: 20 });
     });
     it("should check 'change' method", () => {
       // Given
       const inputType = {
-        axes: ["y"],
+        axes: ["y"]
       };
 
       // When/Then
-      expect(this.inst.get(inputType)).to.be.eql({ y: 0 });
+      expect(inst.get(inputType)).to.be.eql({ y: 0 });
 
       // When
-      this.inst.change(inputType, {}, {});
-      expect(this.inst.get(inputType)).to.be.not.eql({ y: 200 });
+      inst.change(inputType, {}, {});
+      expect(inst.get(inputType)).to.be.not.eql({ y: 200 });
 
-      this.inst.hold(inputType, {});
-      this.inst.change(inputType, {}, { y: 250 });
+      inst.hold(inputType, {});
+      inst.change(inputType, {}, { y: 250 });
 
       // Then
-      expect(this.inst.get(inputType)).to.be.eql({ y: 200 });
+      expect(inst.get(inputType)).to.be.eql({ y: 200 });
     });
     [1, -1].forEach((direction) => {
       it(`should check delta that dragged out of bounce area(direction: ${direction})`, (done) => {
         // Given
         // start pos
-        let depaPos = direction > 0 ? 200 : 0;
+        const depaPos = direction > 0 ? 200 : 0;
 
-        this.axes.setTo({ y: depaPos }, 0);
-        this.axes.on("change", ({ delta }) => {
+        axes.setTo({ y: depaPos }, 0);
+        axes.on("change", ({ delta }) => {
           // Then
           expect(delta.y).to.be.equals(0);
         });
-        this.axes.on("finish", () => {
+        axes.on("finish", () => {
           done();
         });
 
         // When
         const inputType = {
-          axes: ["y"],
+          axes: ["y"]
         };
         const sign = direction > 0 ? 1 : -1;
-        this.inst.hold(inputType);
+        inst.hold(inputType);
         // The last y position should be zero and neither should Delta.
         // y goes to zero without bounce.
-        this.inst.change(inputType, {}, { y: sign * 10 });
-        this.inst.change(inputType, {}, { y: sign * 20 });
-        this.inst.change(inputType, {}, { y: sign * 30 });
-        this.inst.change(inputType, {}, { y: sign * 40 });
-        this.inst.release(inputType, {}, [0, 0, 0]);
+        inst.change(inputType, {}, { y: sign * 10 });
+        inst.change(inputType, {}, { y: sign * 20 });
+        inst.change(inputType, {}, { y: sign * 30 });
+        inst.change(inputType, {}, { y: sign * 40 });
+        inst.release(inputType, {}, [0, 0, 0]);
       });
 
       it(`should check delta that dragged bounce area (direction: ${direction})`, (done) => {
         // Given
         // start pos
-        let depaPos = direction > 0 ? 100 : 0;
+        const depaPos = direction > 0 ? 100 : 0;
 
-        this.axes.setTo({ x: depaPos }, 0);
+        axes.setTo({ x: depaPos }, 0);
 
         let isFirstTime = true;
-        this.axes.on("change", ({ delta }) => {
+        axes.on("change", ({ delta }) => {
           // Then
           if (isFirstTime) {
             // bounce area
@@ -114,36 +121,36 @@ describe("InputObserver", function () {
           // out of bounce area
           expect(delta.x).to.be.equals(0);
         });
-        this.axes.on("finish", () => {
+        axes.on("finish", () => {
           done();
         });
 
         // When
         const inputType = {
-          axes: ["x"],
+          axes: ["x"]
         };
         const sign = direction > 0 ? 1 : -1;
-        this.inst.hold(inputType);
+        inst.hold(inputType);
         // Move them approximately 150 by slope bounce to reach the end.
         // bounce area
-        this.inst.change(inputType, {}, { x: sign * 150 });
+        inst.change(inputType, {}, { x: sign * 150 });
         // out of bounce area
-        this.inst.change(inputType, {}, { x: sign * 10 });
-        this.inst.change(inputType, {}, { x: sign * 10 });
-        this.inst.change(inputType, {}, { x: sign * 10 });
+        inst.change(inputType, {}, { x: sign * 10 });
+        inst.change(inputType, {}, { x: sign * 10 });
+        inst.change(inputType, {}, { x: sign * 10 });
 
-        this.axes.off("change");
-        this.inst.release(inputType, {}, [0, 0, 0]);
+        axes.off("change");
+        inst.release(inputType, {}, [0, 0, 0]);
       });
       it(`should check delta that 'circular' option was enabled(direction: ${direction})`, (done) => {
         // Given
         // start pos
-        let depaPos = direction > 0 ? 180 : 0;
-        let destPos = direction > 0 ? 300 : -180;
+        const depaPos = direction > 0 ? 180 : 0;
+        const destPos = direction > 0 ? 300 : -180;
         let z = depaPos;
 
-        this.axes.setTo({ z: depaPos }, 0);
-        this.axes.on("change", ({ pos, delta }) => {
+        axes.setTo({ z: depaPos }, 0);
+        axes.on("change", ({ pos, delta }) => {
           // Then
           // Find the value as approximated as possible due to floating decimal point problems.
 
@@ -164,113 +171,113 @@ describe("InputObserver", function () {
             z = pos.z;
           }
         });
-        this.axes.on("finish", () => {
+        axes.on("finish", () => {
           done();
         });
 
         // When
         // The last y position should be zero and neither should Delta.
-        this.axes.setTo({ z: destPos }, 300);
+        axes.setTo({ z: destPos }, 300);
       });
     });
     it("should check delta that there is no bounce and the position goes to zero.", (done) => {
       // Given
       const inputType = {
-        axes: ["y"],
+        axes: ["y"]
       };
       // start pos
       let y = 50;
-      this.axes.setTo({ y: 50 }, 0);
-      this.axes.on("change", ({ pos, delta }) => {
+      axes.setTo({ y: 50 }, 0);
+      axes.on("change", ({ pos, delta }) => {
         // Then
         // Find the value as approximated as possible due to floating decimal point problems.
         expect(delta.y + y).to.be.closeTo(pos.y, 0.0000001);
 
         y = pos.y;
       });
-      this.axes.on("finish", () => {
+      axes.on("finish", () => {
         done();
       });
 
       // When
       // The last y position should be zero and neither should Delta.
-      this.axes.setTo({ y: 0 }, 300);
+      axes.setTo({ y: 0 }, 300);
     });
     it("should check delta that there is circular", (done) => {
       // Given
       // start pos
       let z = 0;
-      this.axes.setTo({ z: 0 }, 0);
-      this.axes.on("change", ({ delta }) => {
+      axes.setTo({ z: 0 }, 0);
+      axes.on("change", ({ delta }) => {
         z += delta.z;
         // Delta is high if the speed is too fast.
         expect(Math.abs(delta.z)).to.be.below(60);
       });
-      this.axes.on("finish", () => {
+      axes.on("finish", () => {
         expect(z).to.be.closeTo(1000, 0.001);
         done();
       });
 
       // When
       const inputType = {
-        axes: ["z"],
+        axes: ["z"]
       };
-      this.inst.hold(inputType);
+      inst.hold(inputType);
       // 40 * 25
       for (let i = 0; i < 25; ++i) {
-        this.inst.change(inputType, {}, { z: 40 });
+        inst.change(inputType, {}, { z: 40 });
       }
-      this.inst.release(inputType, {}, [0, 0, 0]);
+      inst.release(inputType, {}, [0, 0, 0]);
     });
     it("should check delta that there is no bounce and the position is out", (done) => {
       // Given
       const inputType = {
-        axes: ["y"],
+        axes: ["y"]
       };
       // start pos
-      let y = 50;
-      this.axes.setTo({ y: 50 }, 0);
-      this.axes.on("change", ({ pos, delta }) => {
+      const y = 50;
+      axes.setTo({ y: 50 }, 0);
+      axes.on("change", ({ pos, delta }) => {
         // Then
         // Find the value as approximated as possible due to floating decimal point problems.
         expect(delta.y + 50).to.be.closeTo(pos.y, 0.0000001);
       });
-      this.axes.on("finish", () => {
+      axes.on("finish", () => {
         done();
       });
 
       // When
 
-      this.inst.hold(inputType);
+      inst.hold(inputType);
       // The last y position should be zero and neither should Delta.
       // y goes to zero without bounce.
-      this.inst.change(inputType, {}, { y: -60 });
-      this.inst.release(inputType, {}, [0, 0, 0]);
+      inst.change(inputType, {}, { y: -60 });
+      inst.release(inputType, {}, [0, 0, 0]);
     });
     it("should check delta that there is bounce and the position is out", (done) => {
       // Given
       const inputType = {
-        axes: ["x"],
+        axes: ["x"]
       };
 
       // start pos
       let x = 50;
-      this.axes.setTo({ x: 50 }, 0);
-      this.axes.on("change", ({ pos, delta }) => {
+      axes.setTo({ x: 50 }, 0);
+      axes.on("change", ({ pos, delta }) => {
         // Then
         // Find the value as approximated as possible due to floating decimal point problems.
         expect(delta.x + x).to.be.closeTo(pos.x, 0.0000001);
         x = pos.x;
       });
-      this.axes.on("finish", () => {
+      axes.on("finish", () => {
         done();
       });
 
       // When
-      this.inst.hold(inputType);
+      inst.hold(inputType);
       // x bounces by -10 and returns to zero.
-      this.inst.change(inputType, {}, { x: -60 });
-      this.inst.release(inputType, {}, [0, 0, 0]);
+      inst.change(inputType, {}, { x: -60 });
+      inst.release(inputType, {}, [0, 0, 0]);
     });
   });
 });

--- a/test/unit/inputType/InputType.spec.js
+++ b/test/unit/inputType/InputType.spec.js
@@ -7,65 +7,78 @@ import { TouchEventInput } from "../../../src/eventInput/TouchEventInput";
 import { TouchMouseEventInput } from "../../../src/eventInput/TouchMouseEventInput";
 
 describe("InputType", () => {
-  describe("SUPPORT_TOUCH mocking", function() {
+  describe("SUPPORT_TOUCH mocking", () => {
     it("should check convertInputType when supporting touch", () => {
       // Given
       const MockEventInjector = EventInjector();
       const MockInputInjector = InputInjector({
-		  "../eventInput/EventInput": MockEventInjector,
-	  });
+        "../eventInput/EventInput": MockEventInjector
+      });
 
       MockEventInjector.SUPPORT_TOUCH = true;
       MockEventInjector.SUPPORT_POINTER_EVENTS = true;
       // When
-      let inputType = ["pointer", "touch", "mouse" ];
+      let inputType = ["pointer", "touch", "mouse"];
       // Then
-      expect(MockInputInjector.convertInputType(inputType) instanceof PointerEventInput).to.be.equal(true);
+      expect(
+        MockInputInjector.convertInputType(inputType) instanceof
+          PointerEventInput
+      ).to.be.equal(true);
       MockEventInjector.SUPPORT_POINTER_EVENTS = false;
 
-      expect(MockInputInjector.convertInputType(inputType) instanceof TouchMouseEventInput).to.be.equal(true);
+      expect(
+        MockInputInjector.convertInputType(inputType) instanceof
+          TouchMouseEventInput
+      ).to.be.equal(true);
       // When
-      inputType = [ "touch" ];
+      inputType = ["touch"];
       // Then
-      expect(MockInputInjector.convertInputType(inputType) instanceof TouchEventInput).to.be.equal(true);
-
-	  // When
-      inputType = [ "mouse" ];
-      // Then
-      expect(MockInputInjector.convertInputType(inputType) instanceof MouseEventInput).to.be.equal(true);
+      expect(
+        MockInputInjector.convertInputType(inputType) instanceof TouchEventInput
+      ).to.be.equal(true);
 
       // When
-      inputType = [ ];
+      inputType = ["mouse"];
+      // Then
+      expect(
+        MockInputInjector.convertInputType(inputType) instanceof MouseEventInput
+      ).to.be.equal(true);
+
+      // When
+      inputType = [];
       // Then
       expect(MockInputInjector.convertInputType(inputType)).to.be.null;
     });
-
 
     it("should check convertInputType when not supporting touch", () => {
       // Given
       const MockEventInjector = EventInjector();
       const MockInputInjector = InputInjector({
-		  "../eventInput/EventInput": MockEventInjector,
-	  });
+        "../eventInput/EventInput": MockEventInjector
+      });
       MockEventInjector.SUPPORT_TOUCH = false;
 
       // When
-      let inputType = [ "touch", "mouse" ];
+      let inputType = ["touch", "mouse"];
       // Then
-      expect(MockInputInjector.convertInputType(inputType) instanceof MouseEventInput).to.be.equal(true);
+      expect(
+        MockInputInjector.convertInputType(inputType) instanceof MouseEventInput
+      ).to.be.equal(true);
 
       // When
-      inputType = [ "touch" ];
+      inputType = ["touch"];
       // Then
       expect(MockInputInjector.convertInputType(inputType)).to.be.null;
 
       // When
-      inputType = [ "mouse" ];
+      inputType = ["mouse"];
       // Then
-      expect(MockInputInjector.convertInputType(inputType) instanceof MouseEventInput).to.be.equal(true);
+      expect(
+        MockInputInjector.convertInputType(inputType) instanceof MouseEventInput
+      ).to.be.equal(true);
 
       // When
-      inputType = [ ];
+      inputType = [];
       // Then
       expect(MockInputInjector.convertInputType(inputType)).to.be.null;
     });

--- a/test/unit/inputType/MoveKeyInput.spec.js
+++ b/test/unit/inputType/MoveKeyInput.spec.js
@@ -1,66 +1,82 @@
-import TestHelper from "./TestHelper";
 import Axes from "../../../src/Axes.ts";
-import {MoveKeyInput,
-  KEY_A, KEY_D, KEY_DOWN_ARROW, KEY_TOP_ARROW, KEY_LEFT_ARROW,
-  KEY_RIGHT_ARROW, KEY_S, KEY_UP_ARROW, KEY_W} from "../../../src/inputType/MoveKeyInput";
-import {UNIQUEKEY} from "../../../src/inputType/InputType";
+import {
+  MoveKeyInput,
+  KEY_A,
+  KEY_D,
+  KEY_DOWN_ARROW,
+  KEY_TOP_ARROW,
+  KEY_LEFT_ARROW,
+  KEY_RIGHT_ARROW,
+  KEY_S,
+  KEY_UP_ARROW,
+  KEY_W
+} from "../../../src/inputType/MoveKeyInput";
+
+import TestHelper from "./TestHelper";
 
 describe("MoveKeyInput", () => {
-  describe("instance method", function() {
+	let el;
+	let elBody;
+	let input;
+	let inst;
+	let observer;
+	let timer;
+
+  describe("instance method", () => {
     beforeEach(() => {
-      this.inst = new MoveKeyInput(sandbox());
+      inst = new MoveKeyInput(sandbox());
     });
     afterEach(() => {
-      if (this.inst) {
-        this.inst.destroy();
-        this.inst = null;
+      if (inst) {
+        inst.destroy();
+        inst = null;
       }
       cleanup();
     });
     it("should check status after disconnect", () => {
       // Given
-      this.inst.connect({});
+      inst.connect({});
 
       // When
-      this.inst.disconnect();
+      inst.disconnect();
 
       // Then
-      expect(this.observer).to.be.not.exist;
-      expect(this.inst.element).to.be.exist;
-      expect(this._timer).to.be.not.exist;
+      expect(observer).to.be.not.exist;
+      expect(inst.element).to.be.exist;
+      expect(timer).to.be.not.exist;
     });
     it("should check status after destroy", () => {
       // Given
-      this.inst.connect({});
+      inst.connect({});
 
       // When
-      this.inst.destroy();
+      inst.destroy();
 
       // Then
-      expect(this.inst.element).to.be.not.exist;
-      expect(this.observer).to.be.not.exist;
-      expect(this._timer).to.be.not.exist;
-      this.inst = null;
+      expect(inst.element).to.be.not.exist;
+      expect(observer).to.be.not.exist;
+      expect(timer).to.be.not.exist;
+      inst = null;
     });
   });
-  describe("enable/disable", function() {
+  describe("enable/disable", () => {
     beforeEach(() => {
-      this.el = sandbox();
-      this.inst = new MoveKeyInput(this.el);
-      this.inst.mapAxes(["x", "y"]);
-      this.observer = {
-        release() {},
-        hold() {},
-        change() {},
+      el = sandbox();
+      inst = new MoveKeyInput(el);
+      inst.mapAxes(["x", "y"]);
+      observer = {
+        release: () => {},
+        hold: () => {},
+        change: () => {},
         options: {
           deceleration: 0.0001
         }
       };
     });
     afterEach(() => {
-      if (this.inst) {
-        this.inst.destroy();
-        this.inst = null;
+      if (inst) {
+        inst.destroy();
+        inst = null;
       }
       cleanup();
     });
@@ -69,125 +85,124 @@ describe("MoveKeyInput", () => {
       // Given
       // When
       // Then
-      expect(this.inst.isEnabled()).to.be.false;
+      expect(inst.isEnabled()).to.be.false;
 
       // When
-      this.inst.disable();
+      inst.disable();
 
       // Then
-      expect(this.inst.isEnabled()).to.be.false;
+      expect(inst.isEnabled()).to.be.false;
 
       // When
-      this.inst.enable();
+      inst.enable();
 
       // Then
-      expect(this.inst.isEnabled()).to.be.true;
+      expect(inst.isEnabled()).to.be.true;
 
       // When (after connection)
-      this.inst.connect(this.observer);
-      this.inst.enable();
+      inst.connect(observer);
+      inst.enable();
 
       // Then
-      expect(this.inst.isEnabled()).to.be.true;
+      expect(inst.isEnabled()).to.be.true;
     });
   });
 
-  describe("No axes keydown event test", function() {
+  describe("No axes keydown event test", () => {
     beforeEach(() => {
-      this.elBody = sandbox();
-      this.el = document.createElement("div");
-      this.elBody.appendChild(this.el);
+      elBody = sandbox();
+      el = document.createElement("div");
+      elBody.appendChild(el);
 
-      this.input = new MoveKeyInput(this.el);
-      this.inst = new Axes({
+      input = new MoveKeyInput(el);
+      inst = new Axes({
         x: {
-            range: [10, 120]
+          range: [10, 120]
         },
         y: {
-            range: [10, 120]
+          range: [10, 120]
         }
       });
     });
 
     afterEach(() => {
-      if (this.ins) {
-        this.inst.destroy();
-        this.inst = null;
+      if (inst) {
+        inst.destroy();
+        inst = null;
       }
-      if (this.input) {
-        this.input.destroy();
-        this.input = null;
+      if (input) {
+        input.destroy();
+        input = null;
       }
       cleanup();
     });
 
     it("no event triggering when connet no axes(Left, Right)", (done) => {
       const change = sinon.spy();
-      this.inst.connect([], this.input);
-      this.inst.on("change", change);
-      TestHelper.key(this.el, "keydown", {keyCode: KEY_RIGHT_ARROW}, () => {
+      inst.connect([], input);
+      inst.on("change", change);
+      TestHelper.key(el, "keydown", { keyCode: KEY_RIGHT_ARROW }, () => {
         expect(change.calledOnce).to.be.false;
         done();
       });
     });
     it("no event triggering when connet no axes(Top, Bottom)", (done) => {
       const change = sinon.spy();
-      this.inst.connect([], this.input);
-      this.inst.on("change", change);
-      TestHelper.key(this.el, "keydown", {keyCode: KEY_TOP_ARROW}, () => {
+      inst.connect([], input);
+      inst.on("change", change);
+      TestHelper.key(el, "keydown", { keyCode: KEY_TOP_ARROW }, () => {
         expect(change.calledOnce).to.be.false;
         done();
       });
     });
   });
-  describe("Keydown event test", function() {
+  describe("Keydown event test", () => {
     beforeEach(() => {
-      this.elBody = sandbox();
-      this.el = document.createElement("div");
-      this.elBody.appendChild(this.el);
+      elBody = sandbox();
+      el = document.createElement("div");
+      elBody.appendChild(el);
 
-      this.input = new MoveKeyInput(this.el);
-      this.inst = new Axes({
+      input = new MoveKeyInput(el);
+      inst = new Axes({
         x: {
-            range: [10, 120]
+          range: [10, 120]
         },
         y: {
-            range: [10, 120]
+          range: [10, 120]
         }
       });
 
-      this.inst.connect(["x", "y"], this.input);
+      inst.connect(["x", "y"], input);
     });
 
     afterEach(() => {
-      if (this.ins) {
-        this.inst.destroy();
-        this.inst = null;
+      if (inst) {
+        inst.destroy();
+        inst = null;
       }
-      if (this.input) {
-        this.input.destroy();
-        this.input = null;
+      if (input) {
+        input.destroy();
+        input = null;
       }
       cleanup();
     });
 
     it("no event triggering when disconnected", (done) => {
-        // Given
-        const rightArrayKeyCode = {keyCode: KEY_RIGHT_ARROW};
-        let changeTriggered = false;
+      // Given
+      const rightArrayKeyCode = { keyCode: KEY_RIGHT_ARROW };
+      let changeTriggered = false;
 
-        this.inst
-        .on("change", () => {
-            changeTriggered = true;
-        });
-        this.inst.disconnect();
+      inst.on("change", () => {
+        changeTriggered = true;
+      });
+      inst.disconnect();
 
-        // When
-        TestHelper.key(this.el, "keydown", rightArrayKeyCode, () => {
-            // Then
-            expect(changeTriggered).to.be.false;
-            done();
-	    });
+      // When
+      TestHelper.key(el, "keydown", rightArrayKeyCode, () => {
+        // Then
+        expect(changeTriggered).to.be.false;
+        done();
+      });
     });
 
     it("no event triggering when pressed is not move key", (done) => {
@@ -195,208 +210,217 @@ describe("MoveKeyInput", () => {
       const bKeyCode = 66;
       let changeTriggered = false;
 
-      this.inst
-      .on("change", () => {
+      inst.on("change", () => {
         changeTriggered = true;
       });
 
       // When
-      TestHelper.key(this.el, "keydown", bKeyCode, () => {
+      TestHelper.key(el, "keydown", bKeyCode, () => {
         // Then
         expect(changeTriggered).to.be.false;
         done();
       });
-
     });
 
     // left
     [KEY_LEFT_ARROW, KEY_A].forEach((keyCode, idx) => {
-        it("should trigger 'change' event to left(keyCode: "+keyCode+")", (done) => {
-            // Given
-            let changeTriggered = false;
-            let deltaX = 0;
-            const leftKeyCode = {
-                keyCode: keyCode
-            };
-            this.input.options.scale[0] = -1;
-            this.inst
-            .on("change", (e) => {
-              deltaX = e.delta.x;
-              changeTriggered = true;
-            });
+      it(
+        "should trigger 'change' event to left(keyCode: " + keyCode + ")",
+        (done) => {
+          // Given
+          let changeTriggered = false;
+          let deltaX = 0;
+          const leftKeyCode = {
+            keyCode: keyCode
+          };
+          input.options.scale[0] = -1;
+          inst.on("change", (e) => {
+            deltaX = e.delta.x;
+            changeTriggered = true;
+          });
 
-            // When
-            TestHelper.key(this.el, "keydown", leftKeyCode);
+          // When
+          TestHelper.key(el, "keydown", leftKeyCode);
 
-            // Then
-            expect(changeTriggered).to.be.true;
-            expect(deltaX).to.be.equal(1);
-            done();
-        });
+          // Then
+          expect(changeTriggered).to.be.true;
+          expect(deltaX).to.be.equal(1);
+          done();
+        }
+      );
     });
 
     // right
     [KEY_RIGHT_ARROW, KEY_D].forEach((keyCode, idx) => {
-        it("should trigger 'change' event to right(keyCode: "+keyCode+")", done => {
-            // Given
-            let changeTriggered = false;
-            let deltaX = 0;
-            const rightKeyCode = {
-                keyCode: keyCode
-            };
-            const change = sinon.spy(e => {
-              deltaX = e.delta.x;
-              changeTriggered = true;
-              expect(deltaX).to.be.equal(1);
-              this.inst.off("change");
-            })
-            const hold = sinon.spy();
+      it(
+        "should trigger 'change' event to right(keyCode: " + keyCode + ")",
+        (done) => {
+          // Given
+          let changeTriggered = false;
+          let deltaX = 0;
+          const rightKeyCode = {
+            keyCode: keyCode
+          };
+          const change = sinon.spy((e) => {
+            deltaX = e.delta.x;
+            changeTriggered = true;
+            expect(deltaX).to.be.equal(1);
+            inst.off("change");
+          });
+          const hold = sinon.spy();
 
-            this.inst.on("hold", hold);
-            this.inst.on("change", change);
+          inst.on("hold", hold);
+          inst.on("change", change);
 
-            // When / Then
-            expect(this.input._holding).to.be.false;
-            TestHelper.key(this.el, "keydown", rightKeyCode, e => {
-              expect(this.input._holding).to.be.true;
+          // When / Then
+          expect(input._holding).to.be.false;
+          TestHelper.key(el, "keydown", rightKeyCode, (e) => {
+            expect(input._holding).to.be.true;
+            expect(hold.callCount).to.be.equal(1);
+
+            // Then
+            expect(change.calledOnce).to.be.true;
+
+            TestHelper.key(el, "keydown", rightKeyCode, (e) => {
+              expect(input._holding).to.be.true;
               expect(hold.callCount).to.be.equal(1);
-
-                // Then
-              expect(change.calledOnce).to.be.true;
-
-
-              TestHelper.key(this.el, "keydown", rightKeyCode, e => {
-                expect(this.input._holding).to.be.true;
-                expect(hold.callCount).to.be.equal(1);
-                done();
-              });
+              done();
             });
-        });
+          });
+        }
+      );
     });
 
     // up
     [KEY_UP_ARROW, KEY_W].forEach((keyCode, idx) => {
-        it("should trigger 'change' event to up("+keyCode+")", (done) => {
-            // Given
-            let changeTriggered = false;
-            let deltaY = 0;
-            const upKeyCode = {
-                keyCode: keyCode
-            };
-            const change = sinon.spy(e => {
-              deltaY = e.delta.y;
-              changeTriggered = true;
-              expect(deltaY).to.be.equal(1);
-              this.inst.off("change");
-            })
-            const hold = sinon.spy();
-
-            this.inst.on("hold", hold);
-            this.inst.on("change", change);
-
-            expect(this.input._holding).to.be.false;
-            // When
-            TestHelper.key(this.el, "keydown", upKeyCode, e => {
-              expect(this.input._holding).to.be.true;
-              expect(hold.callCount).to.be.equal(1);
-
-                // Then
-              expect(change.calledOnce).to.be.true;
-
-
-              TestHelper.key(this.el, "keydown", upKeyCode, e => {
-                expect(this.input._holding).to.be.true;
-                expect(hold.callCount).to.be.equal(1);
-                done();
-              });
-            });
-
+      it("should trigger 'change' event to up(" + keyCode + ")", (done) => {
+        // Given
+        let changeTriggered = false;
+        let deltaY = 0;
+        const upKeyCode = {
+          keyCode: keyCode
+        };
+        const change = sinon.spy((e) => {
+          deltaY = e.delta.y;
+          changeTriggered = true;
+          expect(deltaY).to.be.equal(1);
+          inst.off("change");
         });
+        const hold = sinon.spy();
+
+        inst.on("hold", hold);
+        inst.on("change", change);
+
+        expect(input._holding).to.be.false;
+        // When
+        TestHelper.key(el, "keydown", upKeyCode, (e) => {
+          expect(input._holding).to.be.true;
+          expect(hold.callCount).to.be.equal(1);
+
+          // Then
+          expect(change.calledOnce).to.be.true;
+
+          TestHelper.key(el, "keydown", upKeyCode, (e) => {
+            expect(input._holding).to.be.true;
+            expect(hold.callCount).to.be.equal(1);
+            done();
+          });
+        });
+      });
     });
 
     // down
     [KEY_DOWN_ARROW, KEY_S].forEach((keyCode, idx) => {
-        it("should trigger 'change' event to down("+keyCode+")", () => {
-            // Given
-            let changeTriggered = false;
-            let deltaY = 0;
-            this.inst
-            .on("change", (e) => {
-                deltaY = e.delta.y;
-                changeTriggered = true;
-            });
-            const downKeyCode = {
-                keyCode: keyCode
-            };
-            this.input.options.scale[1] = -1;
-
-            // When
-            TestHelper.key(this.el, "keydown", downKeyCode);
-
-            // Then
-            expect(changeTriggered).to.be.true;
-            expect(deltaY).to.be.equal(1);
+      it("should trigger 'change' event to down(" + keyCode + ")", () => {
+        // Given
+        let changeTriggered = false;
+        let deltaY = 0;
+        inst.on("change", (e) => {
+          deltaY = e.delta.y;
+          changeTriggered = true;
         });
+        const downKeyCode = {
+          keyCode: keyCode
+        };
+        input.options.scale[1] = -1;
+
+        // When
+        TestHelper.key(el, "keydown", downKeyCode);
+
+        // Then
+        expect(changeTriggered).to.be.true;
+        expect(deltaY).to.be.equal(1);
+      });
     });
     // down
     [1, 2, 3, 4].forEach((keyCode, idx) => {
-      it("should not trigger 'change' event to down wrong keyCode("+keyCode+")", done => {
+      it(
+        "should not trigger 'change' event to down wrong keyCode(" +
+          keyCode +
+          ")",
+        (done) => {
           // Given
-          let changeTriggered = false;
-          let deltaY = 0;
           const changeHandler = sinon.spy();
           const holdHandler = sinon.spy();
           const releaseHandler = sinon.spy();
           const downKeyCode = {
-              keyCode: keyCode
+            keyCode: keyCode
           };
 
-
-          this.inst.on("hold", holdHandler);
-          this.inst.on("change", changeHandler);
-          this.inst.on("release", releaseHandler);
+          inst.on("hold", holdHandler);
+          inst.on("change", changeHandler);
+          inst.on("release", releaseHandler);
 
           // When
-          TestHelper.key(this.el, "keydown", downKeyCode);
+          TestHelper.key(el, "keydown", downKeyCode);
 
           // Then
           expect(changeHandler.calledOnce).to.be.false;
           expect(holdHandler.calledOnce).to.be.false;
           setTimeout(() => {
-            TestHelper.key(this.el, "keyup", downKeyCode);
+            TestHelper.key(el, "keyup", downKeyCode);
             expect(releaseHandler.calledOnce).to.be.false;
             done();
           }, 100);
-      });
-      it("triggering order test to down wrong keyCode("+keyCode+")", (done) => {
-        // Given
-        const deltaY = 1;
-        const eventLog = [];
-        const eventLogAnswer = ["hold", "change", "release"];
+        }
+      );
+      it(
+        "triggering order test to down wrong keyCode(" + keyCode + ")",
+        (done) => {
+          // Given
+          const eventLog = [];
+          const eventLogAnswer = ["hold", "change", "release"];
 
-        this.inst
-        .on("hold", () => {
-          eventLog.push("hold");
-        }).on("change", () => {
-          eventLog.push("change");
-        }).on("release", () => {
-          eventLog.push("release");
-        });
-
-        // When
-        TestHelper.key(this.el, "keydown", {keyCode: KEY_DOWN_ARROW}, () => {
-          setTimeout(()=> {
-            TestHelper.key(this.el, "keyup", {keyCode: keyCode}, () => {
-              setTimeout(()=> {
-                // Then
-                expect(eventLog).to.be.deep.equal(eventLogAnswer);
-                done();
-              }, 100);
+          inst
+            .on("hold", () => {
+              eventLog.push("hold");
+            })
+            .on("change", () => {
+              eventLog.push("change");
+            })
+            .on("release", () => {
+              eventLog.push("release");
             });
-          }, 20);
-        });
-      });
+
+          // When
+          TestHelper.key(
+            el,
+            "keydown",
+            { keyCode: KEY_DOWN_ARROW },
+            () => {
+              setTimeout(() => {
+                TestHelper.key(el, "keyup", { keyCode: keyCode }, () => {
+                  setTimeout(() => {
+                    // Then
+                    expect(eventLog).to.be.deep.equal(eventLogAnswer);
+                    done();
+                  }, 100);
+                });
+              }, 20);
+            }
+          );
+        }
+      );
     });
   });
 });
-

--- a/test/unit/inputType/PanInput.spec.js
+++ b/test/unit/inputType/PanInput.spec.js
@@ -2,107 +2,112 @@ import Axes from "../../../src/Axes.ts";
 import {
   PanInput,
   getDirectionByAngle,
-  useDirection,
+  useDirection
 } from "../../../src/inputType/PanInput";
 import {
   DIRECTION_ALL,
   DIRECTION_HORIZONTAL,
   DIRECTION_NONE,
-  DIRECTION_VERTICAL,
+  DIRECTION_VERTICAL
 } from "../../../src/const";
 
 describe("PanInput", () => {
-  describe("instance method", function () {
+	let el;
+	let input;
+	let inst;
+	let observer;
+
+  describe("instance method", () => {
     beforeEach(() => {
-      this.inst = new PanInput(sandbox());
+      inst = new PanInput(sandbox());
     });
     afterEach(() => {
-      if (this.inst) {
-        this.inst.destroy();
-        this.inst = null;
+      if (inst) {
+        inst.destroy();
+        inst = null;
       }
       cleanup();
     });
     it("should check 'mapAxes' method", () => {
       // when
-      this.inst.mapAxes(["x"]);
+      inst.mapAxes(["x"]);
 
       // then
-      expect(this.inst.axes).to.be.eql(["x"]);
-      expect(this.inst._direction).to.be.equal(DIRECTION_HORIZONTAL);
+      expect(inst.axes).to.be.eql(["x"]);
+      expect(inst._direction).to.be.equal(DIRECTION_HORIZONTAL);
 
       // when
-      this.inst.mapAxes(["", "y"]);
+      inst.mapAxes(["", "y"]);
 
       // then
-      expect(this.inst.axes).to.be.eql(["", "y"]);
-      expect(this.inst._direction).to.be.equal(DIRECTION_VERTICAL);
+      expect(inst.axes).to.be.eql(["", "y"]);
+      expect(inst._direction).to.be.equal(DIRECTION_VERTICAL);
 
       // when
-      this.inst.mapAxes(["x", "y"]);
+      inst.mapAxes(["x", "y"]);
 
       // then
-      expect(this.inst.axes).to.be.eql(["x", "y"]);
-      expect(this.inst._direction).to.be.equal(DIRECTION_ALL);
+      expect(inst.axes).to.be.eql(["x", "y"]);
+      expect(inst._direction).to.be.equal(DIRECTION_ALL);
 
       // when
-      this.inst.mapAxes(["x", "y", "z"]);
+      inst.mapAxes(["x", "y", "z"]);
 
       // then
-      expect(this.inst.axes).to.be.eql(["x", "y", "z"]);
-      expect(this.inst._direction).to.be.equal(DIRECTION_ALL);
+      expect(inst.axes).to.be.eql(["x", "y", "z"]);
+      expect(inst._direction).to.be.equal(DIRECTION_ALL);
     });
     it("should check status after disconnect", () => {
       // Given
-      this.inst.connect({});
+      inst.connect({});
 
       // When
-      this.inst.disconnect();
+      inst.disconnect();
 
       // Then
-      expect(this.observer).to.be.not.exist;
-      expect(this.inst.element).to.be.exist;
-      expect(this.inst._direction).to.be.equal(DIRECTION_NONE);
+      expect(observer).to.be.not.exist;
+      expect(inst.element).to.be.exist;
+      expect(inst._direction).to.be.equal(DIRECTION_NONE);
     });
     it("should check status after destroy", () => {
       // Given
-      this.inst.connect({});
-      const beforeEl = this.inst.element;
+      inst.connect({});
+      const beforeEl = inst.element;
 
       // When
-      this.inst.destroy();
+      inst.destroy();
 
       // Then
-      expect(this.inst.element).to.be.not.exist;
-      expect(this.observer).to.be.not.exist;
-      expect(this.inst._direction).to.be.equal(DIRECTION_NONE);
+      expect(inst.element).to.be.not.exist;
+      expect(observer).to.be.not.exist;
+      expect(inst._direction).to.be.equal(DIRECTION_NONE);
 
-      this.inst = null;
+      inst = null;
     });
   });
-  describe("enable/disable", function () {
+  describe("enable/disable", () => {
     beforeEach(() => {
-      this.el = sandbox();
-      this.input = new PanInput(this.el, {
-        inputType: ["touch", "mouse"],
+      el = sandbox();
+      input = new PanInput(el, {
+        inputType: ["touch", "mouse"]
       });
-      this.inst = new Axes({
+      inst = new Axes({
         x: {
-            range: [0, 200]
+          range: [0, 200]
         },
         y: {
-            range: [0, 200]
+          range: [0, 200]
         }
       });
     });
     afterEach(() => {
-      if (this.inst) {
-        this.inst.destroy();
-        this.inst = null;
+      if (inst) {
+        inst.destroy();
+        inst = null;
       }
-      if (this.input) {
-        this.input.destroy();
-        this.input = null;
+      if (input) {
+        input.destroy();
+        input = null;
       }
       cleanup();
     });
@@ -111,42 +116,42 @@ describe("PanInput", () => {
       // Given
       // When
       // Then
-      expect(this.input.isEnabled()).to.be.false;
+      expect(input.isEnabled()).to.be.false;
 
       // When
-      this.input.enable();
+      input.enable();
 
       // Then
-      expect(this.input.isEnabled()).to.be.true;
+      expect(input.isEnabled()).to.be.true;
 
       // When
-      this.input.disable();
+      input.disable();
 
       // Then
-      expect(this.input.isEnabled()).to.be.false;
+      expect(input.isEnabled()).to.be.false;
     });
     it("should check event when enable method is called", (done) => {
       // Given
       const hold = sinon.spy();
       const change = sinon.spy();
       const release = sinon.spy();
-      this.inst.connect(["x", "y"], this.input);
-      this.inst.on("hold", hold);
-      this.inst.on("change", change);
-      this.inst.on("release", release);
+      inst.connect(["x", "y"], input);
+      inst.on("hold", hold);
+      inst.on("change", change);
+      inst.on("release", release);
 
       // When
-      expect(this.input.isEnabled()).to.be.true;
+      expect(input.isEnabled()).to.be.true;
 
       // When
       Simulator.gestures.pan(
-        this.el,
+        el,
         {
           pos: [0, 0],
           deltaX: 50,
           deltaY: 50,
           duration: 200,
-          easing: "linear",
+          easing: "linear"
         },
         () => {
           // Then
@@ -162,24 +167,24 @@ describe("PanInput", () => {
       const hold = sinon.spy();
       const change = sinon.spy();
       const release = sinon.spy();
-      this.inst.connect(["x", "y"], this.input);
-      this.inst.on("hold", hold);
-      this.inst.on("change", change);
-      this.inst.on("release", release);
+      inst.connect(["x", "y"], input);
+      inst.on("hold", hold);
+      inst.on("change", change);
+      inst.on("release", release);
 
       // When
-      expect(this.input.isEnabled()).to.be.true;
-      this.input.disable();
+      expect(input.isEnabled()).to.be.true;
+      input.disable();
 
       // When
       Simulator.gestures.pan(
-        this.el,
+        el,
         {
           pos: [0, 0],
           deltaX: 50,
           deltaY: 50,
           duration: 200,
-          easing: "linear",
+          easing: "linear"
         },
         () => {
           // Then
@@ -192,9 +197,9 @@ describe("PanInput", () => {
     });
   });
 
-  describe("static method", function () {
+  describe("static method", () => {
     it("should check user's direction", () => {
-      //Given
+      // Given
       // When thresholdAngle = 45
       // Then
       expect(getDirectionByAngle(0, 45)).to.be.equal(DIRECTION_HORIZONTAL);
@@ -305,18 +310,6 @@ describe("PanInput", () => {
       expect(
         useDirection(DIRECTION_VERTICAL, DIRECTION_VERTICAL, DIRECTION_VERTICAL)
       ).to.be.true;
-    });
-  });
-  describe("options test", function () {
-    beforeEach(() => {
-      this.inst = new PanInput(sandbox());
-    });
-    afterEach(() => {
-      if (this.inst) {
-        this.inst.destroy();
-        this.inst = null;
-      }
-      cleanup();
     });
   });
 });

--- a/test/unit/inputType/PanInput.spec.js
+++ b/test/unit/inputType/PanInput.spec.js
@@ -1,9 +1,9 @@
+import Axes from "../../../src/Axes.ts";
 import {
   PanInput,
   getDirectionByAngle,
   useDirection,
 } from "../../../src/inputType/PanInput";
-import { PinchInput } from "../../../src/inputType/PinchInput";
 import {
   DIRECTION_ALL,
   DIRECTION_HORIZONTAL,
@@ -12,123 +12,6 @@ import {
 } from "../../../src/const";
 
 describe("PanInput", () => {
-  describe("when hammer instance is shared", function () {
-    beforeEach(() => {
-      this.el = sandbox();
-      this.inst1 = new PanInput(this.el, {
-        inputType: ["touch", "mouse"],
-      });
-      this.inst2 = new PinchInput(this.el);
-      this.inst1.mapAxes(["x1", "y1"]);
-      this.inst2.mapAxes(["x2"]);
-      const observer = {
-        get() {
-          return {
-            x: 10,
-          };
-        },
-        release() {},
-        hold() {},
-        change() {},
-        options: {
-          deceleration: 0.0001,
-        },
-      };
-      this.inst1.connect(observer);
-      this.inst2.connect(observer);
-
-      this.beforePanstart = this.inst1._onPanstart;
-      this.beforePinchstart = this.inst2._onPinchStart;
-      this.onPanstart = sinon.spy(this.beforePanstart);
-      this.onPinchstart = sinon.spy(this.beforePinchstart);
-    });
-    afterEach(() => {
-      if (this.inst1) {
-        this.inst1.destroy();
-        this.inst1 = null;
-      }
-      if (this.inst2) {
-        this.inst2.destroy();
-        this.inst2 = null;
-      }
-      cleanup();
-    });
-    it("should check multi event (pan/pinch)", (done) => {
-      // Given
-
-      // When
-      expect(this.inst1.element).to.be.equal(this.inst2.element);
-
-      // When
-      Simulator.gestures.pan(
-        this.el,
-        {
-          pos: [0, 0],
-          deltaX: 50,
-          deltaY: 50,
-          duration: 200,
-          easing: "linear",
-        },
-        () => {
-          // Then
-          expect(this.onPanstart.called).to.be.true;
-          expect(this.onPinchstart.called).to.be.false;
-
-          Simulator.gestures.pinch(
-            this.el,
-            {
-              duration: 500,
-              scale: 0.5,
-            },
-            () => {
-              // Then
-              expect(this.onPanstart.callCount).to.be.equal(1);
-              expect(this.onPinchstart.callCount).to.be.equal(1);
-              done();
-            }
-          );
-        }
-      );
-    });
-    it("should check multi dettached event (pan/pinch)", (done) => {
-      // Given
-
-      // When
-      this.inst1.disconnect();
-      expect(this.inst1.element).to.be.equal(this.inst2.element);
-
-      // When
-      Simulator.gestures.pan(
-        this.el,
-        {
-          pos: [0, 0],
-          deltaX: 50,
-          deltaY: 50,
-          duration: 200,
-          easing: "linear",
-        },
-        () => {
-          // Then
-          expect(this.onPanstart.called).to.be.false;
-          expect(this.onPanstart.called).to.be.false;
-
-          Simulator.gestures.pinch(
-            this.el,
-            {
-              duration: 500,
-              scale: 0.5,
-            },
-            () => {
-              // Then
-              expect(this.onPanstart.called).to.be.false;
-              expect(this.onPanstart.called).to.be.false;
-              done();
-            }
-          );
-        }
-      );
-    });
-  });
   describe("instance method", function () {
     beforeEach(() => {
       this.inst = new PanInput(sandbox());
@@ -200,28 +83,26 @@ describe("PanInput", () => {
   describe("enable/disable", function () {
     beforeEach(() => {
       this.el = sandbox();
-      this.inst = new PanInput(this.el, {
+      this.input = new PanInput(this.el, {
         inputType: ["touch", "mouse"],
       });
-      this.inst.mapAxes(["x1", "y1"]);
-      this.observer = {
-        get() {
-          return {
-            x: 10,
-          };
+      this.inst = new Axes({
+        x: {
+            range: [0, 200]
         },
-        release() {},
-        hold() {},
-        change() {},
-        options: {
-          deceleration: 0.0001,
-        },
-      };
+        y: {
+            range: [0, 200]
+        }
+      });
     });
     afterEach(() => {
       if (this.inst) {
         this.inst.destroy();
         this.inst = null;
+      }
+      if (this.input) {
+        this.input.destroy();
+        this.input = null;
       }
       cleanup();
     });
@@ -230,28 +111,32 @@ describe("PanInput", () => {
       // Given
       // When
       // Then
-      expect(this.inst.isEnabled()).to.be.false;
+      expect(this.input.isEnabled()).to.be.false;
 
       // When
-      this.inst.enable();
+      this.input.enable();
 
       // Then
-      expect(this.inst.isEnabled()).to.be.true;
+      expect(this.input.isEnabled()).to.be.true;
 
       // When
-      this.inst.disable();
+      this.input.disable();
 
       // Then
-      expect(this.inst.isEnabled()).to.be.false;
+      expect(this.input.isEnabled()).to.be.false;
     });
     it("should check event when enable method is called", (done) => {
       // Given
-      this.inst.connect(this.observer);
-      const beforeHandler = this.inst._onPanstart;
+      const hold = sinon.spy();
+      const change = sinon.spy();
+      const release = sinon.spy();
+      this.inst.connect(["x", "y"], this.input);
+      this.inst.on("hold", hold);
+      this.inst.on("change", change);
+      this.inst.on("release", release);
 
       // When
-      expect(this.inst.isEnabled()).to.be.true;
-      const onPanEndHandler = sinon.spy(beforeHandler);
+      expect(this.input.isEnabled()).to.be.true;
 
       // When
       Simulator.gestures.pan(
@@ -265,20 +150,26 @@ describe("PanInput", () => {
         },
         () => {
           // Then
-          expect(onPanEndHandler.called).to.be.true;
+          expect(hold.calledOnce).to.be.true;
+          expect(change.called).to.be.true;
+          expect(release.calledOnce).to.be.true;
           done();
         }
       );
     });
     it("should check event when disable method is called", (done) => {
       // Given
-      this.inst.connect(this.observer);
-      const beforeHandler = this.inst._onPanstart;
-      // When
+      const hold = sinon.spy();
+      const change = sinon.spy();
+      const release = sinon.spy();
+      this.inst.connect(["x", "y"], this.input);
+      this.inst.on("hold", hold);
+      this.inst.on("change", change);
+      this.inst.on("release", release);
 
-      const onPanEndHandler = sinon.spy(beforeHandler);
-      expect(this.inst.isEnabled()).to.be.true;
-      this.inst.disable();
+      // When
+      expect(this.input.isEnabled()).to.be.true;
+      this.input.disable();
 
       // When
       Simulator.gestures.pan(
@@ -292,7 +183,9 @@ describe("PanInput", () => {
         },
         () => {
           // Then
-          expect(onPanEndHandler.called).to.be.false;
+          expect(hold.called).to.be.false;
+          expect(change.called).to.be.false;
+          expect(release.called).to.be.false;
           done();
         }
       );

--- a/test/unit/inputType/PinchInput.spec.js
+++ b/test/unit/inputType/PinchInput.spec.js
@@ -2,60 +2,65 @@ import Axes from "../../../src/Axes.ts";
 import { PinchInput } from "../../../src/inputType/PinchInput";
 
 describe("PinchInput", () => {
-  describe("instance method", function () {
+	let el;
+	let input;
+	let inst;
+	let observer;
+
+  describe("instance method", () => {
     beforeEach(() => {
-      this.inst = new PinchInput(sandbox());
+      inst = new PinchInput(sandbox());
     });
     afterEach(() => {
-      if (this.inst) {
-        this.inst.destroy();
-        this.inst = null;
+      if (inst) {
+        inst.destroy();
+        inst = null;
       }
       cleanup();
     });
     it("should check status after disconnect", () => {
       // Given
-      this.inst.connect({});
+      inst.connect({});
 
       // When
-      this.inst.disconnect();
+      inst.disconnect();
 
       // Then
-      expect(this.observer).to.be.not.exist;
-      expect(this.inst.element).to.be.exist;
+      expect(observer).to.be.not.exist;
+      expect(inst.element).to.be.exist;
     });
     it("should check status after destroy", () => {
       // Given
-      this.inst.connect({});
+      inst.connect({});
 
       // When
-      this.inst.destroy();
+      inst.destroy();
 
       // Then
-      expect(this.inst.element).to.be.not.exist;
-      expect(this.observer).to.be.not.exist;
+      expect(inst.element).to.be.not.exist;
+      expect(observer).to.be.not.exist;
 
-      this.inst = null;
+      inst = null;
     });
   });
-  describe("enable/disable", function () {
+  describe("enable/disable", () => {
     beforeEach(() => {
-      this.el = sandbox();
-      this.input = new PinchInput(this.el, { inputType: ["touch"] });
-      this.inst = new Axes({
+      el = sandbox();
+      input = new PinchInput(el, { inputType: ["touch"] });
+      inst = new Axes({
         zoom: {
-            range: [1, 10]
+          range: [1, 10]
         }
       });
     });
     afterEach(() => {
-      if (this.inst) {
-        this.inst.destroy();
-        this.inst = null;
+      if (inst) {
+        inst.destroy();
+        inst = null;
       }
-      if (this.input) {
-        this.input.destroy();
-        this.input = null;
+      if (input) {
+        input.destroy();
+        input = null;
       }
       cleanup();
     });
@@ -64,45 +69,45 @@ describe("PinchInput", () => {
       // Given
       // When
       // Then
-      expect(this.input.isEnabled()).to.be.false;
+      expect(input.isEnabled()).to.be.false;
 
       // When
-      this.input.disable();
+      input.disable();
 
       // Then
-      expect(this.input.isEnabled()).to.be.false;
+      expect(input.isEnabled()).to.be.false;
 
       // When
-      this.input.enable();
+      input.enable();
 
       // Then
-      expect(this.input.isEnabled()).to.be.true;
+      expect(input.isEnabled()).to.be.true;
 
       // When
-      this.input.disable();
+      input.disable();
 
       // Then
-      expect(this.input.isEnabled()).to.be.false;
+      expect(input.isEnabled()).to.be.false;
     });
     it("should check event when enable method is called", (done) => {
       // Given
       const hold = sinon.spy();
       const change = sinon.spy();
       const release = sinon.spy();
-      this.inst.connect(["zoom"], this.input);
-      this.inst.on("hold", hold);
-      this.inst.on("change", change);
-      this.inst.on("release", release);
+      inst.connect(["zoom"], input);
+      inst.on("hold", hold);
+      inst.on("change", change);
+      inst.on("release", release);
 
       // When
-      expect(this.input.isEnabled()).to.be.true;
+      expect(input.isEnabled()).to.be.true;
 
       // When
       Simulator.gestures.pinch(
-        this.el,
+        el,
         {
           duration: 500,
-          scale: 0.5,
+          scale: 0.5
         },
         () => {
           // Then
@@ -118,21 +123,21 @@ describe("PinchInput", () => {
       const hold = sinon.spy();
       const change = sinon.spy();
       const release = sinon.spy();
-      this.inst.connect(["zoom"], this.input);
-      this.inst.on("hold", hold);
-      this.inst.on("change", change);
-      this.inst.on("release", release);
+      inst.connect(["zoom"], input);
+      inst.on("hold", hold);
+      inst.on("change", change);
+      inst.on("release", release);
 
       // When
-      expect(this.input.isEnabled()).to.be.true;
-      this.input.disable();
+      expect(input.isEnabled()).to.be.true;
+      input.disable();
 
       // When
       Simulator.gestures.pinch(
-        this.el,
+        el,
         {
           duration: 500,
-          scale: 0.5,
+          scale: 0.5
         },
         () => {
           // Then
@@ -145,48 +150,48 @@ describe("PinchInput", () => {
     });
   });
 
-  describe("offset value", function () {
+  describe("offset value", () => {
     beforeEach(() => {
-      this.el = sandbox();
-      this.input = new PinchInput(this.el, { inputType: ["touch"] });
-      this.inst = new Axes(
+      el = sandbox();
+      input = new PinchInput(el, { inputType: ["touch"] });
+      inst = new Axes(
         {
           x: {
-            range: [10, 120],
-          },
+            range: [10, 120]
+          }
         },
         { round: 1 },
         {
-          x: 50,
+          x: 50
         }
       );
-      this.inst.connect(["x"], this.input);
+      inst.connect(["x"], input);
     });
     afterEach(() => {
-      if (this.ins) {
-        this.inst.destroy();
-        this.inst = null;
+      if (inst) {
+        inst.destroy();
+        inst = null;
       }
-      if (this.input) {
-        this.input.destroy();
-        this.input = null;
+      if (input) {
+        input.destroy();
+        input = null;
       }
       cleanup();
     });
 
     it("The offset value should be returned using the position value when the hold event is triggered.", (done) => {
       // Given
-      this.input.options.scale = 1;
+      input.options.scale = 1;
       // When
       Simulator.gestures.pinch(
-        this.el,
+        el,
         {
           duration: 500,
-          scale: 1.1,
+          scale: 1.1
         },
         () => {
           // Then
-          expect(this.inst.get(["x"]).x).to.be.equal(55);
+          expect(inst.get(["x"]).x).to.be.equal(55);
           done();
         }
       );
@@ -194,33 +199,20 @@ describe("PinchInput", () => {
 
     it("The offset value should apply scale option", (done) => {
       // Given
-      this.input.options.scale = 1;
+      input.options.scale = 1;
       // When
       Simulator.gestures.pinch(
-        this.el,
+        el,
         {
           duration: 500,
-          scale: 0.9,
+          scale: 0.9
         },
         () => {
           // Then
-          expect(this.inst.get(["x"]).x).to.be.equal(45);
+          expect(inst.get(["x"]).x).to.be.equal(45);
           done();
         }
       );
-    });
-  });
-
-  describe("options test", function () {
-    beforeEach(() => {
-      this.inst = new PinchInput(sandbox());
-    });
-    afterEach(() => {
-      if (this.inst) {
-        this.inst.destroy();
-        this.inst = null;
-      }
-      cleanup();
     });
   });
 });

--- a/test/unit/inputType/RotatePanInput.spec.js
+++ b/test/unit/inputType/RotatePanInput.spec.js
@@ -1,5 +1,6 @@
-import Axes from "../../../src/Axes";
 import { RotatePanInput } from "../../../src/inputType/RotatePanInput";
+import Axes from "../../../src/Axes";
+
 import TestHelper from "./TestHelper";
 
 describe("RotatePanInput", () => {
@@ -8,7 +9,7 @@ describe("RotatePanInput", () => {
   let axes;
   let clock;
 
-  async function testPanMove(MOVES) {
+   const testPanMove = async (MOVES) => {
     const resultAngles = [];
 
     for (let i = 0; i < MOVES.length; i++) {
@@ -39,13 +40,13 @@ describe("RotatePanInput", () => {
     el.style.backgroundColor = "yellow";
 
     input = new RotatePanInput(el, {
-      inputType: ["touch", "mouse"],
+      inputType: ["touch", "mouse"]
     });
 
     axes = new Axes({
       angle: {
-        range: [-360, 360],
-      },
+        range: [-360, 360]
+      }
     });
 
     axes.connect("angle", input);
@@ -73,7 +74,7 @@ describe("RotatePanInput", () => {
       deltaX: 100, // Until 200
       deltaY: 0,
       duration: 2000,
-      expectedAngle: 45,
+      expectedAngle: 45
     };
 
     const MOVE_HORIZONTALLY_FULL_AT_TOP = {
@@ -81,7 +82,7 @@ describe("RotatePanInput", () => {
       deltaX: 200,
       deltaY: 0,
       duration: 3000,
-      expectedAngle: 90,
+      expectedAngle: 90
     };
 
     const MOVE_VERTICALLY_HALF_AT_LEFT = {
@@ -89,7 +90,7 @@ describe("RotatePanInput", () => {
       deltaX: 0,
       deltaY: 100,
       duration: 2000,
-      expectedAngle: -45,
+      expectedAngle: -45
     };
 
     const MOVE_VERTICALLY_HALF_AT_RIGHT = {
@@ -97,14 +98,14 @@ describe("RotatePanInput", () => {
       deltaX: 0,
       deltaY: 100,
       duration: 2000,
-      expectedAngle: 45,
+      expectedAngle: 45
     };
 
     const MOVES = [
       MOVE_HORIZONTALLY_HALF_AT_TOP,
       MOVE_HORIZONTALLY_FULL_AT_TOP,
       MOVE_VERTICALLY_HALF_AT_LEFT,
-      MOVE_VERTICALLY_HALF_AT_RIGHT,
+      MOVE_VERTICALLY_HALF_AT_RIGHT
     ];
 
     await testPanMove(MOVES);
@@ -117,35 +118,35 @@ describe("RotatePanInput", () => {
       deltaX: 100, // Until 200
       deltaY: 0,
       duration: 2000,
-      expectedAngle: (Math.atan2(100 / 2, RADIUS) * 2 * 180) / Math.PI,
+      expectedAngle: (Math.atan2(100 / 2, RADIUS) * 2 * 180) / Math.PI
     };
     const MOVE_HORIZONTALLY_HALF_AT_BOTTOM = {
       pos: [50, 200], // Mid index of width 201 is 100 (201 - 1 / 2 )
       deltaX: 100, // Until 200
       deltaY: 0,
       duration: 2000,
-      expectedAngle: (-Math.atan2(100 / 2, RADIUS) * 2 * 180) / Math.PI,
+      expectedAngle: (-Math.atan2(100 / 2, RADIUS) * 2 * 180) / Math.PI
     };
     const MOVE_VERTICALLY_HALF_AT_LEFT = {
       pos: [0, 50], // Mid index of width 201 is 100 (201 - 1 / 2 )
       deltaX: 0, // Until 200
       deltaY: 100,
       duration: 2000,
-      expectedAngle: (-Math.atan2(100 / 2, RADIUS) * 2 * 180) / Math.PI,
+      expectedAngle: (-Math.atan2(100 / 2, RADIUS) * 2 * 180) / Math.PI
     };
     const MOVE_VERTICALLY_HALF_AT_RIGHT = {
       pos: [200, 50], // Mid index of width 201 is 100 (201 - 1 / 2 )
       deltaX: 0, // Until 200
       deltaY: 100,
       duration: 2000,
-      expectedAngle: (Math.atan2(100 / 2, RADIUS) * 2 * 180) / Math.PI,
+      expectedAngle: (Math.atan2(100 / 2, RADIUS) * 2 * 180) / Math.PI
     };
 
     const MOVES = [
       MOVE_HORIZONTALLY_HALF_AT_TOP,
       MOVE_HORIZONTALLY_HALF_AT_BOTTOM,
       MOVE_VERTICALLY_HALF_AT_LEFT,
-      MOVE_VERTICALLY_HALF_AT_RIGHT,
+      MOVE_VERTICALLY_HALF_AT_RIGHT
     ];
 
     // Then
@@ -161,13 +162,13 @@ describe("RotatePanInput", () => {
       pos: [50, 0], // Mid index of width 201 is 100 (201 - 1 / 2 )
       deltaX: 100, // Until 200
       deltaY: 0,
-      duration: 2000,
+      duration: 2000
     };
     const MOVE_HORIZONTALLY_FAST = {
       pos: [50, 0], // Mid index of width 201 is 100 (201 - 1 / 2 )
       deltaX: 100, // Until 200
       deltaY: 0,
-      duration: 200,
+      duration: 200
     };
     const MOVES = [MOVE_HORIZONTALLY_SLOW, MOVE_HORIZONTALLY_FAST];
 
@@ -194,13 +195,13 @@ describe("RotatePanInput", () => {
     smElement.style.backgroundColor = "yellow";
 
     const smInput = new RotatePanInput(smElement, {
-      inputType: ["touch", "mouse"],
+      inputType: ["touch", "mouse"]
     });
 
     const smAxes = new Axes({
       angle: {
-        range: [-360, 360],
-      },
+        range: [-360, 360]
+      }
     });
 
     smAxes.connect("angle", smInput);
@@ -216,7 +217,7 @@ describe("RotatePanInput", () => {
       deltaX: 100, // Until 200
       deltaY: 0,
       duration: 2000,
-      expectedAngle: 45,
+      expectedAngle: 45
     };
 
     const MOVE_HORIZONTALLY_ON_SMALL = {
@@ -226,7 +227,7 @@ describe("RotatePanInput", () => {
       deltaX: 50, // Until 100
       deltaY: 0,
       duration: 2000,
-      expectedAngle: 45,
+      expectedAngle: 45
     };
 
     const MOVES = [MOVE_HORIZONTALLY_ON_BIG, MOVE_HORIZONTALLY_ON_SMALL];
@@ -244,7 +245,7 @@ describe("RotatePanInput", () => {
       deltaX: 100, // Until 200
       deltaY: 0,
       duration: 2000,
-      expectedAngle: 45,
+      expectedAngle: 45
     };
 
     axes.setTo({ angle: 0 });
@@ -267,7 +268,7 @@ describe("RotatePanInput", () => {
       deltaX: 50, // Until 100
       deltaY: 0,
       duration: 2000,
-      expectedAngle: 45,
+      expectedAngle: 45
     };
 
     axes.setTo({ angle: 0 });

--- a/test/unit/inputType/RotatePanInput.spec.js
+++ b/test/unit/inputType/RotatePanInput.spec.js
@@ -167,7 +167,7 @@ describe("RotatePanInput", () => {
       pos: [50, 0], // Mid index of width 201 is 100 (201 - 1 / 2 )
       deltaX: 100, // Until 200
       deltaY: 0,
-      duration: 1000,
+      duration: 200,
     };
     const MOVES = [MOVE_HORIZONTALLY_SLOW, MOVE_HORIZONTALLY_FAST];
 

--- a/test/unit/inputType/TestHelper.js
+++ b/test/unit/inputType/TestHelper.js
@@ -1,98 +1,109 @@
 export default class TestHelper {
-	static wheelVertical(target, value, callback) {
-		if (target instanceof Element === false) {
-			return;
-		}
+  static wheelVertical(target, value, callback) {
+    if (target instanceof Element === false) {
+      return;
+    }
 
-		const params = {deltaY: value};
-		let wheelEvent;
+    const params = { deltaY: value };
+    let wheelEvent;
 
-		try {
-			wheelEvent = new WheelEvent("wheel", params);
-		} catch (e) {
-			wheelEvent = document.createEvent("WheelEvent");
-			wheelEvent.initEvent("wheel", params);
-		}
-		let isCall = false;
+    try {
+      wheelEvent = new WheelEvent("wheel", params);
+    } catch (e) {
+      wheelEvent = document.createEvent("WheelEvent");
+      wheelEvent.initEvent("wheel", params);
+    }
+    let isCall = false;
 
-		function callbackOnce() {
-			if (isCall) {
-				return;
-			}
-			isCall = true;
-			callback && callback();
-			target.removeEventListener("wheel", callbackOnce);// Is this posible??
-		}
-		target.addEventListener("wheel", callbackOnce);
-		target.dispatchEvent(wheelEvent);
-	}
-	static key(target, behavior, value, callback) {
-		if (target instanceof Element === false) {
-			return;
-		}
-		let keyboardEvent;
+    const callbackOnce = () => {
+      if (isCall) {
+        return;
+      }
+      isCall = true;
+      callback && callback();
+      target.removeEventListener("wheel", callbackOnce); // Is this posible??
+    };
+    target.addEventListener("wheel", callbackOnce);
+    target.dispatchEvent(wheelEvent);
+  }
 
-		try {
-			keyboardEvent = new KeyboardEvent(behavior, value);
-			delete keyboardEvent.keyCode;
-			Object.defineProperty(keyboardEvent, "keyCode", {
-				"value": value.keyCode,
-				"writable": true,
-			});
-		} catch (e) {
-			keyboardEvent = document.createEvent("KeyboardEvent");
-			keyboardEvent.initKeyboardEvent(behavior, true, false, null, 0, false, 0, false, value.keyCode, 0);
-		}
+  static key(target, behavior, value, callback) {
+    if (target instanceof Element === false) {
+      return;
+    }
+    let keyboardEvent;
 
-		function callbackOnce() {
-			callback && callback();
-			target.removeEventListener(behavior, callbackOnce);// Is this posible??
-		}
+    try {
+      keyboardEvent = new KeyboardEvent(behavior, value);
+      delete keyboardEvent.keyCode;
+      Object.defineProperty(keyboardEvent, "keyCode", {
+        value: value.keyCode,
+        writable: true
+      });
+    } catch (e) {
+      keyboardEvent = document.createEvent("KeyboardEvent");
+      keyboardEvent.initKeyboardEvent(
+        behavior,
+        true,
+        false,
+        null,
+        0,
+        false,
+        0,
+        false,
+        value.keyCode,
+        0
+      );
+    }
 
-		target.addEventListener(behavior, callbackOnce);
-		target.dispatchEvent(keyboardEvent);
-	}
-	/**
-	 * looping async function
-	 *
-	 * @param {*} count loop count
-	 * @param {*} loopFunc user loop function
-	 * @param {*} complete callback function which called if done.
-	 */
-	static asyncLoop(count, loopFunc, complete) {
-		let i = 0;
+    const callbackOnce = () => {
+      callback && callback();
+      target.removeEventListener(behavior, callbackOnce); // Is this posible??
+    }
 
-		function loop() {
-			if (i >= count) {
-				complete();
-				return;
-			}
+    target.addEventListener(behavior, callbackOnce);
+    target.dispatchEvent(keyboardEvent);
+  }
 
-			loopFunc(i, () => {
-				// done
-				i++;
-				loop();
-			});
-		}
+  /**
+   * looping async function
+   * @param {*} count loop count
+   * @param {*} loopFunc user loop function
+   * @param {*} complete callback function which called if done.
+   */
+  static asyncLoop(count, loopFunc, complete) {
+    let i = 0;
 
-		loop();
-	}
+    const loop = () => {
+      if (i >= count) {
+        complete();
+        return;
+      }
 
-	static panOnElement(el, param, debugOption) {
-		const rect = el.getBoundingClientRect();
+      loopFunc(i, () => {
+        // done
+        i++;
+        loop();
+      });
+    }
 
-		const paramByEl = Object.assign({}, param, {
-			pos: [rect.left + param.pos[0], rect.top + param.pos[1]]
-		});
+    loop();
+  }
 
-		// console.log(paramByEl);
-		return new Promise(res => {
-			Simulator.gestures.pan(el, paramByEl, res);
+  static panOnElement(el, param, debugOption) {
+    const rect = el.getBoundingClientRect();
 
-			if (debugOption) {
-				debugOption.clock && debugOption.clock.tick(param.duration + 100); // margin (100) is needed.
-			}
-		});
-	}
+    const paramByEl = Object.assign({}, param, {
+      pos: [rect.left + param.pos[0], rect.top + param.pos[1]]
+    });
+
+    // console.log(paramByEl);
+    return new Promise((res) => {
+      Simulator.gestures.pan(el, paramByEl, res);
+
+      if (debugOption) {
+        debugOption.clock && debugOption.clock.tick(param.duration + 100); // margin (100) is needed.
+      }
+    });
+  }
 }
-

--- a/test/unit/inputType/WheelInput.spec.js
+++ b/test/unit/inputType/WheelInput.spec.js
@@ -1,64 +1,71 @@
-import TestHelper from "./TestHelper";
 import Axes from "../../../src/Axes.ts";
 import { WheelInput } from "../../../src/inputType/WheelInput";
 
+import TestHelper from "./TestHelper";
+
 describe("WheelInput", () => {
-  describe("instance method", function () {
+	let el;
+	let input;
+	let inst;
+	let observer;
+	let timer;
+
+  describe("instance method", () => {
     beforeEach(() => {
-      this.inst = new WheelInput(sandbox(), { releaseDelay: 50 });
+      inst = new WheelInput(sandbox(), { releaseDelay: 50 });
     });
     afterEach(() => {
-      if (this.inst) {
-        this.inst.destroy();
-        this.inst = null;
+      if (inst) {
+        inst.destroy();
+        inst = null;
       }
       cleanup();
     });
     it("should check status after disconnect", () => {
       // Given
-      this.inst.connect({});
+      inst.connect({});
 
       // When
-      this.inst.disconnect();
+      inst.disconnect();
 
       // Then
-      expect(this.observer).to.be.not.exist;
-      expect(this.inst.element).to.be.exist;
-      expect(this._timer).to.be.not.exist;
+      expect(observer).to.be.not.exist;
+      expect(inst.element).to.be.exist;
+      expect(timer).to.be.not.exist;
     });
     it("should check status after destroy", () => {
       // Given
-      this.inst.connect({});
+      inst.connect({});
 
       // When
-      this.inst.destroy();
+      inst.destroy();
 
       // Then
-      expect(this.inst.element).to.be.not.exist;
-      expect(this.observer).to.be.not.exist;
-      expect(this._timer).to.be.not.exist;
+      expect(inst.element).to.be.not.exist;
+      expect(observer).to.be.not.exist;
+      expect(timer).to.be.not.exist;
 
-      this.inst = null;
+      inst = null;
     });
   });
-  describe("enable/disable", function () {
+  describe("enable/disable", () => {
     beforeEach(() => {
-      this.el = sandbox();
-      this.inst = new WheelInput(this.el, { releaseDelay: 50 });
-      this.inst.mapAxes(["x"]);
-      this.observer = {
-        release() {},
-        hold() {},
-        change() {},
+      el = sandbox();
+      inst = new WheelInput(el, { releaseDelay: 50 });
+      inst.mapAxes(["x"]);
+      observer = {
+        release: () => {},
+        hold: () => {},
+        change: () => {},
         options: {
-          deceleration: 0.0001,
-        },
+          deceleration: 0.0001
+        }
       };
     });
     afterEach(() => {
-      if (this.inst) {
-        this.inst.destroy();
-        this.inst = null;
+      if (inst) {
+        inst.destroy();
+        inst = null;
       }
       cleanup();
     });
@@ -67,55 +74,55 @@ describe("WheelInput", () => {
       // Given
       // When
       // Then
-      expect(this.inst.isEnabled()).to.be.false;
+      expect(inst.isEnabled()).to.be.false;
 
       // When
-      this.inst.disable();
+      inst.disable();
 
       // Then
-      expect(this.inst.isEnabled()).to.be.false;
+      expect(inst.isEnabled()).to.be.false;
 
       // When
-      this.inst.enable();
+      inst.enable();
 
       // Then
-      expect(this.inst.isEnabled()).to.be.true;
+      expect(inst.isEnabled()).to.be.true;
 
       // When (after connection)
-      this.inst.connect(this.observer);
-      this.inst.enable();
+      inst.connect(observer);
+      inst.enable();
 
       // Then
-      expect(this.inst.isEnabled()).to.be.true;
+      expect(inst.isEnabled()).to.be.true;
     });
   });
 
-  describe("simple wheel event test", function () {
+  describe("simple wheel event test", () => {
     beforeEach(() => {
-      this.el = sandbox();
-      this.input = new WheelInput(this.el, { releaseDelay: 50 });
-      this.inst = new Axes(
+      el = sandbox();
+      input = new WheelInput(el, { releaseDelay: 50 });
+      inst = new Axes(
         {
           x: {
-            range: [10, 120],
-          },
+            range: [10, 120]
+          }
         },
         {
-          maximumDuration: 30,
+          maximumDuration: 30
         }
       );
-      this.inst.connect(["x"], this.input);
+      inst.connect(["x"], input);
     });
 
     afterEach(() => {
-      this.el = null;
-      if (this.inst) {
-        this.inst.destroy();
-        this.inst = null;
+      el = null;
+      if (inst) {
+        inst.destroy();
+        inst = null;
       }
-      if (this.input) {
-        this.input.destroy();
-        this.input = null;
+      if (input) {
+        input.destroy();
+        input = null;
       }
       cleanup();
     });
@@ -125,14 +132,14 @@ describe("WheelInput", () => {
       const deltaY = 300;
       // When
       // 1. Scroll
-      TestHelper.wheelVertical(this.el, deltaY, () => {
+      TestHelper.wheelVertical(el, deltaY, () => {
         // 2. detach & destroy wheel input
-        this.inst.disconnect(this.input);
-        this.input.destroy();
-        this.input = null;
+        inst.disconnect(input);
+        input.destroy();
+        input = null;
         // 3. create new wheel input
-        this.input = new WheelInput(this.el, { releaseDelay: 50 });
-        this.inst.connect(["x"], this.input);
+        input = new WheelInput(el, { releaseDelay: 50 });
+        inst.connect(["x"], input);
 
         // Then -> script error should not be occur.
         setTimeout(done, 50);
@@ -140,44 +147,44 @@ describe("WheelInput", () => {
     });
   });
 
-  [1, 2, 4].forEach(function (scale) {
-    [true, false].forEach(function (useNormalized) {
-      describe(`wheel event test(useNormalized: ${useNormalized})`, function () {
+  [1, 2, 4].forEach((scale) => {
+    [true, false].forEach((useNormalized) => {
+      describe(`wheel event test(useNormalized: ${useNormalized})`, () => {
         beforeEach(() => {
-          this.el = sandbox();
-          this.input = new WheelInput(this.el, {
+          el = sandbox();
+          input = new WheelInput(el, {
             useNormalized: useNormalized,
             scale: scale,
-            releaseDelay: 50,
+            releaseDelay: 50
           });
-          this.inst = new Axes(
+          inst = new Axes(
             {
               x: {
-                range: [10, 120],
-              },
+                range: [10, 120]
+              }
             },
             {
-              maximumDuration: 0,
+              maximumDuration: 0
             }
           );
-          this.inst.connect(["x"], this.input);
+          inst.connect(["x"], input);
         });
 
         afterEach(() => {
-          this.el = null;
-          if (this.inst) {
-            this.inst.destroy();
-            this.inst = null;
+          el = null;
+          if (inst) {
+            inst.destroy();
+            inst = null;
           }
-          if (this.input) {
-            this.input.destroy();
-            this.input = null;
+          if (input) {
+            input.destroy();
+            input = null;
           }
           cleanup();
         });
         [-1, -3, -5, -9].forEach((d) => {
           it(`should check delta test (delta: ${d}, useNormalized: ${useNormalized})`, (done) => {
-            this.inst.on("change", ({ pos, delta }) => {
+            inst.on("change", ({ pos, delta }) => {
               if (delta.x === 0) {
                 return;
               }
@@ -186,10 +193,10 @@ describe("WheelInput", () => {
                 scale * (useNormalized ? sign : sign * Math.abs(d))
               );
             });
-            this.inst.on("release", (e) => {
+            inst.on("release", (e) => {
               done();
             });
-            TestHelper.wheelVertical(this.el, d, () => {});
+            TestHelper.wheelVertical(el, d, () => {});
           });
         });
         it("no event triggering when disconnected", (done) => {
@@ -197,13 +204,13 @@ describe("WheelInput", () => {
           const deltaY = 1;
           let changeTriggered = false;
 
-          this.inst.on("change", () => {
+          inst.on("change", () => {
             changeTriggered = true;
           });
-          this.inst.disconnect();
+          inst.disconnect();
 
           // When
-          TestHelper.wheelVertical(this.el, deltaY, () => {
+          TestHelper.wheelVertical(el, deltaY, () => {
             // Then
             expect(changeTriggered).to.be.false;
             done();
@@ -215,12 +222,12 @@ describe("WheelInput", () => {
           const deltaY = 0;
           let changeTriggered = false;
 
-          this.inst.on("change", () => {
+          inst.on("change", () => {
             changeTriggered = true;
           });
 
           // When
-          TestHelper.wheelVertical(this.el, deltaY, () => {
+          TestHelper.wheelVertical(el, deltaY, () => {
             // Then
             expect(changeTriggered).to.be.false;
             done();
@@ -232,7 +239,7 @@ describe("WheelInput", () => {
           const deltaY = -1;
           const eventLog = [];
 
-          this.inst
+          inst
             .on("hold", () => {
               eventLog.push("hold");
             })
@@ -244,9 +251,9 @@ describe("WheelInput", () => {
             });
 
           // When
-          TestHelper.wheelVertical(this.el, deltaY, () => {
+          TestHelper.wheelVertical(el, deltaY, () => {
             setTimeout(() => {
-              TestHelper.wheelVertical(this.el, deltaY, () => {
+              TestHelper.wheelVertical(el, deltaY, () => {
                 setTimeout(() => {
                   // Then
                   eventLog.forEach((log, index) => {

--- a/test/unit/utils.spec.js
+++ b/test/unit/utils.spec.js
@@ -3,26 +3,28 @@ import {
   toArray,
   equal,
   getDecimalPlace,
-  roundNumber,
+  roundNumber
 } from "../../src/utils";
 
-describe("Util Test", function () {
+describe("Util Test", () => {
+	let el;
+
   beforeEach(() => {
-    this.el = sandbox();
+    el = sandbox();
   });
   afterEach(() => {
     cleanup();
   });
   it("should check 'equal' method", () => {
     // Given
-    let target1 = {
+    const target1 = {
       x: 10,
       y: 20,
-      z: 30,
+      z: 30
     };
-    let target2 = {
+    const target2 = {
       x: 10,
-      y: 20,
+      y: 20
     };
 
     // Then
@@ -43,19 +45,19 @@ describe("Util Test", function () {
     expect($(div) instanceof HTMLElement).to.be.true;
     expect($($(div)) instanceof HTMLElement).to.be.true;
     expect($(divs, true).length).to.be.equal(2);
-    expect($("#sandbox")).to.be.equal(this.el);
-    expect(this.el).to.be.equal(this.el);
+    expect($("#sandbox")).to.be.equal(el);
+    expect(el).to.be.equal(el);
   });
   it("should check `toArray` method", () => {
     // Given
-    this.el.innerHTML = `<div>content1</div>
+    el.innerHTML = `<div>content1</div>
     <div>content2</div>
     <div>content3</div>`;
     // When
-    const useSlice = Array.prototype.slice.call(this.el.childNodes);
+    const useSlice = Array.prototype.slice.call(el.childNodes);
 
     // Then
-    expect(toArray(this.el.childNodes)).to.be.eql(useSlice);
+    expect(toArray(el.childNodes)).to.be.eql(useSlice);
   });
 
   it("should roundNumber by round unit", () => {
@@ -63,7 +65,7 @@ describe("Util Test", function () {
     const targetVal = 99.123456789;
     const inputValues = [100, 10, 1, 0, 0.1, 0.01, 0.001, 0.0001];
     const expectValues = [
-      100, 100, 99, 0, 99.1, 99.12, 99.123, 99.1235 /* round */,
+      100, 100, 99, 0, 99.1, 99.12, 99.123, 99.1235 /* round */
     ];
     // Ref. Same result : https://codepen.io/GreenSock/pen/mLMYwM
 


### PR DESCRIPTION
## Details
Fixed issues with unit tests not working correctly.
 - Instead of tracking hammer events via sinon.spy, now track Axes events.
 - An error that event.stop did not work properly was detected and fixed during the testing process.

Unit tests for `updateAnimation` and `stopAnimation` have been added.