### PR TITLE
feat: add inputButton option to PanInputOption

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,7 +18,7 @@
   "overrides": [
     {
       "files": [
-        "./**/*.{ts,tsx}"
+        "./**/*.{ts,tsx,js}"
       ],
       "extends": [
         "plugin:@typescript-eslint/recommended",

--- a/demo/docs/demos/gallery.mdx
+++ b/demo/docs/demos/gallery.mdx
@@ -1,9 +1,0 @@
----
-title: Gallery
-id: gallery
-slug: /gallery
-sidebar_position: 12
----
-import Gallery from "@site/src/pages/demos/gallery";
-
-<Gallery />

--- a/demo/src/css/demos/cube.css
+++ b/demo/src/css/demos/cube.css
@@ -1,4 +1,6 @@
 #area {
+  display: flex;
+  justify-content: center;
   position:relative;
   width:100%; height:200px;
   -webkit-perspective: 300px;
@@ -8,7 +10,7 @@
   perspective: 300px;
   background: #f5f5f5;
   border-radius: 4px;
-  margin-bottom: 20px;    
+  margin-bottom: 20px;
 }
 
 #box {
@@ -39,9 +41,9 @@
   -ms-border-radius:4px;
   -o-border-radius:4px;
   border-radius:4px;
-  background: 
+  background:
     repeating-radial-gradient(
-      line at 0 0, 
+      line at 0 0,
       #eee,
       #ccc 50px
     );
@@ -58,8 +60,8 @@
   background-image: -webkit-repeating-linear-gradient(left, hsla(0,0%,100%,0) 0%, hsla(0,0%,100%,0)   6%, hsla(0,0%,100%, .1) 7.5%),
     -webkit-repeating-linear-gradient(left, hsla(0,0%,  0%,0) 0%, hsla(0,0%,  0%,0)   4%, hsla(0,0%,  0%,.03) 4.5%),
     -webkit-repeating-linear-gradient(left, hsla(0,0%,100%,0) 0%, hsla(0,0%,100%,0) 1.2%, hsla(0,0%,100%,.15) 2.2%),
-    linear-gradient(180deg, hsl(0,0%,78%)  0%, 
-    hsl(0,0%,90%) 47%, 
+    linear-gradient(180deg, hsl(0,0%,78%)  0%,
+    hsl(0,0%,90%) 47%,
     hsl(0,0%,78%) 53%,
     hsl(0,0%,70%)100%);
 }

--- a/demo/src/pages/demos/cube.tsx
+++ b/demo/src/pages/demos/cube.tsx
@@ -5,11 +5,20 @@ import "../../css/demos/cube.css";
 
 const Cube = () => {
   useEffect(() => {
+    const area = document.getElementById("area");
     const box = document.getElementById("box");
+    const container = document.getElementById("container");
+    const areaWidth = area.getBoundingClientRect().width;
 
     // 1. Initialize eg.Axes
     const axes = new Axes(
       {
+        offsetX: {
+          range: [-(areaWidth / 4), areaWidth / 4],
+        },
+        offsetY: {
+          range: [-25, 25],
+        },
         rotateX: {
           range: [0, 360],
           circular: true,
@@ -29,18 +38,24 @@ const Cube = () => {
       box.style[
         "transform"
       ] = `rotateY(${pos.rotateX}deg) rotateX(${pos.rotateY}deg)`;
+      container.style[
+        "transform"
+      ] = `translate3d(${pos.offsetX}px, ${pos.offsetY}px, 0)`;
     });
 
     // 3. Initialize a inputType and connect it
     axes
-      .connect("rotateX rotateY", new PanInput("#area"))
       .connect(
-        "rotateX rotateY",
-        new MoveKeyInput("#area", { scale: [10, -10] })
-      );
+        "offsetX offsetY",
+        new PanInput(area, { inputButton: ["right"] })
+      )
+      .connect("rotateX rotateY", new PanInput(area))
+      .connect("rotateX rotateY", new MoveKeyInput(area, { scale: [10, -10] }));
 
     // 4. move to position
     axes.setTo({
+      offsetX: 0,
+      offsetY: 0,
       rotateX: 40,
       rotateY: 315,
     });
@@ -50,49 +65,55 @@ const Cube = () => {
     <div>
       <p>You can rotate the cube using two axes.</p>
       <div id="area">
-        <div id="box">
-          <div
-            className="face metal-linear"
-            style={{
-              transform:
-                "rotateX(0deg) rotateY(0deg) translate3d(-50px,-50px,50px)",
-            }}
-          >
-            1
-          </div>
-          <div
-            className="face metal-linear"
-            style={{
-              transform: "rotateY(-90deg) translate3d(0px,-50px,100px)",
-            }}
-          >
-            2
-          </div>
-          <div
-            className="face metal-linear"
-            style={{ transform: "rotateY(90deg) translate3d(0px,-50px,0px)" }}
-          >
-            3
-          </div>
-          <div
-            className="face metal-linear"
-            style={{ transform: "rotateX(90deg) translate3d(-50px,0px,100px)" }}
-          >
-            4
-          </div>
-          <div
-            className="face metal-linear"
-            style={{
-              transform: "rotateY(180deg) translate3d(50px,-50px,50px)",
-            }}
-          >
-            5
-          </div>
-          <div
-            className="face metal-linear"
-            style={{ transform: "rotateX(-90deg) translate3d(-50px,0px,0px)" }}
-          >
-            6
+        <div id="container">
+          <div id="box">
+            <div
+              className="face metal-linear"
+              style={{
+                transform:
+                  "rotateX(0deg) rotateY(0deg) translate3d(-50px,-50px,50px)",
+              }}
+            >
+              1
+            </div>
+            <div
+              className="face metal-linear"
+              style={{
+                transform: "rotateY(-90deg) translate3d(0px,-50px,100px)",
+              }}
+            >
+              2
+            </div>
+            <div
+              className="face metal-linear"
+              style={{ transform: "rotateY(90deg) translate3d(0px,-50px,0px)" }}
+            >
+              3
+            </div>
+            <div
+              className="face metal-linear"
+              style={{
+                transform: "rotateX(90deg) translate3d(-50px,0px,100px)",
+              }}
+            >
+              4
+            </div>
+            <div
+              className="face metal-linear"
+              style={{
+                transform: "rotateY(180deg) translate3d(50px,-50px,50px)",
+              }}
+            >
+              5
+            </div>
+            <div
+              className="face metal-linear"
+              style={{
+                transform: "rotateX(-90deg) translate3d(-50px,0px,0px)",
+              }}
+            >
+              6
+            </div>
           </div>
         </div>
       </div>

--- a/demo/src/pages/demos/subway.tsx
+++ b/demo/src/pages/demos/subway.tsx
@@ -37,7 +37,7 @@ const Cube = () => {
         interrutable: false,
       },
       {
-        zoom: baseScale,
+        zoom: 1,
       }
     );
 

--- a/src/const.ts
+++ b/src/const.ts
@@ -7,6 +7,10 @@ export const DIRECTION_DOWN = 16;
 export const DIRECTION_VERTICAL = 8 | 16;
 export const DIRECTION_ALL = 2 | 4 | 8 | 16;
 
+export const MOUSE_LEFT = "left";
+export const MOUSE_RIGHT = "right";
+export const MOUSE_MIDDLE = "middle";
+
 import getAgent from "@egjs/agent";
 
 import { window } from "./browser";

--- a/src/eventInput/EventInput.ts
+++ b/src/eventInput/EventInput.ts
@@ -10,13 +10,21 @@ export const SUPPORT_POINTER_EVENTS = SUPPORT_POINTER || SUPPORT_MSPOINTER;
 export abstract class EventInput {
   public prevEvent: ExtendedEvent;
 
-  public abstract onEventStart(event: InputEventType): ExtendedEvent;
+  public abstract onEventStart(
+    event: InputEventType,
+    inputButton?: string[]
+  ): ExtendedEvent;
 
-  public abstract onEventMove(event: InputEventType): ExtendedEvent;
+  public abstract onEventMove(
+    event: InputEventType,
+    inputButton?: string[]
+  ): ExtendedEvent;
 
   public abstract onEventEnd(event: InputEventType): void;
 
   public abstract getTouches(event: InputEventType): number;
+
+  protected abstract _getButton(event: InputEventType): string;
 
   protected abstract _getScale(event: InputEventType): number;
 
@@ -70,4 +78,21 @@ export abstract class EventInput {
     const y = end.clientY - start.clientY;
     return Math.sqrt(x * x + y * y);
   }
+
+  protected _isValidButton(button: string, inputButton: string[]): boolean {
+    return inputButton.includes(button);
+  }
+
+  protected _preventMouseButton(event: InputEventType, button: string): void {
+    if (button === "right") {
+      window.addEventListener("contextmenu", this._stopContextMenu);
+    } else if (button === "middle") {
+      event.preventDefault();
+    }
+  }
+
+  private _stopContextMenu = (event: InputEventType) => {
+    event.preventDefault();
+    window.removeEventListener("contextmenu", this._stopContextMenu);
+  };
 }

--- a/src/eventInput/EventInput.ts
+++ b/src/eventInput/EventInput.ts
@@ -23,9 +23,9 @@ export abstract class EventInput {
 
   public abstract onEventEnd(event: InputEventType): void;
 
-  public abstract getTouches(event: InputEventType): number;
+  public abstract onRelease(event: InputEventType): void;
 
-  public abstract forceRelease(event: InputEventType): void;
+  public abstract getTouches(event: InputEventType): number;
 
   protected abstract _getScale(event: InputEventType): number;
 

--- a/src/eventInput/EventInput.ts
+++ b/src/eventInput/EventInput.ts
@@ -1,6 +1,7 @@
 import { ExtendedEvent, InputEventType } from "../types";
 import { getAngle } from "../utils";
 import { window } from "../browser";
+import { MOUSE_LEFT, MOUSE_MIDDLE, MOUSE_RIGHT } from "../const";
 
 export const SUPPORT_TOUCH = "ontouchstart" in window;
 export const SUPPORT_POINTER = "PointerEvent" in window;
@@ -23,8 +24,6 @@ export abstract class EventInput {
   public abstract onEventEnd(event: InputEventType): void;
 
   public abstract getTouches(event: InputEventType): number;
-
-  protected abstract _getButton(event: InputEventType): string;
 
   protected abstract _getScale(event: InputEventType): number;
 
@@ -79,14 +78,26 @@ export abstract class EventInput {
     return Math.sqrt(x * x + y * y);
   }
 
+  protected _getButton(event: InputEventType): string {
+    const buttonCodeMap = { 1: MOUSE_LEFT, 2: MOUSE_RIGHT, 4: MOUSE_MIDDLE };
+    const button = this._isTouchEvent(event)
+      ? MOUSE_LEFT
+      : buttonCodeMap[event.buttons];
+    return button ? button : null;
+  }
+
+  protected _isTouchEvent(event: InputEventType): event is TouchEvent {
+    return event.type.indexOf("touch") > -1;
+  }
+
   protected _isValidButton(button: string, inputButton: string[]): boolean {
-    return inputButton.includes(button);
+    return inputButton.indexOf(button) > -1;
   }
 
   protected _preventMouseButton(event: InputEventType, button: string): void {
-    if (button === "right") {
+    if (button === MOUSE_RIGHT) {
       window.addEventListener("contextmenu", this._stopContextMenu);
-    } else if (button === "middle") {
+    } else if (button === MOUSE_MIDDLE) {
       event.preventDefault();
     }
   }

--- a/src/eventInput/EventInput.ts
+++ b/src/eventInput/EventInput.ts
@@ -25,6 +25,8 @@ export abstract class EventInput {
 
   public abstract getTouches(event: InputEventType): number;
 
+  public abstract forceRelease(event: InputEventType): void;
+
   protected abstract _getScale(event: InputEventType): number;
 
   protected abstract _getCenter(event: InputEventType): {

--- a/src/eventInput/MouseEventInput.ts
+++ b/src/eventInput/MouseEventInput.ts
@@ -11,7 +11,7 @@ export class MouseEventInput extends EventInput {
     event: InputEventType,
     inputButton?: string[]
   ): ExtendedEvent {
-    const button = this._getButton(event as MouseEvent);
+    const button = this._getButton(event);
     if (inputButton && !this._isValidButton(button, inputButton)) {
       return null;
     }
@@ -25,7 +25,7 @@ export class MouseEventInput extends EventInput {
   ): ExtendedEvent {
     if (
       inputButton &&
-      !this._isValidButton(this._getButton(event as MouseEvent), inputButton)
+      !this._isValidButton(this._getButton(event), inputButton)
     ) {
       return null;
     }
@@ -38,19 +38,6 @@ export class MouseEventInput extends EventInput {
 
   public getTouches(): number {
     return 0;
-  }
-
-  protected _getButton(event: MouseEvent): string {
-    switch (event.buttons) {
-      case 1:
-        return "left";
-      case 2:
-        return "right";
-      case 4:
-        return "middle";
-      default:
-        return "left";
-    }
   }
 
   protected _getScale(): number {

--- a/src/eventInput/MouseEventInput.ts
+++ b/src/eventInput/MouseEventInput.ts
@@ -7,11 +7,28 @@ export class MouseEventInput extends EventInput {
   public readonly move = ["mousemove"];
   public readonly end = ["mouseup"];
 
-  public onEventStart(event: InputEventType): ExtendedEvent {
+  public onEventStart(
+    event: InputEventType,
+    inputButton?: string[]
+  ): ExtendedEvent {
+    const button = this._getButton(event as MouseEvent);
+    if (inputButton && !this._isValidButton(button, inputButton)) {
+      return null;
+    }
+    this._preventMouseButton(event, button);
     return this.extendEvent(event);
   }
 
-  public onEventMove(event: InputEventType): ExtendedEvent {
+  public onEventMove(
+    event: InputEventType,
+    inputButton?: string[]
+  ): ExtendedEvent {
+    if (
+      inputButton &&
+      !this._isValidButton(this._getButton(event as MouseEvent), inputButton)
+    ) {
+      return null;
+    }
     return this.extendEvent(event);
   }
 
@@ -21,6 +38,19 @@ export class MouseEventInput extends EventInput {
 
   public getTouches(): number {
     return 0;
+  }
+
+  protected _getButton(event: MouseEvent): string {
+    switch (event.buttons) {
+      case 1:
+        return "left";
+      case 2:
+        return "right";
+      case 4:
+        return "middle";
+      default:
+        return "left";
+    }
   }
 
   protected _getScale(): number {

--- a/src/eventInput/MouseEventInput.ts
+++ b/src/eventInput/MouseEventInput.ts
@@ -36,12 +36,13 @@ export class MouseEventInput extends EventInput {
     return;
   }
 
-  public getTouches(): number {
-    return 0;
+  public onRelease(): void {
+    this.prevEvent = null;
+    return;
   }
 
-  public forceRelease(): void {
-    return;
+  public getTouches(): number {
+    return 0;
   }
 
   protected _getScale(): number {

--- a/src/eventInput/MouseEventInput.ts
+++ b/src/eventInput/MouseEventInput.ts
@@ -40,6 +40,10 @@ export class MouseEventInput extends EventInput {
     return 0;
   }
 
+  public forceRelease(): void {
+    return;
+  }
+
   protected _getScale(): number {
     return 1;
   }

--- a/src/eventInput/PointerEventInput.ts
+++ b/src/eventInput/PointerEventInput.ts
@@ -13,12 +13,29 @@ export class PointerEventInput extends EventInput {
   private _firstInputs: PointerEvent[] = [];
   private _recentInputs: PointerEvent[] = [];
 
-  public onEventStart(event: InputEventType): ExtendedEvent {
+  public onEventStart(
+    event: InputEventType,
+    inputButton?: string[]
+  ): ExtendedEvent {
+    const button = this._getButton(event as PointerEvent);
+    if (inputButton && !this._isValidButton(button, inputButton)) {
+      return null;
+    }
+    this._preventMouseButton(event, button);
     this._updatePointerEvent(event as PointerEvent);
     return this.extendEvent(event);
   }
 
-  public onEventMove(event: InputEventType): ExtendedEvent {
+  public onEventMove(
+    event: InputEventType,
+    inputButton?: string[]
+  ): ExtendedEvent {
+    if (
+      inputButton &&
+      !this._isValidButton(this._getButton(event as PointerEvent), inputButton)
+    ) {
+      return null;
+    }
     this._updatePointerEvent(event as PointerEvent);
     return this.extendEvent(event);
   }
@@ -29,6 +46,19 @@ export class PointerEventInput extends EventInput {
 
   public getTouches(): number {
     return this._recentInputs.length;
+  }
+
+  protected _getButton(event: PointerEvent): string {
+    switch (event.buttons) {
+      case 1:
+        return "left";
+      case 2:
+        return "right";
+      case 4:
+        return "middle";
+      default:
+        return "left";
+    }
   }
 
   protected _getScale(): number {
@@ -76,7 +106,7 @@ export class PointerEventInput extends EventInput {
     }
   }
 
-  private _removePointerEvent(event: PointerEvent) {
+  private _removePointerEvent(event?: PointerEvent) {
     this._firstInputs = this._firstInputs.filter(
       (x) => x.pointerId !== event.pointerId
     );

--- a/src/eventInput/PointerEventInput.ts
+++ b/src/eventInput/PointerEventInput.ts
@@ -17,7 +17,7 @@ export class PointerEventInput extends EventInput {
     event: InputEventType,
     inputButton?: string[]
   ): ExtendedEvent {
-    const button = this._getButton(event as PointerEvent);
+    const button = this._getButton(event);
     if (inputButton && !this._isValidButton(button, inputButton)) {
       return null;
     }
@@ -32,7 +32,7 @@ export class PointerEventInput extends EventInput {
   ): ExtendedEvent {
     if (
       inputButton &&
-      !this._isValidButton(this._getButton(event as PointerEvent), inputButton)
+      !this._isValidButton(this._getButton(event), inputButton)
     ) {
       return null;
     }
@@ -46,19 +46,6 @@ export class PointerEventInput extends EventInput {
 
   public getTouches(): number {
     return this._recentInputs.length;
-  }
-
-  protected _getButton(event: PointerEvent): string {
-    switch (event.buttons) {
-      case 1:
-        return "left";
-      case 2:
-        return "right";
-      case 4:
-        return "middle";
-      default:
-        return "left";
-    }
   }
 
   protected _getScale(): number {

--- a/src/eventInput/PointerEventInput.ts
+++ b/src/eventInput/PointerEventInput.ts
@@ -48,6 +48,12 @@ export class PointerEventInput extends EventInput {
     return this._recentInputs.length;
   }
 
+  public forceRelease(): void {
+    this._firstInputs = [];
+    this._recentInputs = [];
+    return;
+  }
+
   protected _getScale(): number {
     if (this._recentInputs.length !== 2) {
       return null; // TODO: consider calculating non-pinch gesture scale

--- a/src/eventInput/PointerEventInput.ts
+++ b/src/eventInput/PointerEventInput.ts
@@ -44,14 +44,15 @@ export class PointerEventInput extends EventInput {
     this._removePointerEvent(event as PointerEvent);
   }
 
-  public getTouches(): number {
-    return this._recentInputs.length;
-  }
-
-  public forceRelease(): void {
+  public onRelease(): void {
+    this.prevEvent = null;
     this._firstInputs = [];
     this._recentInputs = [];
     return;
+  }
+
+  public getTouches(): number {
+    return this._recentInputs.length;
   }
 
   protected _getScale(): number {

--- a/src/eventInput/TouchEventInput.ts
+++ b/src/eventInput/TouchEventInput.ts
@@ -27,6 +27,11 @@ export class TouchEventInput extends EventInput {
     return (event as TouchEvent).touches.length;
   }
 
+  public forceRelease(): void {
+    this._baseTouches = null;
+    return;
+  }
+
   protected _getScale(event: TouchEvent): number {
     if (event.touches.length !== 2 || this._baseTouches.length < 2) {
       return null; // TODO: consider calculating non-pinch gesture scale

--- a/src/eventInput/TouchEventInput.ts
+++ b/src/eventInput/TouchEventInput.ts
@@ -23,13 +23,14 @@ export class TouchEventInput extends EventInput {
     return;
   }
 
-  public getTouches(event: InputEventType): number {
-    return (event as TouchEvent).touches.length;
-  }
-
-  public forceRelease(): void {
+  public onRelease(): void {
+    this.prevEvent = null;
     this._baseTouches = null;
     return;
+  }
+
+  public getTouches(event: InputEventType): number {
+    return (event as TouchEvent).touches.length;
   }
 
   protected _getScale(event: TouchEvent): number {

--- a/src/eventInput/TouchEventInput.ts
+++ b/src/eventInput/TouchEventInput.ts
@@ -27,6 +27,10 @@ export class TouchEventInput extends EventInput {
     return (event as TouchEvent).touches.length;
   }
 
+  protected _getButton(): string {
+    return "left";
+  }
+
   protected _getScale(event: TouchEvent): number {
     if (event.touches.length !== 2 || this._baseTouches.length < 2) {
       return null; // TODO: consider calculating non-pinch gesture scale

--- a/src/eventInput/TouchEventInput.ts
+++ b/src/eventInput/TouchEventInput.ts
@@ -27,10 +27,6 @@ export class TouchEventInput extends EventInput {
     return (event as TouchEvent).touches.length;
   }
 
-  protected _getButton(): string {
-    return "left";
-  }
-
   protected _getScale(event: TouchEvent): number {
     if (event.touches.length !== 2 || this._baseTouches.length < 2) {
       return null; // TODO: consider calculating non-pinch gesture scale

--- a/src/eventInput/TouchMouseEventInput.ts
+++ b/src/eventInput/TouchMouseEventInput.ts
@@ -9,14 +9,31 @@ export class TouchMouseEventInput extends EventInput {
 
   private _baseTouches: TouchList;
 
-  public onEventStart(event: InputEventType): ExtendedEvent {
+  public onEventStart(
+    event: InputEventType,
+    inputButton?: string[]
+  ): ExtendedEvent {
+    const button = this._getButton(event as PointerEvent);
+    if (inputButton && !this._isValidButton(button, inputButton)) {
+      return null;
+    }
     if (this._isTouchEvent(event)) {
       this._baseTouches = (event as TouchEvent).touches;
     }
+    this._preventMouseButton(event, button);
     return this.extendEvent(event);
   }
 
-  public onEventMove(event: InputEventType): ExtendedEvent {
+  public onEventMove(
+    event: InputEventType,
+    inputButton?: string[]
+  ): ExtendedEvent {
+    if (
+      inputButton &&
+      !this._isValidButton(this._getButton(event), inputButton)
+    ) {
+      return null;
+    }
     return this.extendEvent(event);
   }
 
@@ -29,6 +46,22 @@ export class TouchMouseEventInput extends EventInput {
 
   public getTouches(event: InputEventType): number {
     return this._isTouchEvent(event) ? (event as TouchEvent).touches.length : 0;
+  }
+
+  protected _getButton(event: InputEventType): string {
+    if (this._isTouchEvent(event)) {
+      return "left";
+    }
+    switch ((event as MouseEvent).buttons) {
+      case 1:
+        return "left";
+      case 2:
+        return "right";
+      case 4:
+        return "middle";
+      default:
+        return "left";
+    }
   }
 
   protected _getScale(event: MouseEvent | TouchEvent): number {
@@ -90,6 +123,6 @@ export class TouchMouseEventInput extends EventInput {
   }
 
   private _isTouchEvent(event: InputEventType): boolean {
-    return event.hasOwnProperty("touches");
+    return event.type.includes("touch");
   }
 }

--- a/src/eventInput/TouchMouseEventInput.ts
+++ b/src/eventInput/TouchMouseEventInput.ts
@@ -13,12 +13,12 @@ export class TouchMouseEventInput extends EventInput {
     event: InputEventType,
     inputButton?: string[]
   ): ExtendedEvent {
-    const button = this._getButton(event as PointerEvent);
+    const button = this._getButton(event);
+    if (this._isTouchEvent(event)) {
+      this._baseTouches = event.touches;
+    }
     if (inputButton && !this._isValidButton(button, inputButton)) {
       return null;
-    }
-    if (this._isTouchEvent(event)) {
-      this._baseTouches = (event as TouchEvent).touches;
     }
     this._preventMouseButton(event, button);
     return this.extendEvent(event);
@@ -39,44 +39,23 @@ export class TouchMouseEventInput extends EventInput {
 
   public onEventEnd(event: InputEventType): void {
     if (this._isTouchEvent(event)) {
-      this._baseTouches = (event as TouchEvent).touches;
+      this._baseTouches = event.touches;
     }
     return;
   }
 
   public getTouches(event: InputEventType): number {
-    return this._isTouchEvent(event) ? (event as TouchEvent).touches.length : 0;
-  }
-
-  protected _getButton(event: InputEventType): string {
-    if (this._isTouchEvent(event)) {
-      return "left";
-    }
-    switch ((event as MouseEvent).buttons) {
-      case 1:
-        return "left";
-      case 2:
-        return "right";
-      case 4:
-        return "middle";
-      default:
-        return "left";
-    }
+    return this._isTouchEvent(event) ? event.touches.length : 0;
   }
 
   protected _getScale(event: MouseEvent | TouchEvent): number {
     if (this._isTouchEvent(event)) {
-      if (
-        (event as TouchEvent).touches.length !== 2 ||
-        this._baseTouches.length < 2
-      ) {
+      if (event.touches.length !== 2 || this._baseTouches.length < 2) {
         return 1; // TODO: consider calculating non-pinch gesture scale
       }
       return (
-        this._getDistance(
-          (event as TouchEvent).touches[0],
-          (event as TouchEvent).touches[1]
-        ) / this._getDistance(this._baseTouches[0], this._baseTouches[1])
+        this._getDistance(event.touches[0], event.touches[1]) /
+        this._getDistance(this._baseTouches[0], this._baseTouches[1])
       );
     }
     return this.prevEvent.scale;
@@ -88,13 +67,13 @@ export class TouchMouseEventInput extends EventInput {
   } {
     if (this._isTouchEvent(event)) {
       return {
-        x: (event as TouchEvent).touches[0].clientX,
-        y: (event as TouchEvent).touches[0].clientY,
+        x: event.touches[0].clientX,
+        y: event.touches[0].clientY,
       };
     }
     return {
-      x: (event as MouseEvent).clientX,
-      y: (event as MouseEvent).clientY,
+      x: event.clientX,
+      y: event.clientY,
     };
   }
 
@@ -120,9 +99,5 @@ export class TouchMouseEventInput extends EventInput {
     return nextSpot.id === prevSpot.id
       ? { x: nextSpot.x - prevSpot.x, y: nextSpot.y - prevSpot.y }
       : { x: 0, y: 0 };
-  }
-
-  private _isTouchEvent(event: InputEventType): boolean {
-    return event.type.includes("touch");
   }
 }

--- a/src/eventInput/TouchMouseEventInput.ts
+++ b/src/eventInput/TouchMouseEventInput.ts
@@ -44,13 +44,14 @@ export class TouchMouseEventInput extends EventInput {
     return;
   }
 
-  public getTouches(event: InputEventType): number {
-    return this._isTouchEvent(event) ? event.touches.length : 0;
-  }
-
-  public forceRelease(): void {
+  public onRelease(): void {
+    this.prevEvent = null;
     this._baseTouches = null;
     return;
+  }
+
+  public getTouches(event: InputEventType): number {
+    return this._isTouchEvent(event) ? event.touches.length : 0;
   }
 
   protected _getScale(event: MouseEvent | TouchEvent): number {

--- a/src/eventInput/TouchMouseEventInput.ts
+++ b/src/eventInput/TouchMouseEventInput.ts
@@ -48,6 +48,11 @@ export class TouchMouseEventInput extends EventInput {
     return this._isTouchEvent(event) ? event.touches.length : 0;
   }
 
+  public forceRelease(): void {
+    this._baseTouches = null;
+    return;
+  }
+
   protected _getScale(event: MouseEvent | TouchEvent): number {
     if (this._isTouchEvent(event)) {
       if (event.touches.length !== 2 || this._baseTouches.length < 2) {

--- a/src/inputType/InputType.ts
+++ b/src/inputType/InputType.ts
@@ -1,6 +1,6 @@
 import { Axis } from "../AxisManager";
 import { AxesOption } from "../Axes";
-import { ActiveInput } from "../types";
+import { ActiveEvent } from "../types";
 import { MouseEventInput } from "../eventInput/MouseEventInput";
 import { TouchEventInput } from "../eventInput/TouchEventInput";
 import { PointerEventInput } from "../eventInput/PointerEventInput";
@@ -44,7 +44,7 @@ export const toAxis = (source: string[], offset: number[]): Axis => {
   }, {});
 };
 
-export const convertInputType = (inputType: string[] = []): ActiveInput => {
+export const convertInputType = (inputType: string[] = []): ActiveEvent => {
   let hasTouch = false;
   let hasMouse = false;
   let hasPointer = false;

--- a/src/inputType/PanInput.ts
+++ b/src/inputType/PanInput.ts
@@ -307,7 +307,7 @@ export class PanInput implements InputType {
       ]
     );
     this._observer.release(this, prevEvent, velocity);
-    activeInput.prevEvent = null;
+    activeInput.onRelease();
   }
 
   protected _attachWindowEvent(activeInput: ActiveInput) {
@@ -368,7 +368,7 @@ export class PanInput implements InputType {
   private _forceRelease = () => {
     const activeInput = this._activeInput;
     this._detachWindowEvent(activeInput);
-    activeInput.forceRelease();
     this._observer.release(this, activeInput.prevEvent, [0, 0]);
+    activeInput.onRelease();
   };
 }

--- a/src/inputType/PanInput.ts
+++ b/src/inputType/PanInput.ts
@@ -246,8 +246,7 @@ export class PanInput implements InputType {
 
       if (swipeLeftToRight) {
         // iOS swipe left => right
-        this._detachWindowEvent(activeInput);
-        this._observer.release(this, activeInput.prevEvent, [0, 0]);
+        this._forceRelease();
         return;
       } else if (this._atRightEdge) {
         clearTimeout(this._rightEdgeTimer);
@@ -259,10 +258,10 @@ export class PanInput implements InputType {
           this._atRightEdge = false;
         } else {
           // iOS swipe right => left
-          this._rightEdgeTimer = window.setTimeout(() => {
-            this._detachWindowEvent(activeInput);
-            this._observer.release(this, activeInput.prevEvent, [0, 0]);
-          }, 100);
+          this._rightEdgeTimer = window.setTimeout(
+            () => this._forceRelease(),
+            100
+          );
         }
       }
     }
@@ -365,4 +364,11 @@ export class PanInput implements InputType {
     }
     return offset;
   }
+
+  private _forceRelease = () => {
+    const activeInput = this._activeInput;
+    this._detachWindowEvent(activeInput);
+    activeInput.forceRelease();
+    this._observer.release(this, activeInput.prevEvent, [0, 0]);
+  };
 }

--- a/src/inputType/PanInput.ts
+++ b/src/inputType/PanInput.ts
@@ -7,6 +7,7 @@ import {
   DIRECTION_HORIZONTAL,
   DIRECTION_ALL,
   PREVENT_SCROLL_CSSPROPS,
+  MOUSE_LEFT,
 } from "../const";
 import { ActiveInput, InputEventType } from "../types";
 
@@ -118,7 +119,7 @@ export class PanInput implements InputType {
     this.element = $(el);
     this.options = {
       inputType: ["touch", "mouse", "pointer"],
-      inputButton: ["left"],
+      inputButton: [MOUSE_LEFT],
       scale: [1, 1],
       thresholdAngle: 45,
       threshold: 0,

--- a/src/inputType/PinchInput.ts
+++ b/src/inputType/PinchInput.ts
@@ -168,9 +168,9 @@ export class PinchInput implements InputType {
     }
 
     this._observer.release(this, event, [0], 0);
+    activeInput.onRelease();
     this._baseValue = null;
     this._pinchFlag = false;
-    activeInput.prevEvent = null;
   }
 
   private _attachEvent(observer: InputTypeObserver) {

--- a/src/inputType/PinchInput.ts
+++ b/src/inputType/PinchInput.ts
@@ -1,5 +1,5 @@
 import { $, setCssProps } from "../utils";
-import { ActiveInput, InputEventType } from "../types";
+import { ActiveEvent, InputEventType } from "../types";
 import { PREVENT_SCROLL_CSSPROPS } from "../const";
 
 import {
@@ -45,7 +45,7 @@ export class PinchInput implements InputType {
   private _pinchFlag = false;
   private _enabled = false;
   private _originalCssProps: { [key: string]: string };
-  private _activeInput: ActiveInput = null;
+  private _activeEvent: ActiveEvent = null;
   private _baseValue: number;
 
   /**
@@ -69,7 +69,7 @@ export class PinchInput implements InputType {
   }
 
   public connect(observer: InputTypeObserver): InputType {
-    if (this._activeInput) {
+    if (this._activeEvent) {
       this._detachEvent();
     }
     this._attachEvent(observer);
@@ -124,85 +124,85 @@ export class PinchInput implements InputType {
   }
 
   private _onPinchStart(event: InputEventType) {
-    const activeInput = this._activeInput;
-    const pinchEvent = activeInput.onEventStart(event);
-    if (!pinchEvent || !this._enabled || activeInput.getTouches(event) !== 2) {
+    const activeEvent = this._activeEvent;
+    const pinchEvent = activeEvent.onEventStart(event);
+    if (!pinchEvent || !this._enabled || activeEvent.getTouches(event) !== 2) {
       return;
     }
 
     this._baseValue = this._observer.get(this)[this.axes[0]];
     this._observer.hold(this, event);
     this._pinchFlag = true;
-    activeInput.prevEvent = pinchEvent;
+    activeEvent.prevEvent = pinchEvent;
   }
 
   private _onPinchMove(event: InputEventType) {
-    const activeInput = this._activeInput;
-    const pinchEvent = activeInput.onEventMove(event);
+    const activeEvent = this._activeEvent;
+    const pinchEvent = activeEvent.onEventMove(event);
     if (
       !pinchEvent ||
       !this._pinchFlag ||
       !this._enabled ||
-      activeInput.getTouches(event) !== 2
+      activeEvent.getTouches(event) !== 2
     ) {
       return;
     }
 
     const offset = this._getOffset(
       pinchEvent.scale,
-      activeInput.prevEvent.scale
+      activeEvent.prevEvent.scale
     );
     this._observer.change(this, event, toAxis(this.axes, [offset]));
-    activeInput.prevEvent = pinchEvent;
+    activeEvent.prevEvent = pinchEvent;
   }
 
   private _onPinchEnd(event: InputEventType) {
-    const activeInput = this._activeInput;
-    activeInput.onEventEnd(event);
+    const activeEvent = this._activeEvent;
+    activeEvent.onEventEnd(event);
     if (
       !this._pinchFlag ||
       !this._enabled ||
-      activeInput.getTouches(event) >= 2
+      activeEvent.getTouches(event) >= 2
     ) {
       return;
     }
 
     this._observer.release(this, event, [0], 0);
-    activeInput.onRelease();
+    activeEvent.onRelease();
     this._baseValue = null;
     this._pinchFlag = false;
   }
 
   private _attachEvent(observer: InputTypeObserver) {
-    const activeInput = convertInputType(this.options.inputType);
-    if (!activeInput) {
+    const activeEvent = convertInputType(this.options.inputType);
+    if (!activeEvent) {
       throw new Error(
         "There is currently no inputType available for current device. There must be at least one available inputType."
       );
     }
     this._observer = observer;
     this._enabled = true;
-    this._activeInput = activeInput;
-    activeInput?.start.forEach((event) => {
+    this._activeEvent = activeEvent;
+    activeEvent?.start.forEach((event) => {
       this.element.addEventListener(event, this._onPinchStart, false);
     });
-    activeInput?.move.forEach((event) => {
+    activeEvent?.move.forEach((event) => {
       this.element.addEventListener(event, this._onPinchMove, false);
     });
-    activeInput?.end.forEach((event) => {
+    activeEvent?.end.forEach((event) => {
       this.element.addEventListener(event, this._onPinchEnd, false);
     });
   }
 
   private _detachEvent() {
-    const activeInput = this._activeInput;
-    activeInput?.start.forEach((event) => {
+    const activeEvent = this._activeEvent;
+    activeEvent?.start.forEach((event) => {
       this.element.removeEventListener(event, this._onPinchStart, false);
     });
-    activeInput?.move.forEach((event) => {
+    activeEvent?.move.forEach((event) => {
       this.element.removeEventListener(event, this._onPinchMove, false);
     });
-    activeInput?.end.forEach((event) => {
+    activeEvent?.end.forEach((event) => {
       this.element.removeEventListener(event, this._onPinchEnd, false);
     });
     this._enabled = false;

--- a/src/inputType/PinchInput.ts
+++ b/src/inputType/PinchInput.ts
@@ -124,43 +124,45 @@ export class PinchInput implements InputType {
   }
 
   private _onPinchStart(event: InputEventType) {
-    this._activeInput.onEventStart(event);
-    if (!this._enabled || this._activeInput.getTouches(event) !== 2) {
+    const activeInput = this._activeInput;
+    const pinchEvent = activeInput.onEventStart(event);
+    if (!pinchEvent || !this._enabled || activeInput.getTouches(event) !== 2) {
       return;
     }
 
     this._baseValue = this._observer.get(this)[this.axes[0]];
     this._observer.hold(this, event);
     this._pinchFlag = true;
-    const pinchEvent = this._activeInput.extendEvent(event);
-    this._activeInput.prevEvent = pinchEvent;
+    activeInput.prevEvent = pinchEvent;
   }
 
   private _onPinchMove(event: InputEventType) {
-    this._activeInput.onEventMove(event);
+    const activeInput = this._activeInput;
+    const pinchEvent = activeInput.onEventMove(event);
     if (
+      !pinchEvent ||
       !this._pinchFlag ||
       !this._enabled ||
-      this._activeInput.getTouches(event) !== 2
+      activeInput.getTouches(event) !== 2
     ) {
       return;
     }
 
-    const pinchEvent = this._activeInput.extendEvent(event);
     const offset = this._getOffset(
       pinchEvent.scale,
-      this._activeInput.prevEvent.scale
+      activeInput.prevEvent.scale
     );
     this._observer.change(this, event, toAxis(this.axes, [offset]));
-    this._activeInput.prevEvent = pinchEvent;
+    activeInput.prevEvent = pinchEvent;
   }
 
   private _onPinchEnd(event: InputEventType) {
-    this._activeInput.onEventEnd(event);
+    const activeInput = this._activeInput;
+    activeInput.onEventEnd(event);
     if (
       !this._pinchFlag ||
       !this._enabled ||
-      this._activeInput.getTouches(event) >= 2
+      activeInput.getTouches(event) >= 2
     ) {
       return;
     }
@@ -168,7 +170,7 @@ export class PinchInput implements InputType {
     this._observer.release(this, event, [0], 0);
     this._baseValue = null;
     this._pinchFlag = false;
-    this._activeInput.prevEvent = null;
+    activeInput.prevEvent = null;
   }
 
   private _attachEvent(observer: InputTypeObserver) {

--- a/src/inputType/RotatePanInput.ts
+++ b/src/inputType/RotatePanInput.ts
@@ -103,7 +103,7 @@ export class RotatePanInput extends PanInput {
     this._observer.release(this, prevEvent, [
       velocity * this._coefficientForDistanceToAngle,
     ]);
-    activeInput.prevEvent = null;
+    activeInput.onRelease();
     this._detachWindowEvent(activeInput);
   }
 

--- a/src/inputType/RotatePanInput.ts
+++ b/src/inputType/RotatePanInput.ts
@@ -48,8 +48,8 @@ export class RotatePanInput extends PanInput {
   }
 
   protected _onPanstart(event: MouseEvent) {
-    const activeInput = this._activeInput;
-    const panEvent = activeInput.onEventStart(event, this.options.inputButton);
+    const activeEvent = this._activeEvent;
+    const panEvent = activeEvent.onEventStart(event, this.options.inputButton);
     if (!panEvent || !this.isEnabled()) {
       return;
     }
@@ -57,7 +57,7 @@ export class RotatePanInput extends PanInput {
     const rect = this.element.getBoundingClientRect();
 
     this._observer.hold(this, panEvent);
-    this._attachWindowEvent(activeInput);
+    this._attachWindowEvent(activeEvent);
     // TODO: how to do if element is ellipse not circle.
     this._coefficientForDistanceToAngle = 360 / (rect.width * Math.PI); // from 2*pi*r * x / 360
     // TODO: provide a way to set origin like https://developer.mozilla.org/en-US/docs/Web/CSS/transform-origin
@@ -70,12 +70,12 @@ export class RotatePanInput extends PanInput {
     this._prevAngle = null;
 
     this._triggerChange(panEvent);
-    activeInput.prevEvent = panEvent;
+    activeEvent.prevEvent = panEvent;
   }
 
   protected _onPanmove(event: MouseEvent) {
-    const activeInput = this._activeInput;
-    const panEvent = activeInput.onEventMove(event, this.options.inputButton);
+    const activeEvent = this._activeEvent;
+    const panEvent = activeEvent.onEventMove(event, this.options.inputButton);
     if (!panEvent || !this.isEnabled()) {
       return;
     }
@@ -85,16 +85,16 @@ export class RotatePanInput extends PanInput {
     }
     panEvent.srcEvent.stopPropagation();
     this._triggerChange(panEvent);
-    activeInput.prevEvent = panEvent;
+    activeEvent.prevEvent = panEvent;
   }
 
   protected _onPanend(event: MouseEvent) {
-    const activeInput = this._activeInput;
-    activeInput.onEventEnd(event);
+    const activeEvent = this._activeEvent;
+    activeEvent.onEventEnd(event);
     if (!this.isEnabled()) {
       return;
     }
-    const prevEvent = activeInput.prevEvent;
+    const prevEvent = activeEvent.prevEvent;
     this._triggerChange(prevEvent);
     const vx = prevEvent.velocityX;
     const vy = prevEvent.velocityY;
@@ -103,8 +103,8 @@ export class RotatePanInput extends PanInput {
     this._observer.release(this, prevEvent, [
       velocity * this._coefficientForDistanceToAngle,
     ]);
-    activeInput.onRelease();
-    this._detachWindowEvent(activeInput);
+    activeEvent.onRelease();
+    this._detachWindowEvent(activeEvent);
   }
 
   private _triggerChange(event: ExtendedEvent) {

--- a/src/inputType/RotatePanInput.ts
+++ b/src/inputType/RotatePanInput.ts
@@ -49,13 +49,12 @@ export class RotatePanInput extends PanInput {
 
   protected _onPanstart(event: MouseEvent) {
     const activeInput = this._activeInput;
-    activeInput.onEventStart(event);
-    if (!this.isEnabled) {
+    const panEvent = activeInput.onEventStart(event, this.options.inputButton);
+    if (!panEvent || !this.isEnabled()) {
       return;
     }
 
     const rect = this.element.getBoundingClientRect();
-    const panEvent = activeInput.extendEvent(event);
 
     this._observer.hold(this, panEvent);
     this._attachWindowEvent(activeInput);
@@ -76,12 +75,10 @@ export class RotatePanInput extends PanInput {
 
   protected _onPanmove(event: MouseEvent) {
     const activeInput = this._activeInput;
-    activeInput.onEventMove(event);
-    if (!this.isEnabled) {
+    const panEvent = activeInput.onEventMove(event, this.options.inputButton);
+    if (!panEvent || !this.isEnabled()) {
       return;
     }
-
-    const panEvent = activeInput.extendEvent(event);
 
     if (panEvent.srcEvent.cancelable !== false) {
       panEvent.srcEvent.preventDefault();
@@ -94,7 +91,7 @@ export class RotatePanInput extends PanInput {
   protected _onPanend(event: MouseEvent) {
     const activeInput = this._activeInput;
     activeInput.onEventEnd(event);
-    if (!this.isEnabled) {
+    if (!this.isEnabled()) {
       return;
     }
     const prevEvent = activeInput.prevEvent;
@@ -106,6 +103,7 @@ export class RotatePanInput extends PanInput {
     this._observer.release(this, prevEvent, [
       velocity * this._coefficientForDistanceToAngle,
     ]);
+    activeInput.prevEvent = null;
     this._detachWindowEvent(activeInput);
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,7 +9,7 @@ export type ObjectInterface<T = any> = Record<string | number, T>;
 
 export type InputEventType = PointerEvent | MouseEvent | TouchEvent;
 
-export type ActiveInput =
+export type ActiveEvent =
   | MouseEventInput
   | TouchEventInput
   | TouchMouseEventInput

--- a/test/unit/AnimationManager.spec.js
+++ b/test/unit/AnimationManager.spec.js
@@ -5,10 +5,10 @@ import { EventManager } from "../../src/EventManager";
 import Axes from "../../src";
 
 describe("AnimationManager", () => {
-	let inst;
-	let axes;
-	let axis;
-	let options;
+  let inst;
+  let axes;
+  let axis;
+  let options;
 
   describe("method test", () => {
     beforeEach(() => {
@@ -16,29 +16,29 @@ describe("AnimationManager", () => {
         x: {
           range: [0, 100],
           bounce: [50, 50],
-          circular: false
+          circular: false,
         },
         y: {
           range: [0, 200],
           bounce: [0, 0],
-          circular: false
+          circular: false,
         },
         z: {
           range: [-100, 200],
           bounce: [50, 0],
-          circular: true
-        }
+          circular: true,
+        },
       };
       options = {
         deceleration: 0.0001,
         maximumDuration: 2000,
-        minimumDuration: 0
+        minimumDuration: 0,
       };
       inst = new AnimationManager({
         options: options,
         interruptManager: new InterruptManager(options),
         eventManager: new EventManager(null),
-        axisManager: new AxisManager(axis, options)
+        axisManager: new AxisManager(axis, options),
       });
     });
     afterEach(() => {});
@@ -48,17 +48,15 @@ describe("AnimationManager", () => {
       // When
       const depaPos = {
         x: 0,
-        y: 0
+        y: 0,
       };
       const destPos = {
         x: 100,
-        y: 50
+        y: 50,
       };
 
       // When/Then
-      expect(inst.getDuration(depaPos, destPos)).to.be.equal(
-        1414.213562373095
-      );
+      expect(inst.getDuration(depaPos, destPos)).to.be.equal(1414.213562373095);
 
       // When (change option)
       options.maximumDuration = 1200;
@@ -77,19 +75,19 @@ describe("AnimationManager", () => {
       // 0.001
       options.deceleration = 0.001;
       expect(inst.getDisplacement([1.5, 1])).to.be.eql([
-        1352.0817282989958, 901.3878188659972
+        1352.0817282989958, 901.3878188659972,
       ]);
       expect(inst.getDisplacement([1, 1.5])).to.be.eql([
-        901.3878188659972, 1352.0817282989958
+        901.3878188659972, 1352.0817282989958,
       ]);
 
       // 0.01
       options.deceleration = 0.01;
       expect(inst.getDisplacement([1.5, 1])).to.be.eql([
-        135.20817282989958, 90.13878188659973
+        135.20817282989958, 90.13878188659973,
       ]);
       expect(inst.getDisplacement([1, 1.5])).to.be.eql([
-        90.13878188659973, 135.20817282989958
+        90.13878188659973, 135.20817282989958,
       ]);
     });
 
@@ -99,7 +97,7 @@ describe("AnimationManager", () => {
       const pos = {
         x: 200,
         y: 210,
-        z: -155
+        z: -155,
       };
 
       // When
@@ -118,7 +116,7 @@ describe("AnimationManager", () => {
       options.maximumDuration = 500;
       const eventValue = { event: "i'm inputEvent" };
       param = inst._createAnimationParam(pos, 1000, {
-        event: eventValue
+        event: eventValue,
       });
 
       // Then
@@ -136,18 +134,18 @@ describe("AnimationManager", () => {
         x: {
           range: [0, 100],
           bounce: [50, 50],
-          circular: false /* [false, false] */
+          circular: false /* [false, false] */,
         },
         y: {
           range: [0, 200],
           bounce: [0, 0],
-          circular: false /* [false, false] */
+          circular: false /* [false, false] */,
         },
         z: {
           range: [-100, 200],
           bounce: [50, 0],
-          circular: true /* [true, true] */
-        }
+          circular: true /* [true, true] */,
+        },
       };
       options = {
         easing: (x) => {
@@ -156,7 +154,7 @@ describe("AnimationManager", () => {
         interruptable: true,
         deceleration: 0.0001,
         minimumDuration: 0,
-        maximumDuration: 2000
+        maximumDuration: 2000,
       };
       axes = new Axes(axis, options);
       const axisManager = new AxisManager(axis, options);
@@ -165,7 +163,7 @@ describe("AnimationManager", () => {
         options: options,
         interruptManager: new InterruptManager(options),
         eventManager,
-        axisManager
+        axisManager,
       });
       eventManager.setAnimationManager(inst);
     });
@@ -178,14 +176,14 @@ describe("AnimationManager", () => {
       const finishHandler = sinon.spy();
       axes.on({
         change: changeHandler,
-        finish: finishHandler
+        finish: finishHandler,
       });
 
       // When
       inst.setTo(
         {
           x: 100,
-          y: 200
+          y: 200,
         },
         0
       );
@@ -196,7 +194,7 @@ describe("AnimationManager", () => {
       expect(inst.axisManager.get()).to.be.eql({
         x: 100,
         y: 200,
-        z: -100
+        z: -100,
       });
     });
     it("should check 'setTo' method (outside)", () => {
@@ -204,7 +202,7 @@ describe("AnimationManager", () => {
       const depaPos = inst.axisManager.get();
       const destPos = {
         x: 200,
-        z: -155
+        z: -155,
       };
       const self = inst;
       const startHandler = sinon.spy();
@@ -213,7 +211,7 @@ describe("AnimationManager", () => {
       axes.on({
         animationStart: startHandler,
         change: changeHandler,
-        animationEnd: endHandler
+        animationEnd: endHandler,
       });
 
       // When
@@ -231,7 +229,7 @@ describe("AnimationManager", () => {
       const depaPos = inst.axisManager.get();
       const destPos = {
         x: 200,
-        z: -155
+        z: -155,
       };
       const self = inst;
       const startHandler = sinon.spy();
@@ -250,7 +248,7 @@ describe("AnimationManager", () => {
           expect(changeHandler.called).to.be.true;
           expect(event.isTrusted).to.be.false;
           done();
-        }
+        },
       });
 
       // When
@@ -262,12 +260,12 @@ describe("AnimationManager", () => {
       const depaPos = inst.axisManager.get();
       const destPos = {
         x: 0,
-        z: -100
+        z: -100,
       };
       const self = inst;
       const changeHandler = sinon.spy();
       axes.on({
-        change: changeHandler
+        change: changeHandler,
       });
 
       // When
@@ -286,12 +284,12 @@ describe("AnimationManager", () => {
       const depaPos = inst.axisManager.get();
       const destPos = {
         x: 0,
-        z: -100
+        z: -100,
       };
       const self = inst;
       const changeHandler = sinon.spy();
       axes.on({
-        change: changeHandler
+        change: changeHandler,
       });
 
       // When
@@ -316,7 +314,7 @@ describe("AnimationManager", () => {
         done();
       });
       axes.on({
-        change: changeHandler
+        change: changeHandler,
       });
 
       // When
@@ -330,7 +328,7 @@ describe("AnimationManager", () => {
       const self = inst;
       const changeHandler = sinon.spy();
       axes.on({
-        change: changeHandler
+        change: changeHandler,
       });
 
       // When
@@ -343,7 +341,7 @@ describe("AnimationManager", () => {
         expect(changeHandler.args[0][0].delta).to.be.eql({
           x: 0,
           y: 0,
-          z: 600
+          z: 600,
         });
         expect(ret).to.be.eq(self);
         done();
@@ -361,7 +359,7 @@ describe("AnimationManager", () => {
         done();
       });
       axes.on({
-        change: changeHandler
+        change: changeHandler,
       });
 
       // When
@@ -373,7 +371,7 @@ describe("AnimationManager", () => {
       const depaPos = inst.axisManager.get();
       const byPos = {
         x: 20,
-        z: 40
+        z: 40,
       };
       const self = inst;
       const startHandler = sinon.spy();
@@ -389,14 +387,14 @@ describe("AnimationManager", () => {
           expect(self.axisManager.get()).to.be.eql({
             x: depaPos.x + byPos.x,
             y: 0,
-            z: depaPos.z + byPos.z
+            z: depaPos.z + byPos.z,
           });
           expect(startHandler.callCount).to.be.equal(1);
           expect(startHandler.getCall(0).args[0].isTrusted).to.be.false;
           expect(changeHandler.called).to.be.true;
           expect(event.isTrusted).to.be.false;
           done();
-        }
+        },
       });
 
       // When
@@ -409,7 +407,7 @@ describe("AnimationManager", () => {
       const rangeLength = axis.z.range[1] - axis.z.range[0];
       const byPos = {
         x: 200,
-        z: 500
+        z: 500,
       };
       const self = inst;
       const startHandler = sinon.spy();
@@ -429,7 +427,7 @@ describe("AnimationManager", () => {
           expect(changeHandler.called).to.be.true;
           expect(event.isTrusted).to.be.false;
           done();
-        }
+        },
       });
 
       // When
@@ -440,7 +438,7 @@ describe("AnimationManager", () => {
       const depaPos = inst.axisManager.get();
       const destPos = {
         x: 90,
-        z: -80
+        z: -80,
       };
       const self = inst;
       const startHandler = sinon.spy();
@@ -459,7 +457,7 @@ describe("AnimationManager", () => {
           expect(changeHandler.called).to.be.true;
           expect(event.isTrusted).to.be.false;
           done();
-        }
+        },
       });
 
       // When
@@ -470,7 +468,7 @@ describe("AnimationManager", () => {
       const depaPos = inst.axisManager.get();
       const destPos = {
         x: 200,
-        z: -155
+        z: -155,
       };
       const self = inst;
       const startHandler = sinon.spy();
@@ -492,7 +490,7 @@ describe("AnimationManager", () => {
       });
       axes.on({
         animationStart: startHandler,
-        animationEnd: endHandler
+        animationEnd: endHandler,
       });
 
       // When
@@ -526,7 +524,7 @@ describe("AnimationManager", () => {
       axes.on({
         change: changeHandler,
         animationStart: startHandler,
-        animationEnd: endHandler
+        animationEnd: endHandler,
       });
 
       // When
@@ -543,7 +541,7 @@ describe("AnimationManager", () => {
         expect(inst.axisManager.get()).to.not.eql({
           x: 80,
           y: 150,
-          z: -100
+          z: -100,
         });
       }, 100);
       setTimeout(() => {
@@ -578,13 +576,11 @@ describe("AnimationManager", () => {
             duration: 1000,
             depaPos,
             destPos,
-            delta: { z: destPos.z - depaPos.z }
+            delta: { z: destPos.z - depaPos.z },
           },
           () => {
             // Then
-            expect(inst.axisManager.get(["z"]).z).to.be.equals(
-              resultPos.z
-            );
+            expect(inst.axisManager.get(["z"]).z).to.be.equals(resultPos.z);
             done();
           }
         );
@@ -618,13 +614,11 @@ describe("AnimationManager", () => {
             duration: 1000,
             depaPos,
             destPos,
-            delta: { z: destPos.z - depaPos.z }
+            delta: { z: destPos.z - depaPos.z },
           },
           () => {
             // Then
-            expect(inst.axisManager.get(["z"]).z).to.be.equals(
-              resultPos.z
-            );
+            expect(inst.axisManager.get(["z"]).z).to.be.equals(resultPos.z);
             done();
           }
         );
@@ -636,7 +630,7 @@ describe("AnimationManager", () => {
       const endHandler = sinon.spy();
       axes.on({
         animationStart: startHandler,
-        animationEnd: endHandler
+        animationEnd: endHandler,
       });
 
       // When
@@ -648,7 +642,7 @@ describe("AnimationManager", () => {
         expect(endHandler.called).to.be.false;
 
         // When
-        inst.updateAnimation({ destPos: { x: 100, y: 100 }});
+        inst.updateAnimation({ destPos: { x: 100, y: 100 } });
       }, 100);
       setTimeout(() => {
         expect(startHandler.calledOnce).to.be.true;
@@ -666,7 +660,7 @@ describe("AnimationManager", () => {
       const endHandler = sinon.spy();
       axes.on({
         animationStart: startHandler,
-        animationEnd: endHandler
+        animationEnd: endHandler,
       });
 
       // When
@@ -698,7 +692,7 @@ describe("AnimationManager", () => {
       const endHandler = sinon.spy();
       axes.on({
         animationStart: startHandler,
-        animationEnd: endHandler
+        animationEnd: endHandler,
       });
 
       // When
@@ -716,7 +710,10 @@ describe("AnimationManager", () => {
         expect(endHandler.called).to.be.false;
 
         // When
-        inst.updateAnimation({ destPos: { x: 12.3456, y: 1.2345 }, duration: 300 });
+        inst.updateAnimation({
+          destPos: { x: 12.3456, y: 1.2345 },
+          duration: 300,
+        });
       }, 200);
       setTimeout(() => {
         expect(startHandler.calledOnce).to.be.true;
@@ -734,7 +731,7 @@ describe("AnimationManager", () => {
       const endHandler = sinon.spy();
       axes.on({
         animationStart: startHandler,
-        animationEnd: endHandler
+        animationEnd: endHandler,
       });
 
       // When
@@ -769,7 +766,7 @@ describe("AnimationManager", () => {
       const endHandler = sinon.spy();
       axes.on({
         animationStart: startHandler,
-        animationEnd: endHandler
+        animationEnd: endHandler,
       });
 
       // When

--- a/test/unit/Axes.spec.js
+++ b/test/unit/Axes.spec.js
@@ -1,4 +1,3 @@
-
 import PanInputInjector from "inject-loader!../../src/inputType/PanInput.ts";
 
 import Axes from "../../src/Axes.ts";
@@ -8,17 +7,17 @@ import { getDecimalPlace, roundNumber } from "../../src/utils";
 
 describe("Axes", () => {
   let el;
-	let input;
-	let inst;
-	let nestedInst;
-	let holdHandler;
-	let changeHandler;
-	let releaseHandler;
-	let finishHandler;
-	let animationStartHandler;
-	let animationEndHandler;
-	let preventedFn;
-	let notPreventedFn;
+  let input;
+  let inst;
+  let nestedInst;
+  let holdHandler;
+  let changeHandler;
+  let releaseHandler;
+  let finishHandler;
+  let animationStartHandler;
+  let animationEndHandler;
+  let preventedFn;
+  let notPreventedFn;
 
   describe("Axes Test", () => {
     beforeEach(() => {
@@ -44,25 +43,15 @@ describe("Axes", () => {
         interruptable: true,
         minimumDuration: 0,
         maximumDuration: Infinity,
-        deceleration: 0.0006
+        deceleration: 0.0006,
       };
 
       expect(inst).to.be.exist;
-      expect(defaultOptions.easing(0.5)).to.be.equal(
-        inst.options.easing(0.5)
-      );
-      expect(defaultOptions.easing(0.3)).to.be.equal(
-        inst.options.easing(0.3)
-      );
-      expect(defaultOptions.easing(0.1)).to.be.equal(
-        inst.options.easing(0.1)
-      );
-      expect(defaultOptions.easing(0.7)).to.be.equal(
-        inst.options.easing(0.7)
-      );
-      expect(defaultOptions.easing(0.9)).to.be.equal(
-        inst.options.easing(0.9)
-      );
+      expect(defaultOptions.easing(0.5)).to.be.equal(inst.options.easing(0.5));
+      expect(defaultOptions.easing(0.3)).to.be.equal(inst.options.easing(0.3));
+      expect(defaultOptions.easing(0.1)).to.be.equal(inst.options.easing(0.1));
+      expect(defaultOptions.easing(0.7)).to.be.equal(inst.options.easing(0.7));
+      expect(defaultOptions.easing(0.9)).to.be.equal(inst.options.easing(0.9));
       expect(defaultOptions.interruptable).to.be.equal(
         inst.options.interruptable
       );
@@ -85,20 +74,20 @@ describe("Axes", () => {
           x: {
             range: [0, 100],
             bounce: [30, 50],
-            circular: true
+            circular: true,
           },
           otherX: {
             range: [-100, 100],
             bounce: 40,
-            circular: [false, true]
-          }
+            circular: [false, true],
+          },
         },
         {
-          deceleration: 0.001
+          deceleration: 0.001,
         },
         {
           x: 50,
-          otherX: 0
+          otherX: 0,
         }
       );
 
@@ -117,16 +106,16 @@ describe("Axes", () => {
           x: {
             range: [0, 100],
             bounce: [30, 50],
-            circular: true
+            circular: true,
           },
           otherX: {
             range: [-100, 100],
             bounce: 40,
-            circular: [false, true]
-          }
+            circular: [false, true],
+          },
         },
         {
-          deceleration: 0.001
+          deceleration: 0.001,
         }
       );
       // When
@@ -159,21 +148,21 @@ describe("Axes", () => {
           x: {
             range: [0, 100],
             bounce: [30, 50],
-            circular: true
+            circular: true,
           },
           otherX: {
             range: [-100, 100],
             bounce: 40,
-            circular: [false, true]
-          }
+            circular: [false, true],
+          },
         },
         {
-          deceleration: 0.001
+          deceleration: 0.001,
         }
       ).on({
         animationStart: startHandler,
         change: changeHandler,
-        animationEnd: endHandler
+        animationEnd: endHandler,
       });
 
       // When
@@ -187,16 +176,16 @@ describe("Axes", () => {
           x: {
             range: [0, 100],
             bounce: [30, 50],
-            circular: true
+            circular: true,
           },
           otherX: {
             range: [-100, 100],
             bounce: 40,
-            circular: [false, true]
-          }
+            circular: [false, true],
+          },
         },
         {
-          deceleration: 0.001
+          deceleration: 0.001,
         }
       );
       inst.setTo({ x: 50 });
@@ -205,7 +194,7 @@ describe("Axes", () => {
       inst.on({
         animationStart: startHandler,
         change: changeHandler,
-        animationEnd: endHandler
+        animationEnd: endHandler,
       });
 
       const startHandler = sinon.spy();
@@ -230,16 +219,16 @@ describe("Axes", () => {
           x: {
             range: [0, 100],
             bounce: [30, 50],
-            circular: true
+            circular: true,
           },
           otherX: {
             range: [-100, 100],
             bounce: 40,
-            circular: [false, true]
-          }
+            circular: [false, true],
+          },
         },
         {
-          deceleration: 0.001
+          deceleration: 0.001,
         }
       );
       sandbox();
@@ -335,14 +324,14 @@ describe("Axes", () => {
         deltaX: 100,
         deltaY: 10,
         duration: 200,
-        easing: "linear"
+        easing: "linear",
       };
       const MOVE_VERTICALLY = {
         pos: [0, 0],
         deltaX: 0,
         deltaY: 100,
         duration: 200,
-        easing: "linear"
+        easing: "linear",
       };
       const target = document.querySelector("#sandbox");
       const pinchInput = new PinchInput(target, { inputType: ["touch"] });
@@ -375,26 +364,25 @@ describe("Axes", () => {
 
   describe("Nested Axes Test", () => {
     beforeEach(() => {
-      inst = new Axes(
-        {
-          x: {
-            range: [0, 300],
-            bounce: [10, 10]
-          }
-        }
-      );
+      inst = new Axes({
+        x: {
+          range: [0, 300],
+          bounce: [10, 10],
+        },
+      });
       nestedInst = new Axes(
         {
           x: {
             range: [0, 200],
-            bounce: [10, 10]
-          }
-        }, {
-					nested: true
-				}
+            bounce: [10, 10],
+          },
+        },
+        {
+          nested: true,
+        }
       );
-			el = sandbox();
-			el.innerHTML = `<div id="parent"
+      el = sandbox();
+      el.innerHTML = `<div id="parent"
 			style="width:300px; height:200px;"><div id="child" style="width:200px; height:200px;"></div></div>`;
     });
     afterEach(() => {
@@ -423,25 +411,29 @@ describe("Axes", () => {
       const childPrevX = nestedInst.get()["x"];
 
       // When
-			Simulator.gestures.pan(child, {
-        pos: [0, 0],
-        deltaX: 100,
-        deltaY: 0,
-        duration: 200,
-        easing: "linear"
-      }, () => {
-				// Then
-				const parentCurrX = inst.get()["x"];
-				const childCurrX = nestedInst.get()["x"];
+      Simulator.gestures.pan(
+        child,
+        {
+          pos: [0, 0],
+          deltaX: 100,
+          deltaY: 0,
+          duration: 200,
+          easing: "linear",
+        },
+        () => {
+          // Then
+          const parentCurrX = inst.get()["x"];
+          const childCurrX = nestedInst.get()["x"];
 
-				expect(parentPrevX).to.be.equal(parentCurrX);
-				expect(childPrevX).to.be.not.equal(childCurrX);
+          expect(parentPrevX).to.be.equal(parentCurrX);
+          expect(childPrevX).to.be.not.equal(childCurrX);
 
-				parentInput.destroy();
-				childInput.destroy();
-				done();
-			});
-		});
+          parentInput.destroy();
+          childInput.destroy();
+          done();
+        }
+      );
+    });
 
     it("should check both state of the axes attached to the elements when child axes reaches the max range.", (done) => {
       // Given
@@ -457,25 +449,29 @@ describe("Axes", () => {
       const childPrevX = nestedInst.get()["x"];
 
       // When
-			Simulator.gestures.pan(child, {
-        pos: [0, 0],
-        deltaX: 300,
-        deltaY: 0,
-        duration: 200,
-        easing: "linear"
-      }, () => {
-				// Then
-				const parentCurrX = inst.get()["x"];
-				const childCurrX = nestedInst.get()["x"];
+      Simulator.gestures.pan(
+        child,
+        {
+          pos: [0, 0],
+          deltaX: 300,
+          deltaY: 0,
+          duration: 200,
+          easing: "linear",
+        },
+        () => {
+          // Then
+          const parentCurrX = inst.get()["x"];
+          const childCurrX = nestedInst.get()["x"];
 
-				expect(parentPrevX).to.be.not.equal(parentCurrX);
-				expect(childPrevX).to.be.not.equal(childCurrX);
+          expect(parentPrevX).to.be.not.equal(parentCurrX);
+          expect(childPrevX).to.be.not.equal(childCurrX);
 
-				parentInput.destroy();
-				childInput.destroy();
-				done();
-			});
-		});
+          parentInput.destroy();
+          childInput.destroy();
+          done();
+        }
+      );
+    });
   });
 
   [20, 30, 40, 50].forEach((iOSEdgeSwipeThreshold) => {
@@ -485,15 +481,15 @@ describe("Axes", () => {
           {
             x: {
               range: [0, 300],
-              bounce: 100
+              bounce: 100,
             },
             y: {
               range: [0, 400],
-              bounce: 100
-            }
+              bounce: 100,
+            },
           },
           {
-            deceleration: 0.001
+            deceleration: 0.001,
           }
         );
         el = sandbox();
@@ -505,17 +501,17 @@ describe("Axes", () => {
         const MockPanInputInjector = PanInputInjector({
           "../const": {
             IOS_EDGE_THRESHOLD: 30,
-            IS_IOS_SAFARI: true
-          }
+            IS_IOS_SAFARI: true,
+          },
         });
         input = new MockPanInputInjector.PanInput(el, {
           iOSEdgeSwipeThreshold,
-          inputType: ["touch"]
+          inputType: ["touch"],
         });
         inst
           .on({
             release: releaseHandler,
-            finish: finishHandler
+            finish: finishHandler,
           })
           .connect(["x", "y"], input);
 
@@ -553,7 +549,7 @@ describe("Axes", () => {
             deltaX: -50,
             deltaY: 10,
             duration: 200,
-            easing: "linear"
+            easing: "linear",
           },
           () => {
             // Then
@@ -582,7 +578,7 @@ describe("Axes", () => {
             deltaX: -15,
             deltaY: 0,
             duration: 200,
-            easing: "linear"
+            easing: "linear",
           },
           () => {
             // Then
@@ -611,7 +607,7 @@ describe("Axes", () => {
             deltaX: -60,
             deltaY: 0,
             duration: 200,
-            easing: "linear"
+            easing: "linear",
           },
           () => {
             // Then
@@ -637,16 +633,16 @@ describe("Axes", () => {
           {
             x: {
               range: [0, 300],
-              bounce: 100
+              bounce: 100,
             },
             y: {
               range: [0, 400],
-              bounce: 100
-            }
+              bounce: 100,
+            },
           },
           {
             deceleration: 0.001,
-            interruptable: false
+            interruptable: false,
           }
         );
         el = sandbox();
@@ -660,7 +656,7 @@ describe("Axes", () => {
           expect(self.interruptManager._prevented).to.be.false;
         };
         input = new PanInput(el, {
-          inputType: type
+          inputType: type,
         });
         inst.connect(["x", "y"], input);
       });
@@ -694,7 +690,7 @@ describe("Axes", () => {
           release: releaseHandler,
           finish: finishHandler,
           animationStart: animationStartHandler,
-          animationEnd: animationEndHandler
+          animationEnd: animationEndHandler,
         });
 
         // When
@@ -705,7 +701,7 @@ describe("Axes", () => {
             deltaX: 100,
             deltaY: 100,
             duration: 1000,
-            easing: "linear"
+            easing: "linear",
           },
           () => {
             // Then
@@ -747,7 +743,7 @@ describe("Axes", () => {
           release: releaseHandler,
           finish: finishHandler,
           animationStart: animationStartHandler,
-          animationEnd: animationEndHandler
+          animationEnd: animationEndHandler,
         });
 
         // When
@@ -758,7 +754,7 @@ describe("Axes", () => {
             deltaX: 100,
             deltaY: 100,
             duration: 1000,
-            easing: "linear"
+            easing: "linear",
           },
           () => {
             // Then
@@ -806,7 +802,7 @@ describe("Axes", () => {
           release: releaseHandler,
           finish: finishHandler,
           animationStart: animationStartHandler,
-          animationEnd: animationEndHandler
+          animationEnd: animationEndHandler,
         });
 
         // When
@@ -817,7 +813,7 @@ describe("Axes", () => {
             deltaX: 100,
             deltaY: 100,
             duration: 1000,
-            easing: "linear"
+            easing: "linear",
           },
           () => {
             // Then
@@ -849,7 +845,7 @@ describe("Axes", () => {
           release: releaseHandler,
           finish: finishHandler,
           animationStart: animationStartHandler,
-          animationEnd: animationEndHandler
+          animationEnd: animationEndHandler,
         });
 
         // when
@@ -860,7 +856,7 @@ describe("Axes", () => {
             deltaX: 100,
             deltaY: 100,
             duration: 1000,
-            easing: "linear"
+            easing: "linear",
           },
           () => {
             // Then
@@ -889,15 +885,15 @@ describe("Axes", () => {
           {
             x: {
               range: [0, 300],
-              bounce: 100
+              bounce: 100,
             },
             y: {
               range: [0, 400],
-              bounce: 100
-            }
+              bounce: 100,
+            },
           },
           {
-            deceleration: 0.001
+            deceleration: 0.001,
           }
         );
         el = sandbox();
@@ -911,7 +907,7 @@ describe("Axes", () => {
         animationEndHandler = sinon.spy();
 
         input = new PanInput(el, {
-          inputType: type
+          inputType: type,
         });
         inst
           .on({
@@ -919,7 +915,7 @@ describe("Axes", () => {
             release: releaseHandler,
             finish: finishHandler,
             animationStart: animationStartHandler,
-            animationEnd: animationEndHandler
+            animationEnd: animationEndHandler,
           })
           .connect(["x", "y"], input);
       });
@@ -957,7 +953,7 @@ describe("Axes", () => {
             deltaX: 10,
             deltaY: 10,
             duration: 3000,
-            easing: "linear"
+            easing: "linear",
           },
           () => {
             // Then
@@ -1017,7 +1013,7 @@ describe("Axes", () => {
             deltaX: -50,
             deltaY: 10,
             duration: 3000,
-            easing: "linear"
+            easing: "linear",
           },
           () => {
             // Then
@@ -1045,8 +1041,7 @@ describe("Axes", () => {
                 animationStartHandler.getCall(0).args[0];
               expect(animationStartHandler.called).to.be.true;
               expect(animationStartEvent.isTrusted).to.be.true;
-              const animationEndEvent =
-                animationEndHandler.getCall(0).args[0];
+              const animationEndEvent = animationEndHandler.getCall(0).args[0];
               expect(animationEndEvent.isTrusted).to.be.true;
 
               const finishEvent = finishHandler.getCall(0).args[0];
@@ -1082,7 +1077,7 @@ describe("Axes", () => {
             deltaX: 100,
             deltaY: 100,
             duration: 500,
-            easing: "linear"
+            easing: "linear",
           },
           () => {
             // Then
@@ -1126,7 +1121,7 @@ describe("Axes", () => {
           release: releaseHandler,
           finish: finishHandler,
           animationStart: animationStartHandler,
-          animationEnd: animationEndHandler
+          animationEnd: animationEndHandler,
         });
 
         // When
@@ -1137,7 +1132,7 @@ describe("Axes", () => {
             deltaX: 100,
             deltaY: 100,
             duration: 500,
-            easing: "linear"
+            easing: "linear",
           },
           () => {
             // Then
@@ -1164,7 +1159,7 @@ describe("Axes", () => {
           deltaX: 300,
           deltaY: 50,
           duration: 100,
-          easing: "linear"
+          easing: "linear",
         });
 
         // grab while animating
@@ -1194,13 +1189,13 @@ describe("Axes", () => {
       { range: [0, 100], destPos: 50.1234 }, // max decimal place at dest pos,
       { range: [0, 100], destPos: 50 }, // no decimal
       { range: [0, 1000], destPos: 445.17079889807155 }, // number to resolve flicking test failure.
-      { range: [0, 1000], destPos: 240.79930795847713 } // comparison value that works correctly.
+      { range: [0, 1000], destPos: 240.79930795847713 }, // comparison value that works correctly.
     ].forEach((val) => {
       it(`should round final value of animation by max decimal place(${val.range[0]}, ${val.range[1]}, ${val.destPos})`, async () => {
         inst = new Axes({
           x: {
-            range: val.range
-          }
+            range: val.range,
+          },
         });
 
         inst.setTo({ x: val.destPos }, 100);
@@ -1256,8 +1251,8 @@ describe("Axes", () => {
       inst = new Axes(
         {
           x: {
-            range: [0, 200]
-          }
+            range: [0, 200],
+          },
         },
         { round: 1 }
       );
@@ -1285,7 +1280,7 @@ describe("Axes", () => {
       const result = roundNumber(dividend / divisor, 0.000001);
       // Decimal place should be 0
       return getDecimalPlace(result) === 0;
-    }
+    };
 
     const checkAnimatedValueIsRound = async (round) => {
       // Given
@@ -1293,8 +1288,8 @@ describe("Axes", () => {
       inst = new Axes(
         {
           x: {
-            range: [0, 200]
-          }
+            range: [0, 200],
+          },
         },
         { round }
       ).on({
@@ -1306,7 +1301,7 @@ describe("Axes", () => {
         },
         finish: () => {
           dividables.push(isDividable(inst.get().x, round));
-        }
+        },
       });
 
       // When
@@ -1316,6 +1311,6 @@ describe("Axes", () => {
       inst.destroy();
 
       return dividables;
-    }
+    };
   });
 });

--- a/test/unit/AxisManager.spec.js
+++ b/test/unit/AxisManager.spec.js
@@ -1,7 +1,7 @@
 import { AxisManager } from "../../src/AxisManager";
 
 describe("AxisManager", () => {
-	let inst;
+  let inst;
 
   describe("instance method", () => {
     beforeEach(() => {
@@ -9,18 +9,18 @@ describe("AxisManager", () => {
         x: {
           range: [0, 100],
           bounce: [50, 50],
-          circular: false
+          circular: false,
         },
         y: {
           range: [0, 200],
           bounce: [0, 0],
-          circular: false
+          circular: false,
         },
         z: {
           range: [-100, 200],
           bounce: [50, 0],
-          circular: true
-        }
+          circular: true,
+        },
       });
     });
     afterEach(() => {});
@@ -38,7 +38,7 @@ describe("AxisManager", () => {
       expect(moved.delta).to.be.eql({
         x: 10,
         y: 20,
-        z: 130
+        z: 130,
       });
 
       // When (single)
@@ -52,7 +52,7 @@ describe("AxisManager", () => {
       expect(moved.delta).to.be.eql({
         x: 20,
         y: 0,
-        z: 0
+        z: 0,
       });
 
       // When (not included)
@@ -67,7 +67,7 @@ describe("AxisManager", () => {
       expect(moved.delta).to.be.eql({
         x: 0,
         y: 0,
-        z: 0
+        z: 0,
       });
     });
 
@@ -105,15 +105,14 @@ describe("AxisManager", () => {
       inst.moveTo({ x: 20, y: 0 });
 
       // Then
-      expect(inst.every(inst.get(), (v, opt, k) => v !== orgPos[k]))
-        .to.be.false;
+      expect(inst.every(inst.get(), (v, opt, k) => v !== orgPos[k])).to.be
+        .false;
 
       // When
       inst.moveTo({ x: 20, y: 30, z: 0 });
 
       // Then
-      expect(inst.every(inst.get(), (v, opt, k) => v !== orgPos[k]))
-        .to.be.true;
+      expect(inst.every(inst.get(), (v, opt, k) => v !== orgPos[k])).to.be.true;
     });
 
     it("should check 'filter' high-order method", () => {
@@ -125,17 +124,17 @@ describe("AxisManager", () => {
       inst.moveTo({ x: 20, y: 0 });
 
       // Then
-      expect(
-        inst.filter(inst.get(), (v, opt, k) => v !== orgPos[k])
-      ).to.be.eql({ x: 20 });
+      expect(inst.filter(inst.get(), (v, opt, k) => v !== orgPos[k])).to.be.eql(
+        { x: 20 }
+      );
 
       // When
       inst.moveTo({ x: 20, y: 30, z: 0 });
 
       // Then
-      expect(
-        inst.filter(inst.get(), (v, opt, k) => v !== orgPos[k])
-      ).to.be.eql({ x: 20, y: 30, z: 0 });
+      expect(inst.filter(inst.get(), (v, opt, k) => v !== orgPos[k])).to.be.eql(
+        { x: 20, y: 30, z: 0 }
+      );
     });
 
     it("should check 'map' high-order method", () => {
@@ -150,7 +149,7 @@ describe("AxisManager", () => {
       expect(inst.map(inst.get(), (v) => v + 20)).to.be.eql({
         x: 40,
         y: 20,
-        z: -80
+        z: -80,
       });
     });
 

--- a/test/unit/InputObserver.spec.js
+++ b/test/unit/InputObserver.spec.js
@@ -1,12 +1,12 @@
 import Axes from "../../src/Axes";
 
 describe("InputObserver", () => {
-	let inst;
-	let options;
-	let axes;
-	let axis;
-	let axisManager;
-	let animationManager;
+  let inst;
+  let options;
+  let axes;
+  let axis;
+  let axisManager;
+  let animationManager;
 
   describe("observer test", () => {
     beforeEach(() => {
@@ -14,23 +14,23 @@ describe("InputObserver", () => {
         x: {
           range: [0, 100],
           bounce: [50, 50],
-          circular: false
+          circular: false,
         },
         y: {
           range: [0, 200],
           bounce: [0, 0],
-          circular: false
+          circular: false,
         },
         z: {
           range: [-100, 200],
           bounce: [50, 0],
-          circular: true
-        }
+          circular: true,
+        },
       };
       options = {
         deceleration: 0.0001,
         maximumDuration: 2000,
-        minimumDuration: 0
+        minimumDuration: 0,
       };
       axes = new Axes(axis, options);
       axisManager = axes.axisManager;
@@ -42,7 +42,7 @@ describe("InputObserver", () => {
     it("should check 'get' method", () => {
       // Given
       const inputType = {
-        axes: ["y"]
+        axes: ["y"],
       };
 
       // When/Then
@@ -57,7 +57,7 @@ describe("InputObserver", () => {
     it("should check 'change' method", () => {
       // Given
       const inputType = {
-        axes: ["y"]
+        axes: ["y"],
       };
 
       // When/Then
@@ -90,7 +90,7 @@ describe("InputObserver", () => {
 
         // When
         const inputType = {
-          axes: ["y"]
+          axes: ["y"],
         };
         const sign = direction > 0 ? 1 : -1;
         inst.hold(inputType);
@@ -127,7 +127,7 @@ describe("InputObserver", () => {
 
         // When
         const inputType = {
-          axes: ["x"]
+          axes: ["x"],
         };
         const sign = direction > 0 ? 1 : -1;
         inst.hold(inputType);
@@ -183,7 +183,7 @@ describe("InputObserver", () => {
     it("should check delta that there is no bounce and the position goes to zero.", (done) => {
       // Given
       const inputType = {
-        axes: ["y"]
+        axes: ["y"],
       };
       // start pos
       let y = 50;
@@ -220,7 +220,7 @@ describe("InputObserver", () => {
 
       // When
       const inputType = {
-        axes: ["z"]
+        axes: ["z"],
       };
       inst.hold(inputType);
       // 40 * 25
@@ -232,7 +232,7 @@ describe("InputObserver", () => {
     it("should check delta that there is no bounce and the position is out", (done) => {
       // Given
       const inputType = {
-        axes: ["y"]
+        axes: ["y"],
       };
       // start pos
       const y = 50;
@@ -257,7 +257,7 @@ describe("InputObserver", () => {
     it("should check delta that there is bounce and the position is out", (done) => {
       // Given
       const inputType = {
-        axes: ["x"]
+        axes: ["x"],
       };
 
       // start pos

--- a/test/unit/inputType/InputType.spec.js
+++ b/test/unit/inputType/InputType.spec.js
@@ -1,10 +1,10 @@
-import InputInjector from "inject-loader!../../../src/inputType/InputType";
-import EventInjector from "inject-loader!../../../src/eventInput/EventInput";
-
 import { MouseEventInput } from "../../../src/eventInput/MouseEventInput";
 import { PointerEventInput } from "../../../src/eventInput/PointerEventInput";
 import { TouchEventInput } from "../../../src/eventInput/TouchEventInput";
 import { TouchMouseEventInput } from "../../../src/eventInput/TouchMouseEventInput";
+
+import InputInjector from "inject-loader!../../../src/inputType/InputType";
+import EventInjector from "inject-loader!../../../src/eventInput/EventInput";
 
 describe("InputType", () => {
   describe("SUPPORT_TOUCH mocking", () => {
@@ -12,7 +12,7 @@ describe("InputType", () => {
       // Given
       const MockEventInjector = EventInjector();
       const MockInputInjector = InputInjector({
-        "../eventInput/EventInput": MockEventInjector
+        "../eventInput/EventInput": MockEventInjector,
       });
 
       MockEventInjector.SUPPORT_TOUCH = true;
@@ -54,7 +54,7 @@ describe("InputType", () => {
       // Given
       const MockEventInjector = EventInjector();
       const MockInputInjector = InputInjector({
-        "../eventInput/EventInput": MockEventInjector
+        "../eventInput/EventInput": MockEventInjector,
       });
       MockEventInjector.SUPPORT_TOUCH = false;
 

--- a/test/unit/inputType/MoveKeyInput.spec.js
+++ b/test/unit/inputType/MoveKeyInput.spec.js
@@ -9,18 +9,18 @@ import {
   KEY_RIGHT_ARROW,
   KEY_S,
   KEY_UP_ARROW,
-  KEY_W
+  KEY_W,
 } from "../../../src/inputType/MoveKeyInput";
 
 import TestHelper from "./TestHelper";
 
 describe("MoveKeyInput", () => {
-	let el;
-	let elBody;
-	let input;
-	let inst;
-	let observer;
-	let timer;
+  let el;
+  let elBody;
+  let input;
+  let inst;
+  let observer;
+  let timer;
 
   describe("instance method", () => {
     beforeEach(() => {
@@ -69,8 +69,8 @@ describe("MoveKeyInput", () => {
         hold: () => {},
         change: () => {},
         options: {
-          deceleration: 0.0001
-        }
+          deceleration: 0.0001,
+        },
       };
     });
     afterEach(() => {
@@ -117,11 +117,11 @@ describe("MoveKeyInput", () => {
       input = new MoveKeyInput(el);
       inst = new Axes({
         x: {
-          range: [10, 120]
+          range: [10, 120],
         },
         y: {
-          range: [10, 120]
-        }
+          range: [10, 120],
+        },
       });
     });
 
@@ -165,11 +165,11 @@ describe("MoveKeyInput", () => {
       input = new MoveKeyInput(el);
       inst = new Axes({
         x: {
-          range: [10, 120]
+          range: [10, 120],
         },
         y: {
-          range: [10, 120]
-        }
+          range: [10, 120],
+        },
       });
 
       inst.connect(["x", "y"], input);
@@ -231,7 +231,7 @@ describe("MoveKeyInput", () => {
           let changeTriggered = false;
           let deltaX = 0;
           const leftKeyCode = {
-            keyCode: keyCode
+            keyCode: keyCode,
           };
           input.options.scale[0] = -1;
           inst.on("change", (e) => {
@@ -259,7 +259,7 @@ describe("MoveKeyInput", () => {
           let changeTriggered = false;
           let deltaX = 0;
           const rightKeyCode = {
-            keyCode: keyCode
+            keyCode: keyCode,
           };
           const change = sinon.spy((e) => {
             deltaX = e.delta.x;
@@ -298,7 +298,7 @@ describe("MoveKeyInput", () => {
         let changeTriggered = false;
         let deltaY = 0;
         const upKeyCode = {
-          keyCode: keyCode
+          keyCode: keyCode,
         };
         const change = sinon.spy((e) => {
           deltaY = e.delta.y;
@@ -340,7 +340,7 @@ describe("MoveKeyInput", () => {
           changeTriggered = true;
         });
         const downKeyCode = {
-          keyCode: keyCode
+          keyCode: keyCode,
         };
         input.options.scale[1] = -1;
 
@@ -364,7 +364,7 @@ describe("MoveKeyInput", () => {
           const holdHandler = sinon.spy();
           const releaseHandler = sinon.spy();
           const downKeyCode = {
-            keyCode: keyCode
+            keyCode: keyCode,
           };
 
           inst.on("hold", holdHandler);
@@ -403,22 +403,17 @@ describe("MoveKeyInput", () => {
             });
 
           // When
-          TestHelper.key(
-            el,
-            "keydown",
-            { keyCode: KEY_DOWN_ARROW },
-            () => {
-              setTimeout(() => {
-                TestHelper.key(el, "keyup", { keyCode: keyCode }, () => {
-                  setTimeout(() => {
-                    // Then
-                    expect(eventLog).to.be.deep.equal(eventLogAnswer);
-                    done();
-                  }, 100);
-                });
-              }, 20);
-            }
-          );
+          TestHelper.key(el, "keydown", { keyCode: KEY_DOWN_ARROW }, () => {
+            setTimeout(() => {
+              TestHelper.key(el, "keyup", { keyCode: keyCode }, () => {
+                setTimeout(() => {
+                  // Then
+                  expect(eventLog).to.be.deep.equal(eventLogAnswer);
+                  done();
+                }, 100);
+              });
+            }, 20);
+          });
         }
       );
     });

--- a/test/unit/inputType/PanInput.spec.js
+++ b/test/unit/inputType/PanInput.spec.js
@@ -2,20 +2,20 @@ import Axes from "../../../src/Axes.ts";
 import {
   PanInput,
   getDirectionByAngle,
-  useDirection
+  useDirection,
 } from "../../../src/inputType/PanInput";
 import {
   DIRECTION_ALL,
   DIRECTION_HORIZONTAL,
   DIRECTION_NONE,
-  DIRECTION_VERTICAL
+  DIRECTION_VERTICAL,
 } from "../../../src/const";
 
 describe("PanInput", () => {
-	let el;
-	let input;
-	let inst;
-	let observer;
+  let el;
+  let input;
+  let inst;
+  let observer;
 
   describe("instance method", () => {
     beforeEach(() => {
@@ -89,15 +89,15 @@ describe("PanInput", () => {
     beforeEach(() => {
       el = sandbox();
       input = new PanInput(el, {
-        inputType: ["touch", "mouse"]
+        inputType: ["touch", "mouse"],
       });
       inst = new Axes({
         x: {
-          range: [0, 200]
+          range: [0, 200],
         },
         y: {
-          range: [0, 200]
-        }
+          range: [0, 200],
+        },
       });
     });
     afterEach(() => {
@@ -151,7 +151,7 @@ describe("PanInput", () => {
           deltaX: 50,
           deltaY: 50,
           duration: 200,
-          easing: "linear"
+          easing: "linear",
         },
         () => {
           // Then
@@ -184,7 +184,7 @@ describe("PanInput", () => {
           deltaX: 50,
           deltaY: 50,
           duration: 200,
-          easing: "linear"
+          easing: "linear",
         },
         () => {
           // Then
@@ -318,11 +318,11 @@ describe("PanInput", () => {
       el = sandbox();
       inst = new Axes({
         x: {
-          range: [0, 200]
+          range: [0, 200],
         },
         y: {
-          range: [0, 200]
-        }
+          range: [0, 200],
+        },
       });
     });
     afterEach(() => {
@@ -337,40 +337,40 @@ describe("PanInput", () => {
       cleanup();
     });
 
-		["left", "middle", "right"].forEach((button) => {
-			it("should check 'inputButton' option", (done) => {
-				// Given
-				const hold = sinon.spy();
-				const change = sinon.spy();
-				const release = sinon.spy();
-				input = new PanInput(el, {
-					inputType: ["touch", "mouse"],
-					inputButton: [button]
-				});
-				inst.connect(["x", "y"], input);
-				inst.on("hold", hold);
-				inst.on("change", change);
-				inst.on("release", release);
+    ["left", "middle", "right"].forEach((button) => {
+      it("should check 'inputButton' option", (done) => {
+        // Given
+        const hold = sinon.spy();
+        const change = sinon.spy();
+        const release = sinon.spy();
+        input = new PanInput(el, {
+          inputType: ["touch", "mouse"],
+          inputButton: [button],
+        });
+        inst.connect(["x", "y"], input);
+        inst.on("hold", hold);
+        inst.on("change", change);
+        inst.on("release", release);
 
-				// When
-				Simulator.gestures.pan(
-					el,
-					{
-						pos: [0, 0],
-						deltaX: 50,
-						deltaY: 50,
-						duration: 200,
-						easing: "linear"
-					},
-					() => {
-						// Then
-						expect(hold.called).to.be.equals(button === "left");
-						expect(change.called).to.be.equals(button === "left");
-						expect(release.called).to.be.equals(button === "left");
-						done();
-					}
-				);
-			});
-		});
+        // When
+        Simulator.gestures.pan(
+          el,
+          {
+            pos: [0, 0],
+            deltaX: 50,
+            deltaY: 50,
+            duration: 200,
+            easing: "linear",
+          },
+          () => {
+            // Then
+            expect(hold.called).to.be.equals(button === "left");
+            expect(change.called).to.be.equals(button === "left");
+            expect(release.called).to.be.equals(button === "left");
+            done();
+          }
+        );
+      });
+    });
   });
 });

--- a/test/unit/inputType/PanInput.spec.js
+++ b/test/unit/inputType/PanInput.spec.js
@@ -312,4 +312,65 @@ describe("PanInput", () => {
       ).to.be.true;
     });
   });
+
+  describe("options test", () => {
+    beforeEach(() => {
+      el = sandbox();
+      inst = new Axes({
+        x: {
+          range: [0, 200]
+        },
+        y: {
+          range: [0, 200]
+        }
+      });
+    });
+    afterEach(() => {
+      if (inst) {
+        inst.destroy();
+        inst = null;
+      }
+      if (input) {
+        input.destroy();
+        input = null;
+      }
+      cleanup();
+    });
+
+		["left", "middle", "right"].forEach((button) => {
+			it("should check 'inputButton' option", (done) => {
+				// Given
+				const hold = sinon.spy();
+				const change = sinon.spy();
+				const release = sinon.spy();
+				input = new PanInput(el, {
+					inputType: ["touch", "mouse"],
+					inputButton: [button]
+				});
+				inst.connect(["x", "y"], input);
+				inst.on("hold", hold);
+				inst.on("change", change);
+				inst.on("release", release);
+
+				// When
+				Simulator.gestures.pan(
+					el,
+					{
+						pos: [0, 0],
+						deltaX: 50,
+						deltaY: 50,
+						duration: 200,
+						easing: "linear"
+					},
+					() => {
+						// Then
+						expect(hold.called).to.be.equals(button === "left");
+						expect(change.called).to.be.equals(button === "left");
+						expect(release.called).to.be.equals(button === "left");
+						done();
+					}
+				);
+			});
+		});
+  });
 });

--- a/test/unit/inputType/PinchInput.spec.js
+++ b/test/unit/inputType/PinchInput.spec.js
@@ -2,10 +2,10 @@ import Axes from "../../../src/Axes.ts";
 import { PinchInput } from "../../../src/inputType/PinchInput";
 
 describe("PinchInput", () => {
-	let el;
-	let input;
-	let inst;
-	let observer;
+  let el;
+  let input;
+  let inst;
+  let observer;
 
   describe("instance method", () => {
     beforeEach(() => {
@@ -49,8 +49,8 @@ describe("PinchInput", () => {
       input = new PinchInput(el, { inputType: ["touch"] });
       inst = new Axes({
         zoom: {
-          range: [1, 10]
-        }
+          range: [1, 10],
+        },
       });
     });
     afterEach(() => {
@@ -107,7 +107,7 @@ describe("PinchInput", () => {
         el,
         {
           duration: 500,
-          scale: 0.5
+          scale: 0.5,
         },
         () => {
           // Then
@@ -137,7 +137,7 @@ describe("PinchInput", () => {
         el,
         {
           duration: 500,
-          scale: 0.5
+          scale: 0.5,
         },
         () => {
           // Then
@@ -157,12 +157,12 @@ describe("PinchInput", () => {
       inst = new Axes(
         {
           x: {
-            range: [10, 120]
-          }
+            range: [10, 120],
+          },
         },
         { round: 1 },
         {
-          x: 50
+          x: 50,
         }
       );
       inst.connect(["x"], input);
@@ -187,7 +187,7 @@ describe("PinchInput", () => {
         el,
         {
           duration: 500,
-          scale: 1.1
+          scale: 1.1,
         },
         () => {
           // Then
@@ -205,7 +205,7 @@ describe("PinchInput", () => {
         el,
         {
           duration: 500,
-          scale: 0.9
+          scale: 0.9,
         },
         () => {
           // Then

--- a/test/unit/inputType/RotatePanInput.spec.js
+++ b/test/unit/inputType/RotatePanInput.spec.js
@@ -9,7 +9,7 @@ describe("RotatePanInput", () => {
   let axes;
   let clock;
 
-   const testPanMove = async (MOVES) => {
+  const testPanMove = async (MOVES) => {
     const resultAngles = [];
 
     for (let i = 0; i < MOVES.length; i++) {
@@ -27,7 +27,7 @@ describe("RotatePanInput", () => {
     resultAngles.forEach((angle, i) => {
       expect(angle).to.be.closeTo(MOVES[i].expectedAngle, 1);
     });
-  }
+  };
 
   beforeEach(() => {
     clock = sinon.useFakeTimers();
@@ -40,13 +40,13 @@ describe("RotatePanInput", () => {
     el.style.backgroundColor = "yellow";
 
     input = new RotatePanInput(el, {
-      inputType: ["touch", "mouse"]
+      inputType: ["touch", "mouse"],
     });
 
     axes = new Axes({
       angle: {
-        range: [-360, 360]
-      }
+        range: [-360, 360],
+      },
     });
 
     axes.connect("angle", input);
@@ -74,7 +74,7 @@ describe("RotatePanInput", () => {
       deltaX: 100, // Until 200
       deltaY: 0,
       duration: 2000,
-      expectedAngle: 45
+      expectedAngle: 45,
     };
 
     const MOVE_HORIZONTALLY_FULL_AT_TOP = {
@@ -82,7 +82,7 @@ describe("RotatePanInput", () => {
       deltaX: 200,
       deltaY: 0,
       duration: 3000,
-      expectedAngle: 90
+      expectedAngle: 90,
     };
 
     const MOVE_VERTICALLY_HALF_AT_LEFT = {
@@ -90,7 +90,7 @@ describe("RotatePanInput", () => {
       deltaX: 0,
       deltaY: 100,
       duration: 2000,
-      expectedAngle: -45
+      expectedAngle: -45,
     };
 
     const MOVE_VERTICALLY_HALF_AT_RIGHT = {
@@ -98,14 +98,14 @@ describe("RotatePanInput", () => {
       deltaX: 0,
       deltaY: 100,
       duration: 2000,
-      expectedAngle: 45
+      expectedAngle: 45,
     };
 
     const MOVES = [
       MOVE_HORIZONTALLY_HALF_AT_TOP,
       MOVE_HORIZONTALLY_FULL_AT_TOP,
       MOVE_VERTICALLY_HALF_AT_LEFT,
-      MOVE_VERTICALLY_HALF_AT_RIGHT
+      MOVE_VERTICALLY_HALF_AT_RIGHT,
     ];
 
     await testPanMove(MOVES);
@@ -118,35 +118,35 @@ describe("RotatePanInput", () => {
       deltaX: 100, // Until 200
       deltaY: 0,
       duration: 2000,
-      expectedAngle: (Math.atan2(100 / 2, RADIUS) * 2 * 180) / Math.PI
+      expectedAngle: (Math.atan2(100 / 2, RADIUS) * 2 * 180) / Math.PI,
     };
     const MOVE_HORIZONTALLY_HALF_AT_BOTTOM = {
       pos: [50, 200], // Mid index of width 201 is 100 (201 - 1 / 2 )
       deltaX: 100, // Until 200
       deltaY: 0,
       duration: 2000,
-      expectedAngle: (-Math.atan2(100 / 2, RADIUS) * 2 * 180) / Math.PI
+      expectedAngle: (-Math.atan2(100 / 2, RADIUS) * 2 * 180) / Math.PI,
     };
     const MOVE_VERTICALLY_HALF_AT_LEFT = {
       pos: [0, 50], // Mid index of width 201 is 100 (201 - 1 / 2 )
       deltaX: 0, // Until 200
       deltaY: 100,
       duration: 2000,
-      expectedAngle: (-Math.atan2(100 / 2, RADIUS) * 2 * 180) / Math.PI
+      expectedAngle: (-Math.atan2(100 / 2, RADIUS) * 2 * 180) / Math.PI,
     };
     const MOVE_VERTICALLY_HALF_AT_RIGHT = {
       pos: [200, 50], // Mid index of width 201 is 100 (201 - 1 / 2 )
       deltaX: 0, // Until 200
       deltaY: 100,
       duration: 2000,
-      expectedAngle: (Math.atan2(100 / 2, RADIUS) * 2 * 180) / Math.PI
+      expectedAngle: (Math.atan2(100 / 2, RADIUS) * 2 * 180) / Math.PI,
     };
 
     const MOVES = [
       MOVE_HORIZONTALLY_HALF_AT_TOP,
       MOVE_HORIZONTALLY_HALF_AT_BOTTOM,
       MOVE_VERTICALLY_HALF_AT_LEFT,
-      MOVE_VERTICALLY_HALF_AT_RIGHT
+      MOVE_VERTICALLY_HALF_AT_RIGHT,
     ];
 
     // Then
@@ -162,13 +162,13 @@ describe("RotatePanInput", () => {
       pos: [50, 0], // Mid index of width 201 is 100 (201 - 1 / 2 )
       deltaX: 100, // Until 200
       deltaY: 0,
-      duration: 2000
+      duration: 2000,
     };
     const MOVE_HORIZONTALLY_FAST = {
       pos: [50, 0], // Mid index of width 201 is 100 (201 - 1 / 2 )
       deltaX: 100, // Until 200
       deltaY: 0,
-      duration: 200
+      duration: 200,
     };
     const MOVES = [MOVE_HORIZONTALLY_SLOW, MOVE_HORIZONTALLY_FAST];
 
@@ -195,13 +195,13 @@ describe("RotatePanInput", () => {
     smElement.style.backgroundColor = "yellow";
 
     const smInput = new RotatePanInput(smElement, {
-      inputType: ["touch", "mouse"]
+      inputType: ["touch", "mouse"],
     });
 
     const smAxes = new Axes({
       angle: {
-        range: [-360, 360]
-      }
+        range: [-360, 360],
+      },
     });
 
     smAxes.connect("angle", smInput);
@@ -217,7 +217,7 @@ describe("RotatePanInput", () => {
       deltaX: 100, // Until 200
       deltaY: 0,
       duration: 2000,
-      expectedAngle: 45
+      expectedAngle: 45,
     };
 
     const MOVE_HORIZONTALLY_ON_SMALL = {
@@ -227,7 +227,7 @@ describe("RotatePanInput", () => {
       deltaX: 50, // Until 100
       deltaY: 0,
       duration: 2000,
-      expectedAngle: 45
+      expectedAngle: 45,
     };
 
     const MOVES = [MOVE_HORIZONTALLY_ON_BIG, MOVE_HORIZONTALLY_ON_SMALL];
@@ -245,7 +245,7 @@ describe("RotatePanInput", () => {
       deltaX: 100, // Until 200
       deltaY: 0,
       duration: 2000,
-      expectedAngle: 45
+      expectedAngle: 45,
     };
 
     axes.setTo({ angle: 0 });
@@ -268,7 +268,7 @@ describe("RotatePanInput", () => {
       deltaX: 50, // Until 100
       deltaY: 0,
       duration: 2000,
-      expectedAngle: 45
+      expectedAngle: 45,
     };
 
     axes.setTo({ angle: 0 });

--- a/test/unit/inputType/TestHelper.js
+++ b/test/unit/inputType/TestHelper.js
@@ -38,7 +38,7 @@ export default class TestHelper {
       delete keyboardEvent.keyCode;
       Object.defineProperty(keyboardEvent, "keyCode", {
         value: value.keyCode,
-        writable: true
+        writable: true,
       });
     } catch (e) {
       keyboardEvent = document.createEvent("KeyboardEvent");
@@ -59,7 +59,7 @@ export default class TestHelper {
     const callbackOnce = () => {
       callback && callback();
       target.removeEventListener(behavior, callbackOnce); // Is this posible??
-    }
+    };
 
     target.addEventListener(behavior, callbackOnce);
     target.dispatchEvent(keyboardEvent);
@@ -85,7 +85,7 @@ export default class TestHelper {
         i++;
         loop();
       });
-    }
+    };
 
     loop();
   }
@@ -94,7 +94,7 @@ export default class TestHelper {
     const rect = el.getBoundingClientRect();
 
     const paramByEl = Object.assign({}, param, {
-      pos: [rect.left + param.pos[0], rect.top + param.pos[1]]
+      pos: [rect.left + param.pos[0], rect.top + param.pos[1]],
     });
 
     // console.log(paramByEl);

--- a/test/unit/inputType/WheelInput.spec.js
+++ b/test/unit/inputType/WheelInput.spec.js
@@ -4,11 +4,11 @@ import { WheelInput } from "../../../src/inputType/WheelInput";
 import TestHelper from "./TestHelper";
 
 describe("WheelInput", () => {
-	let el;
-	let input;
-	let inst;
-	let observer;
-	let timer;
+  let el;
+  let input;
+  let inst;
+  let observer;
+  let timer;
 
   describe("instance method", () => {
     beforeEach(() => {
@@ -58,8 +58,8 @@ describe("WheelInput", () => {
         hold: () => {},
         change: () => {},
         options: {
-          deceleration: 0.0001
-        }
+          deceleration: 0.0001,
+        },
       };
     });
     afterEach(() => {
@@ -104,11 +104,11 @@ describe("WheelInput", () => {
       inst = new Axes(
         {
           x: {
-            range: [10, 120]
-          }
+            range: [10, 120],
+          },
         },
         {
-          maximumDuration: 30
+          maximumDuration: 30,
         }
       );
       inst.connect(["x"], input);
@@ -155,16 +155,16 @@ describe("WheelInput", () => {
           input = new WheelInput(el, {
             useNormalized: useNormalized,
             scale: scale,
-            releaseDelay: 50
+            releaseDelay: 50,
           });
           inst = new Axes(
             {
               x: {
-                range: [10, 120]
-              }
+                range: [10, 120],
+              },
             },
             {
-              maximumDuration: 0
+              maximumDuration: 0,
             }
           );
           inst.connect(["x"], input);

--- a/test/unit/utils.spec.js
+++ b/test/unit/utils.spec.js
@@ -3,11 +3,11 @@ import {
   toArray,
   equal,
   getDecimalPlace,
-  roundNumber
+  roundNumber,
 } from "../../src/utils";
 
 describe("Util Test", () => {
-	let el;
+  let el;
 
   beforeEach(() => {
     el = sandbox();
@@ -20,11 +20,11 @@ describe("Util Test", () => {
     const target1 = {
       x: 10,
       y: 20,
-      z: 30
+      z: 30,
     };
     const target2 = {
       x: 10,
-      y: 20
+      y: 20,
     };
 
     // Then
@@ -65,7 +65,7 @@ describe("Util Test", () => {
     const targetVal = 99.123456789;
     const inputValues = [100, 10, 1, 0, 0.1, 0.01, 0.001, 0.0001];
     const expectValues = [
-      100, 100, 99, 0, 99.1, 99.12, 99.123, 99.1235 /* round */
+      100, 100, 99, 0, 99.1, 99.12, 99.123, 99.1235 /* round */,
     ];
     // Ref. Same result : https://codepen.io/GreenSock/pen/mLMYwM
 


### PR DESCRIPTION
## Details
Added inputButton to PanInputOption which used for PanInput and RotatePanInput.
inputButton option contains the types of mouse buttons PanInput and RotatePanInput will recognize.
inputButton option is ["left"] by default, you can configure like adding/changing it to "middle" and "right" .
Since every touch is recognized as a left click as the PointerEvent, every touch is recognized as a left click.
Added example of newly added option to the existing cube demo.

## Example
![movingcube](https://user-images.githubusercontent.com/13797320/164094604-2df45d7f-f295-41ad-bcef-a6e2992e99b7.gif)

```ts
    axes
      .connect("rotateX rotateY", new PanInput(area, { inputButton: ["left"] ))
      .connect("offsetX offsetY", new PanInput(area, { inputButton: ["right"] }));
```

### Things to be discussed
- When naming this name, we used the singular name, just like the inputType option. If the name inputButton isn't appropriate for a list of mouse buttons that accept input, should we switch to the plural?
- Current button types are internally implemented with the same string as the type that receives input from the user, such as "left" and "middle". Instead of comparing these buttons as strings, should I create constants like "LEFT_BUTTON" and manage them?