### PR TITLE
fix: use clientXY instead of pageXY for computing delta

### DIFF
--- a/src/eventInput/MouseEventInput.ts
+++ b/src/eventInput/MouseEventInput.ts
@@ -59,8 +59,8 @@ export class MouseEventInput extends EventInput {
   protected _getMovement(event: MouseEvent): { x: number; y: number } {
     const prev = this.prevEvent.srcEvent as MouseEvent;
     return {
-      x: event.pageX - prev.pageX,
-      y: event.pageY - prev.pageY,
+      x: event.clientX - prev.clientX,
+      y: event.clientY - prev.clientY,
     };
   }
 }

--- a/src/eventInput/PointerEventInput.ts
+++ b/src/eventInput/PointerEventInput.ts
@@ -81,8 +81,8 @@ export class PointerEventInput extends EventInput {
       };
     }
     return {
-      x: event.pageX - prev.pageX,
-      y: event.pageY - prev.pageY,
+      x: event.clientX - prev.clientX,
+      y: event.clientY - prev.clientY,
     };
   }
 

--- a/src/eventInput/TouchEventInput.ts
+++ b/src/eventInput/TouchEventInput.ts
@@ -59,8 +59,8 @@ export class TouchEventInput extends EventInput {
       };
     }
     return {
-      x: event.touches[0].pageX - prev.touches[0].pageX,
-      y: event.touches[0].pageY - prev.touches[0].pageY,
+      x: event.touches[0].clientX - prev.touches[0].clientX,
+      y: event.touches[0].clientY - prev.touches[0].clientY,
     };
   }
 }

--- a/src/eventInput/TouchMouseEventInput.ts
+++ b/src/eventInput/TouchMouseEventInput.ts
@@ -89,17 +89,17 @@ export class TouchMouseEventInput extends EventInput {
   } {
     const prev = this.prevEvent.srcEvent;
     const [nextSpot, prevSpot] = [event, prev].map((e) => {
-      if (this._isTouchEvent(event)) {
+      if (this._isTouchEvent(e)) {
         return {
-          id: (e as TouchEvent).touches[0].identifier,
-          x: (e as TouchEvent).touches[0].clientX,
-          y: (e as TouchEvent).touches[0].clientY,
+          id: e.touches[0].identifier,
+          x: e.touches[0].clientX,
+          y: e.touches[0].clientY,
         };
       }
       return {
         id: null,
-        x: (e as MouseEvent).clientX,
-        y: (e as MouseEvent).clientY,
+        x: e.clientX,
+        y: e.clientY,
       };
     });
     return nextSpot.id === prevSpot.id

--- a/src/eventInput/TouchMouseEventInput.ts
+++ b/src/eventInput/TouchMouseEventInput.ts
@@ -92,14 +92,14 @@ export class TouchMouseEventInput extends EventInput {
       if (this._isTouchEvent(event)) {
         return {
           id: (e as TouchEvent).touches[0].identifier,
-          x: (e as TouchEvent).touches[0].pageX,
-          y: (e as TouchEvent).touches[0].pageY,
+          x: (e as TouchEvent).touches[0].clientX,
+          y: (e as TouchEvent).touches[0].clientY,
         };
       }
       return {
         id: null,
-        x: (e as MouseEvent).pageX,
-        y: (e as MouseEvent).pageY,
+        x: (e as MouseEvent).clientX,
+        y: (e as MouseEvent).clientY,
       };
     });
     return nextSpot.id === prevSpot.id


### PR DESCRIPTION
## Details
In the test environment of other components using Axes, there are cases where pageX does not exist in the event.
This fix assumes that pageX and pageY don't always exist and changes to use clientX and clientY when calculating movement and delta.