### PR TITLE
fix: calculate velocity using interval, refactor AnimationManager

### DIFF
--- a/src/Axes.ts
+++ b/src/Axes.ts
@@ -16,13 +16,9 @@ import {
   DIRECTION_ALL,
 } from "./const";
 import { InputType } from "./inputType/InputType";
-import {
-  AnimationManagerType,
-  AxesEvents,
-  ObjectInterface,
-  UpdateAnimationOption,
-} from "./types";
+import { AxesEvents, ObjectInterface, UpdateAnimationOption } from "./types";
 import { EasingManager } from "./animation/EasingManager";
+import { AnimationManager } from "./animation/AnimationManager";
 
 export interface AxesOption {
   easing?: (x: number) => number;
@@ -225,7 +221,7 @@ class Axes extends Component<AxesEvents> {
   public eventManager: EventManager;
   public axisManager: AxisManager;
   public interruptManager: InterruptManager;
-  public animationManager: AnimationManagerType;
+  public animationManager: AnimationManager;
   public inputObserver: InputObserver;
   private _inputs: InputType[] = [];
 

--- a/src/Axes.ts
+++ b/src/Axes.ts
@@ -1,6 +1,5 @@
 import Component from "@egjs/component";
 
-import { AnimationManager } from "./AnimationManager";
 import { EventManager } from "./EventManager";
 import { InterruptManager } from "./InterruptManager";
 import { AxisManager, AxisOption, Axis } from "./AxisManager";
@@ -17,7 +16,13 @@ import {
   DIRECTION_ALL,
 } from "./const";
 import { InputType } from "./inputType/InputType";
-import { AxesEvents, ObjectInterface, UpdateAnimationOption } from "./types";
+import {
+  AnimationManagerTypes,
+  AxesEvents,
+  ObjectInterface,
+  UpdateAnimationOption,
+} from "./types";
+import { EasingManager } from "./animation/EasingManager";
 
 export interface AxesOption {
   easing?: (x: number) => number;
@@ -220,7 +225,7 @@ class Axes extends Component<AxesEvents> {
   public eventManager: EventManager;
   public axisManager: AxisManager;
   public interruptManager: InterruptManager;
-  public animationManager: AnimationManager;
+  public animationManager: AnimationManagerTypes;
   public inputObserver: InputObserver;
   private _inputs: InputType[] = [];
 
@@ -251,7 +256,7 @@ class Axes extends Component<AxesEvents> {
     this.interruptManager = new InterruptManager(this.options);
     this.axisManager = new AxisManager(this.axis);
     this.eventManager = new EventManager(this);
-    this.animationManager = new AnimationManager(this);
+    this.animationManager = new EasingManager(this);
     this.inputObserver = new InputObserver(this);
     this.eventManager.setAnimationManager(this.animationManager);
     if (startPos) {

--- a/src/Axes.ts
+++ b/src/Axes.ts
@@ -17,7 +17,7 @@ import {
 } from "./const";
 import { InputType } from "./inputType/InputType";
 import {
-  AnimationManagerTypes,
+  AnimationManagerType,
   AxesEvents,
   ObjectInterface,
   UpdateAnimationOption,
@@ -225,7 +225,7 @@ class Axes extends Component<AxesEvents> {
   public eventManager: EventManager;
   public axisManager: AxisManager;
   public interruptManager: InterruptManager;
-  public animationManager: AnimationManagerTypes;
+  public animationManager: AnimationManagerType;
   public inputObserver: InputObserver;
   private _inputs: InputType[] = [];
 

--- a/src/EventManager.ts
+++ b/src/EventManager.ts
@@ -5,7 +5,7 @@ import { Axis } from "./AxisManager";
 import Axes from "./Axes";
 import { roundNumbers } from "./utils";
 import {
-  AnimationManagerTypes,
+  AnimationManagerType,
   AnimationParam,
   OnAnimationStart,
   OnRelease,
@@ -17,7 +17,7 @@ export interface ChangeEventOption {
 }
 
 export class EventManager {
-  public animationManager: AnimationManagerTypes;
+  public animationManager: AnimationManagerType;
   public constructor(private _axes: Axes) {}
   /**
    * This event is fired when a user holds an element on the screen of the device.
@@ -331,7 +331,7 @@ export class EventManager {
     );
   }
 
-  public setAnimationManager(animationManager: AnimationManagerTypes) {
+  public setAnimationManager(animationManager: AnimationManagerType) {
     this.animationManager = animationManager;
   }
 

--- a/src/EventManager.ts
+++ b/src/EventManager.ts
@@ -2,10 +2,14 @@ import { ComponentEvent } from "@egjs/component";
 
 import { InputType } from "./inputType/InputType";
 import { Axis } from "./AxisManager";
-import { AnimationManager } from "./AnimationManager";
 import Axes from "./Axes";
 import { roundNumbers } from "./utils";
-import { AnimationParam, OnAnimationStart, OnRelease } from "./types";
+import {
+  AnimationManagerTypes,
+  AnimationParam,
+  OnAnimationStart,
+  OnRelease,
+} from "./types";
 
 export interface ChangeEventOption {
   input: InputType;
@@ -13,7 +17,7 @@ export interface ChangeEventOption {
 }
 
 export class EventManager {
-  public animationManager: AnimationManager;
+  public animationManager: AnimationManagerTypes;
   public constructor(private _axes: Axes) {}
   /**
    * This event is fired when a user holds an element on the screen of the device.
@@ -327,7 +331,7 @@ export class EventManager {
     );
   }
 
-  public setAnimationManager(animationManager: AnimationManager) {
+  public setAnimationManager(animationManager: AnimationManagerTypes) {
     this.animationManager = animationManager;
   }
 

--- a/src/EventManager.ts
+++ b/src/EventManager.ts
@@ -4,12 +4,8 @@ import { InputType } from "./inputType/InputType";
 import { Axis } from "./AxisManager";
 import Axes from "./Axes";
 import { roundNumbers } from "./utils";
-import {
-  AnimationManagerType,
-  AnimationParam,
-  OnAnimationStart,
-  OnRelease,
-} from "./types";
+import { AnimationParam, OnAnimationStart, OnRelease } from "./types";
+import { AnimationManager } from "./animation/AnimationManager";
 
 export interface ChangeEventOption {
   input: InputType;
@@ -17,7 +13,7 @@ export interface ChangeEventOption {
 }
 
 export class EventManager {
-  public animationManager: AnimationManagerType;
+  public animationManager: AnimationManager;
   public constructor(private _axes: Axes) {}
   /**
    * This event is fired when a user holds an element on the screen of the device.
@@ -331,7 +327,7 @@ export class EventManager {
     );
   }
 
-  public setAnimationManager(animationManager: AnimationManagerType) {
+  public setAnimationManager(animationManager: AnimationManager) {
     this.animationManager = animationManager;
   }
 

--- a/src/InputObserver.ts
+++ b/src/InputObserver.ts
@@ -10,14 +10,15 @@ import {
   isEndofBounce,
 } from "./Coordinate";
 import { map, equal } from "./utils";
-import { AnimationManagerType, AnimationParam } from "./types";
+import { AnimationParam } from "./types";
+import { AnimationManager } from "./animation/AnimationManager";
 
 export class InputObserver implements InputTypeObserver {
   public options: AxesOption;
   private _interruptManager: InterruptManager;
   private _eventManager: EventManager;
   private _axisManager: AxisManager;
-  private _animationManager: AnimationManagerType;
+  private _animationManager: AnimationManager;
   private _isOutside = false;
   private _moveDistance: Axis = null;
   private _isStopped = false;
@@ -32,7 +33,7 @@ export class InputObserver implements InputTypeObserver {
     interruptManager: InterruptManager;
     eventManager: EventManager;
     axisManager: AxisManager;
-    animationManager: AnimationManagerType;
+    animationManager: AnimationManager;
   }) {
     this.options = options;
     this._interruptManager = interruptManager;

--- a/src/InputObserver.ts
+++ b/src/InputObserver.ts
@@ -2,7 +2,6 @@ import { InterruptManager } from "./InterruptManager";
 import { InputType, InputTypeObserver, toAxis } from "./inputType/InputType";
 import { EventManager, ChangeEventOption } from "./EventManager";
 import { AxisManager, Axis } from "./AxisManager";
-import { AnimationManager } from "./AnimationManager";
 import { AxesOption } from "./Axes";
 import {
   isOutside,
@@ -11,14 +10,14 @@ import {
   isEndofBounce,
 } from "./Coordinate";
 import { map, equal } from "./utils";
-import { AnimationParam } from "./types";
+import { AnimationManagerTypes, AnimationParam } from "./types";
 
 export class InputObserver implements InputTypeObserver {
   public options: AxesOption;
   private _interruptManager: InterruptManager;
   private _eventManager: EventManager;
   private _axisManager: AxisManager;
-  private _animationManager: AnimationManager;
+  private _animationManager: AnimationManagerTypes;
   private _isOutside = false;
   private _moveDistance: Axis = null;
   private _isStopped = false;
@@ -33,7 +32,7 @@ export class InputObserver implements InputTypeObserver {
     interruptManager: InterruptManager;
     eventManager: EventManager;
     axisManager: AxisManager;
-    animationManager: AnimationManager;
+    animationManager: AnimationManagerTypes;
   }) {
     this.options = options;
     this._interruptManager = interruptManager;

--- a/src/InputObserver.ts
+++ b/src/InputObserver.ts
@@ -10,14 +10,14 @@ import {
   isEndofBounce,
 } from "./Coordinate";
 import { map, equal } from "./utils";
-import { AnimationManagerTypes, AnimationParam } from "./types";
+import { AnimationManagerType, AnimationParam } from "./types";
 
 export class InputObserver implements InputTypeObserver {
   public options: AxesOption;
   private _interruptManager: InterruptManager;
   private _eventManager: EventManager;
   private _axisManager: AxisManager;
-  private _animationManager: AnimationManagerTypes;
+  private _animationManager: AnimationManagerType;
   private _isOutside = false;
   private _moveDistance: Axis = null;
   private _isStopped = false;
@@ -32,7 +32,7 @@ export class InputObserver implements InputTypeObserver {
     interruptManager: InterruptManager;
     eventManager: EventManager;
     axisManager: AxisManager;
-    animationManager: AnimationManagerTypes;
+    animationManager: AnimationManagerType;
   }) {
     this.options = options;
     this._interruptManager = interruptManager;

--- a/src/animation/EasingManager.ts
+++ b/src/animation/EasingManager.ts
@@ -1,0 +1,113 @@
+import { AxesOption } from "../Axes";
+import { Axis } from "../AxisManager";
+import { getCirculatedPos } from "../Coordinate";
+import { AnimationParam, UpdateAnimationOption } from "../types";
+import { map } from "../utils";
+
+import { AnimationManager, AnimationState } from "./AnimationManager";
+
+export class EasingManager extends AnimationManager {
+  protected _useDuration = true;
+  protected _options: AxesOption;
+  private _durationOffset: number;
+  private _initialEasingPer: number;
+  private _prevEasingPer: number;
+
+  public interpolate(displacement: number, threshold: number): number {
+    const initSlope = this._easing(0.00001) / 0.00001;
+    return this._easing(displacement / (threshold * initSlope)) * threshold;
+  }
+
+  public updateAnimation(options: UpdateAnimationOption): void {
+    const animateParam = this._animateParam;
+    if (!animateParam) {
+      return;
+    }
+
+    const diffTime = new Date().getTime() - animateParam.startTime;
+    const pos = options?.destPos || animateParam.destPos;
+    const duration = options?.duration || animateParam.duration;
+    if (options?.restart || duration <= diffTime) {
+      this.setTo(pos, duration - diffTime);
+      return;
+    }
+    if (options?.destPos) {
+      const currentPos = this.axisManager.get();
+      // When destination is changed, new delta should be calculated as remaining percent.
+      // For example, moving x:0, y:0 to x:200, y:200 and it has current easing percent of 92%. coordinate is x:184 and y:184
+      // If destination changes to x:300, y:300. xdelta:200, ydelta:200 changes to xdelta:116, ydelta:116 and use remaining easingPer as 100%, not 8% as previous.
+      // Therefore, original easingPer by time is kept. And divided by (1 - self._initialEasingPer) which means new total easing percent. Like calculating 8% as 100%.
+      this._initialEasingPer = this._prevEasingPer;
+      animateParam.delta = this.axisManager.getDelta(currentPos, pos);
+      animateParam.destPos = pos;
+    }
+    if (options?.duration) {
+      const ratio = (diffTime + this._durationOffset) / animateParam.duration;
+      // Use durationOffset for keeping animation ratio after duration is changed.
+      // newRatio = (diffTime + newDurationOffset) / newDuration = oldRatio
+      // newDurationOffset = oldRatio * newDuration - diffTime
+      this._durationOffset = ratio * duration - diffTime;
+      animateParam.duration = duration;
+    }
+  }
+
+  protected _initState(info: AnimationParam): AnimationState {
+    this._initialEasingPer = 0;
+    this._prevEasingPer = 0;
+    this._durationOffset = 0;
+    return {
+      pos: info.depaPos,
+      easingPer: 0,
+      finished: false,
+    };
+  }
+
+  protected _getNextState(prevState: AnimationState): AnimationState {
+    const animateParam = this._animateParam;
+    const prevPos = prevState.pos;
+    const destPos = animateParam.destPos;
+    const directions = map(prevPos, (value, key) => {
+      return value <= destPos[key] ? 1 : -1;
+    });
+    const diffTime = new Date().getTime() - animateParam.startTime;
+    const ratio = (diffTime + this._durationOffset) / animateParam.duration;
+    const easingPer = this._easing(ratio);
+
+    const toPos: Axis = this.axisManager.map(prevPos, (pos, options, key) => {
+      const nextPos =
+        ratio >= 1
+          ? destPos[key]
+          : pos +
+            (animateParam.delta[key] * (easingPer - this._prevEasingPer)) /
+              (1 - this._initialEasingPer);
+
+      // Subtract distance from distance already moved.
+      // Recalculate the remaining distance.
+      // Fix the bouncing phenomenon by changing the range.
+      const circulatedPos = getCirculatedPos(
+        nextPos,
+        options.range,
+        options.circular as boolean[]
+      );
+      if (nextPos !== circulatedPos) {
+        // circular
+        const rangeOffset =
+          directions[key] * (options.range[1] - options.range[0]);
+
+        destPos[key] -= rangeOffset;
+        prevPos[key] -= rangeOffset;
+      }
+      return circulatedPos;
+    });
+    this._prevEasingPer = easingPer;
+    return {
+      pos: toPos,
+      easingPer,
+      finished: easingPer >= 1,
+    };
+  }
+
+  private _easing(p: number): number {
+    return p > 1 ? 1 : this._options.easing(p);
+  }
+}

--- a/src/const.ts
+++ b/src/const.ts
@@ -11,7 +11,7 @@ export const MOUSE_LEFT = "left";
 export const MOUSE_RIGHT = "right";
 export const MOUSE_MIDDLE = "middle";
 
-export const VELOCITY_INTERVAL = 20;
+export const VELOCITY_INTERVAL = 16;
 
 import getAgent from "@egjs/agent";
 

--- a/src/const.ts
+++ b/src/const.ts
@@ -11,6 +11,8 @@ export const MOUSE_LEFT = "left";
 export const MOUSE_RIGHT = "right";
 export const MOUSE_MIDDLE = "middle";
 
+export const VELOCITY_INTERVAL = 20;
+
 import getAgent from "@egjs/agent";
 
 import { window } from "./browser";

--- a/src/eventInput/EventInput.ts
+++ b/src/eventInput/EventInput.ts
@@ -58,9 +58,8 @@ export abstract class EventInput {
     const offsetX = movement.x;
     const offsetY = movement.y;
     const latestInterval = this._latestInterval;
-    const deltaTime = latestInterval
-      ? event.timeStamp - latestInterval.timestamp
-      : 0;
+    const timeStamp = Date.now();
+    const deltaTime = latestInterval ? timeStamp - latestInterval.timestamp : 0;
     let velocityX = prevEvent ? prevEvent.velocityX : 0;
     let velocityY = prevEvent ? prevEvent.velocityY : 0;
     if (!latestInterval || deltaTime >= VELOCITY_INTERVAL) {
@@ -71,7 +70,7 @@ export abstract class EventInput {
         ];
       }
       this._latestInterval = {
-        timestamp: event.timeStamp,
+        timestamp: timeStamp,
         deltaX,
         deltaY,
       };

--- a/src/inputType/PanInput.ts
+++ b/src/inputType/PanInput.ts
@@ -265,7 +265,7 @@ export class PanInput implements InputType {
         }
       }
     }
-    const offset: number[] = this._getOffset(
+    const offset: number[] = this._applyScale(
       [panEvent.offsetX, panEvent.offsetY],
       [
         useDirection(DIRECTION_HORIZONTAL, this._direction, userDirection),
@@ -296,7 +296,7 @@ export class PanInput implements InputType {
     this._detachWindowEvent(activeEvent);
     clearTimeout(this._rightEdgeTimer);
     const prevEvent = activeEvent.prevEvent;
-    const velocity = this._getOffset(
+    const velocity = this._applyScale(
       [
         Math.abs(prevEvent.velocityX) * (prevEvent.offsetX < 0 ? -1 : 1),
         Math.abs(prevEvent.velocityY) * (prevEvent.offsetY < 0 ? -1 : 1),
@@ -306,8 +306,8 @@ export class PanInput implements InputType {
         useDirection(DIRECTION_VERTICAL, this._direction),
       ]
     );
-    this._observer.release(this, prevEvent, velocity);
     activeEvent.onRelease();
+    this._observer.release(this, prevEvent, velocity);
   }
 
   protected _attachWindowEvent(activeEvent: ActiveEvent) {
@@ -352,7 +352,7 @@ export class PanInput implements InputType {
     this._observer = null;
   }
 
-  private _getOffset(properties: number[], direction: boolean[]): number[] {
+  private _applyScale(properties: number[], direction: boolean[]): number[] {
     const offset: number[] = [0, 0];
     const scale = this.options.scale;
 
@@ -367,8 +367,9 @@ export class PanInput implements InputType {
 
   private _forceRelease = () => {
     const activeEvent = this._activeEvent;
+    const prevEvent = activeEvent.prevEvent;
     this._detachWindowEvent(activeEvent);
-    this._observer.release(this, activeEvent.prevEvent, [0, 0]);
     activeEvent.onRelease();
+    this._observer.release(this, prevEvent, [0, 0]);
   };
 }

--- a/src/inputType/PinchInput.ts
+++ b/src/inputType/PinchInput.ts
@@ -167,8 +167,8 @@ export class PinchInput implements InputType {
       return;
     }
 
-    this._observer.release(this, event, [0], 0);
     activeEvent.onRelease();
+    this._observer.release(this, event, [0], 0);
     this._baseValue = null;
     this._pinchFlag = false;
   }

--- a/src/inputType/RotatePanInput.ts
+++ b/src/inputType/RotatePanInput.ts
@@ -100,10 +100,10 @@ export class RotatePanInput extends PanInput {
     const vy = prevEvent.velocityY;
     const velocity =
       Math.sqrt(vx * vx + vy * vy) * (this._lastDiff > 0 ? -1 : 1); // clockwise
+    activeEvent.onRelease();
     this._observer.release(this, prevEvent, [
       velocity * this._coefficientForDistanceToAngle,
     ]);
-    activeEvent.onRelease();
     this._detachWindowEvent(activeEvent);
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,10 +4,13 @@ import { TouchEventInput } from "./eventInput/TouchEventInput";
 import { PointerEventInput } from "./eventInput/PointerEventInput";
 import { TouchMouseEventInput } from "./eventInput/TouchMouseEventInput";
 import { InputType } from "./inputType/InputType";
+import { EasingManager } from "./animation/EasingManager";
 
 export type ObjectInterface<T = any> = Record<string | number, T>;
 
 export type InputEventType = PointerEvent | MouseEvent | TouchEvent;
+
+export type AnimationManagerTypes = EasingManager;
 
 export type ActiveEvent =
   | MouseEventInput

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,13 +4,10 @@ import { TouchEventInput } from "./eventInput/TouchEventInput";
 import { PointerEventInput } from "./eventInput/PointerEventInput";
 import { TouchMouseEventInput } from "./eventInput/TouchMouseEventInput";
 import { InputType } from "./inputType/InputType";
-import { EasingManager } from "./animation/EasingManager";
 
 export type ObjectInterface<T = any> = Record<string | number, T>;
 
 export type InputEventType = PointerEvent | MouseEvent | TouchEvent;
-
-export type AnimationManagerType = EasingManager;
 
 export type ActiveEvent =
   | MouseEventInput

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,7 +10,7 @@ export type ObjectInterface<T = any> = Record<string | number, T>;
 
 export type InputEventType = PointerEvent | MouseEvent | TouchEvent;
 
-export type AnimationManagerTypes = EasingManager;
+export type AnimationManagerType = EasingManager;
 
 export type ActiveEvent =
   | MouseEventInput

--- a/src/types.ts
+++ b/src/types.ts
@@ -120,3 +120,9 @@ export interface ExtendedEvent {
   velocityY: number;
   preventSystemEvent: boolean;
 }
+
+export interface LatestInterval {
+  timestamp: number;
+  deltaX: number;
+  deltaY: number;
+}

--- a/test/unit/AnimationManager.spec.js
+++ b/test/unit/AnimationManager.spec.js
@@ -1,7 +1,7 @@
-import { AnimationManager } from "../../src/AnimationManager";
 import { AxisManager } from "../../src/AxisManager";
 import { InterruptManager } from "../../src/InterruptManager";
 import { EventManager } from "../../src/EventManager";
+import { EasingManager } from "../../src/animation/EasingManager";
 import Axes from "../../src";
 
 describe("AnimationManager", () => {
@@ -34,7 +34,7 @@ describe("AnimationManager", () => {
         maximumDuration: 2000,
         minimumDuration: 0,
       };
-      inst = new AnimationManager({
+      inst = new EasingManager({
         options: options,
         interruptManager: new InterruptManager(options),
         eventManager: new EventManager(null),
@@ -159,7 +159,7 @@ describe("AnimationManager", () => {
       axes = new Axes(axis, options);
       const axisManager = new AxisManager(axis, options);
       const eventManager = new EventManager(axes);
-      inst = new AnimationManager({
+      inst = new EasingManager({
         options: options,
         interruptManager: new InterruptManager(options),
         eventManager,


### PR DESCRIPTION
## Details
Includes refactorings to improve readability and usability in other components.

### Calculate velocity using interval
In the past, the speed of coordinate change was calculated by comparing the [previous event with deltatime, x, and y.](https://github.com/naver/egjs-axes/blob/master/src/eventInput/EventInput.ts#L54-L58)

However when the deltaTime between events is very short, velocity is calculated abnormally high even for small coordinate changes.

It has been changed to update the speed only when the minimum time difference of VELOCITY_INTERVAL has been reached.

### Refactor AnimationManager
All code related to coordinate calculation through Easing has been separated into EasingManager.

AnimationManager is no longer holding information such as easing rates.

Now coordinates are calculated in other code, and it is convenient to add animations other than easing, such as physics-based animations.