### PR TITLE
feat: add touchAction option

### DIFF
--- a/demo/src/css/demos/3dcarousel.css
+++ b/demo/src/css/demos/3dcarousel.css
@@ -4,7 +4,6 @@
     padding-top: 10px;
     overflow: hidden;
     position:relative;
-    touch-action: none; user-select: none; -webkit-user-drag: none;
 }
 
 .list_container {
@@ -13,7 +12,6 @@
     height: 210px;
     position: relative;
     perspective: 1000px;
-    touch-action: none; user-select: none; -webkit-user-drag: none;
 }
 
 #carousel {
@@ -21,7 +19,6 @@
     height: 100%;
     position: absolute;
     transform-style: preserve-3d;
-    touch-action: none; user-select: none; -webkit-user-drag: none;
 }
 
 #carousel figure {
@@ -36,7 +33,7 @@
     position: relative;
     background-position: center;
     background-size: cover;
-    background-repeat: no-repeat;  
+    background-repeat: no-repeat;
     width: 100%;
     border-radius: 100%;
     opacity: 0.75;
@@ -53,9 +50,9 @@
     text-align: center;
     padding-top: 10px;
     font-size: 0.9em;
-    overflow: hidden; 
+    overflow: hidden;
     text-overflow: ellipsis;
-    white-space: nowrap;   
+    white-space: nowrap;
 }
 
 #list_cd_artist {
@@ -84,7 +81,7 @@
 }
 
 .bullet {
-    display: inline-block;  
+    display: inline-block;
     margin: 0 15px;
 }
 

--- a/demo/src/css/demos/axes.css
+++ b/demo/src/css/demos/axes.css
@@ -27,12 +27,10 @@
   border-radius: 50px;
   line-height: 100px;
   text-align: center;
-  touch-action: none; user-select: none; -webkit-user-drag: none;
 }
 #uiWrapper .ui img {
   width: 45px;
   height: 75px;
-  touch-action: none; user-select: none; -webkit-user-drag: none;
 }
 
 #grid canvas {

--- a/demo/src/css/demos/car360viewer.css
+++ b/demo/src/css/demos/car360viewer.css
@@ -10,7 +10,6 @@
 }
 .img_cont img {
   height: 150px;
-  touch-action: none; user-select: none; -webkit-user-drag: none;
   transform: translate3d(0,0,0);
 }
 .car_rotate {
@@ -31,7 +30,6 @@
   background:url(../../../static/img/demos/car360/bg_rotate.png) no-repeat;
   background-size:304px 50px;
   -webkit-background-size:304px 50px;
-  touch-action: none; user-select: none; -webkit-user-drag: none;
   color:transparent;
 }
 

--- a/demo/src/css/demos/cardinhand.css
+++ b/demo/src/css/demos/cardinhand.css
@@ -43,4 +43,4 @@ p {
 
 .handcard { display: inline-block; width: 130px; height: 190px; margin-left: -30px; background-color: #8c532e; border-radius: 5px; padding: 25px 15px; box-sizing: border-box; box-shadow: 0 1px 3px rgba(0, 0, 0, 0.35); position: relative; border-radius: 5px; font-size: 0px; }
 
-.handcard img { margin-top: 12px; width: 90px; user-drag: none; user-select: none; -moz-user-select: none; -webkit-user-drag: none; -webkit-user-select: none; -ms-user-select: none; }
+.handcard img { margin-top: 12px; width: 90px; user-drag: none; user-select: none; -moz-user-select: none; }

--- a/demo/src/css/demos/minimap.css
+++ b/demo/src/css/demos/minimap.css
@@ -2,7 +2,6 @@
   overflow:hidden;
   width: 100%;
   height: 400px;
-  touch-action: none; user-select: none; -webkit-user-drag: none;
 
   max-width: 1280px;
   margin: 0px auto;
@@ -13,7 +12,6 @@
   top: 0;
   width: 1280px;
   height: 1677px;
-  touch-action: none; user-select: none; -webkit-user-drag: none;
   background:url("../../../static/img/demos/minimap/sunflower.jpeg");
 }
 

--- a/demo/src/css/demos/subway.css
+++ b/demo/src/css/demos/subway.css
@@ -10,7 +10,6 @@
 }
 
 #subway {
-  transform-origin: 0 0; 
+  transform-origin: 0 0;
   touch-action: none; user-select: none; -webkit-user-drag: none;
 }
-  

--- a/demo/src/pages/demos/nestedaxes.tsx
+++ b/demo/src/pages/demos/nestedaxes.tsx
@@ -4,7 +4,7 @@ import Axes, { PanInput, WheelInput } from "../../../../src/index";
 import "../../css/demos/nestedaxes.css";
 
 const NestedAxes = () => {
-  const range = (v: number) => [...Array(v).keys()];
+  const range = (v: number) => Array.from(Array(v).keys());
   const HEAD_COUNT = 3;
   const HEAD_SLIDES = range(HEAD_COUNT);
   const BODY_COUNT = 7;

--- a/src/const.ts
+++ b/src/const.ts
@@ -41,8 +41,7 @@ export const TRANSFORM = (() => {
   return "";
 })();
 
-export const PREVENT_SCROLL_CSSPROPS = {
-  "touch-action": "none",
+export const PREVENT_DRAG_CSSPROPS = {
   "user-select": "none",
   "-webkit-user-drag": "none",
 };

--- a/src/inputType/PanInput.ts
+++ b/src/inputType/PanInput.ts
@@ -1,4 +1,4 @@
-import { $, setCssProps } from "../utils";
+import { $, isCssPropsFromAxes, setCssProps } from "../utils";
 import {
   IS_IOS_SAFARI,
   IOS_EDGE_THRESHOLD,
@@ -6,7 +6,6 @@ import {
   DIRECTION_VERTICAL,
   DIRECTION_HORIZONTAL,
   DIRECTION_ALL,
-  PREVENT_SCROLL_CSSPROPS,
   MOUSE_LEFT,
 } from "../const";
 import { ActiveEvent, InputEventType } from "../types";
@@ -26,6 +25,7 @@ export interface PanInputOption {
   threshold?: number;
   iOSEdgeSwipeThreshold?: number;
   releaseOnScroll?: boolean;
+  touchAction?: string;
 }
 
 // get user's direction
@@ -57,11 +57,13 @@ export const useDirection = (checkType, direction, userDirection?): boolean => {
 /**
  * @typedef {Object} PanInputOption The option object of the eg.Axes.PanInput module.
  * @ko eg.Axes.PanInput 모듈의 옵션 객체
- * @param {String[]} [inputType=["touch","mouse", "pointer"]] Types of input devices
+ * @param {String[]} [inputType=["touch", "mouse", "pointer"]] Types of input devices
  * - touch: Touch screen
- * - mouse: Mouse <ko>입력 장치 종류
+ * - mouse: Mouse
+ * - pointer: Mouse and touch <ko>입력 장치 종류
  * - touch: 터치 입력 장치
- * - mouse: 마우스</ko>
+ * - mouse: 마우스
+ * - pointer: 마우스 및 터치</ko>
  * @param {String[]} [inputButton=["left"]] List of buttons to allow input
  * - left: Left mouse button and normal touch
  * - middle: Mouse wheel press
@@ -75,6 +77,7 @@ export const useDirection = (checkType, direction, userDirection?): boolean => {
  * @param {Number} [thresholdAngle=45] The threshold value that determines whether user action is horizontal or vertical (0~90) <ko>사용자의 동작이 가로 방향인지 세로 방향인지 판단하는 기준 각도(0~90)</ko>
  * @param {Number} [threshold=0] Minimal pan distance required before recognizing <ko>사용자의 Pan 동작을 인식하기 위해산 최소한의 거리</ko>
  * @param {Number} [iOSEdgeSwipeThreshold=30] Area (px) that can go to the next page when swiping the right edge in iOS safari <ko>iOS Safari에서 오른쪽 엣지를 스와이프 하는 경우 다음 페이지로 넘어갈 수 있는 영역(px)</ko>
+ * @param {String} [touchAction="none"] Value that overrides the element's "touch-action" css property. It is set to "none" to prevent scrolling during touch. <ko>엘리먼트의 "touch-action" CSS 속성을 덮어쓰는 값. 터치 도중 스크롤을 방지하기 위해 "none" 으로 설정되어 있다.</ko>
  **/
 /**
  * A module that passes the amount of change to eg.Axes when the mouse or touchscreen is down and moved. use less than two axes.
@@ -125,6 +128,7 @@ export class PanInput implements InputType {
       threshold: 0,
       iOSEdgeSwipeThreshold: IOS_EDGE_THRESHOLD,
       releaseOnScroll: false,
+      touchAction: "none",
       ...options,
     };
     this._onPanstart = this._onPanstart.bind(this);
@@ -153,15 +157,15 @@ export class PanInput implements InputType {
       this._detachWindowEvent(this._activeEvent);
     }
     this._attachElementEvent(observer);
-    this._originalCssProps = setCssProps(this.element);
+    this._originalCssProps = setCssProps(this.element, this.options);
     return this;
   }
 
   public disconnect() {
     this._detachElementEvent();
     this._detachWindowEvent(this._activeEvent);
-    if (this._originalCssProps !== PREVENT_SCROLL_CSSPROPS) {
-      setCssProps(this.element, this._originalCssProps);
+    if (!isCssPropsFromAxes(this._originalCssProps)) {
+      setCssProps(this.element, this.options, this._originalCssProps);
     }
     this._direction = DIRECTION_NONE;
     return this;

--- a/src/inputType/PanInput.ts
+++ b/src/inputType/PanInput.ts
@@ -1,4 +1,4 @@
-import { $, isCssPropsFromAxes, setCssProps } from "../utils";
+import { $, isCssPropsFromAxes, setCssProps, revertCssProps } from "../utils";
 import {
   IS_IOS_SAFARI,
   IOS_EDGE_THRESHOLD,
@@ -77,7 +77,7 @@ export const useDirection = (checkType, direction, userDirection?): boolean => {
  * @param {Number} [thresholdAngle=45] The threshold value that determines whether user action is horizontal or vertical (0~90) <ko>사용자의 동작이 가로 방향인지 세로 방향인지 판단하는 기준 각도(0~90)</ko>
  * @param {Number} [threshold=0] Minimal pan distance required before recognizing <ko>사용자의 Pan 동작을 인식하기 위해산 최소한의 거리</ko>
  * @param {Number} [iOSEdgeSwipeThreshold=30] Area (px) that can go to the next page when swiping the right edge in iOS safari <ko>iOS Safari에서 오른쪽 엣지를 스와이프 하는 경우 다음 페이지로 넘어갈 수 있는 영역(px)</ko>
- * @param {String} [touchAction="none"] Value that overrides the element's "touch-action" css property. It is set to "none" to prevent scrolling during touch. <ko>엘리먼트의 "touch-action" CSS 속성을 덮어쓰는 값. 터치 도중 스크롤을 방지하기 위해 "none" 으로 설정되어 있다.</ko>
+ * @param {String} [touchAction=null] Value that overrides the element's "touch-action" css property. If set to null, it is automatically set to prevent scrolling in the direction of the connected axis. <ko>엘리먼트의 "touch-action" CSS 속성을 덮어쓰는 값. 만약 null로 설정된 경우, 연결된 축 방향으로의 스크롤을 방지하게끔 자동으로 설정된다.</ko>
  **/
 /**
  * A module that passes the amount of change to eg.Axes when the mouse or touchscreen is down and moved. use less than two axes.
@@ -108,7 +108,7 @@ export class PanInput implements InputType {
   public axes: string[] = [];
   public element: HTMLElement = null;
   protected _observer: InputTypeObserver;
-  protected _direction;
+  protected _direction: number;
   protected _enabled = false;
   protected _activeEvent: ActiveEvent = null;
   private _originalCssProps: { [key: string]: string };
@@ -128,7 +128,7 @@ export class PanInput implements InputType {
       threshold: 0,
       iOSEdgeSwipeThreshold: IOS_EDGE_THRESHOLD,
       releaseOnScroll: false,
-      touchAction: "none",
+      touchAction: null,
       ...options,
     };
     this._onPanstart = this._onPanstart.bind(this);
@@ -157,7 +157,11 @@ export class PanInput implements InputType {
       this._detachWindowEvent(this._activeEvent);
     }
     this._attachElementEvent(observer);
-    this._originalCssProps = setCssProps(this.element, this.options);
+    this._originalCssProps = setCssProps(
+      this.element,
+      this.options,
+      this._direction
+    );
     return this;
   }
 
@@ -165,7 +169,7 @@ export class PanInput implements InputType {
     this._detachElementEvent();
     this._detachWindowEvent(this._activeEvent);
     if (!isCssPropsFromAxes(this._originalCssProps)) {
-      setCssProps(this.element, this.options, this._originalCssProps);
+      revertCssProps(this.element, this._originalCssProps);
     }
     this._direction = DIRECTION_NONE;
     return this;

--- a/src/inputType/PinchInput.ts
+++ b/src/inputType/PinchInput.ts
@@ -1,5 +1,6 @@
-import { $, isCssPropsFromAxes, setCssProps } from "../utils";
+import { $, isCssPropsFromAxes, setCssProps, revertCssProps } from "../utils";
 import { ActiveEvent, InputEventType } from "../types";
+import { DIRECTION_ALL } from "../const";
 
 import {
   toAxis,
@@ -80,14 +81,18 @@ export class PinchInput implements InputType {
       this._detachEvent();
     }
     this._attachEvent(observer);
-    this._originalCssProps = setCssProps(this.element, this.options);
+    this._originalCssProps = setCssProps(
+      this.element,
+      this.options,
+      DIRECTION_ALL
+    );
     return this;
   }
 
   public disconnect() {
     this._detachEvent();
     if (!isCssPropsFromAxes(this._originalCssProps)) {
-      setCssProps(this.element, this.options, this._originalCssProps);
+      revertCssProps(this.element, this._originalCssProps);
     }
     return this;
   }

--- a/src/inputType/PinchInput.ts
+++ b/src/inputType/PinchInput.ts
@@ -1,6 +1,5 @@
-import { $, setCssProps } from "../utils";
+import { $, isCssPropsFromAxes, setCssProps } from "../utils";
 import { ActiveEvent, InputEventType } from "../types";
-import { PREVENT_SCROLL_CSSPROPS } from "../const";
 
 import {
   toAxis,
@@ -13,6 +12,7 @@ export interface PinchInputOption {
   scale?: number;
   threshold?: number;
   inputType?: string[];
+  touchAction?: string;
 }
 
 /**
@@ -20,6 +20,12 @@ export interface PinchInputOption {
  * @ko eg.Axes.PinchInput 모듈의 옵션 객체
  * @param {Number} [scale=1] Coordinate scale that a user can move<ko>사용자의 동작으로 이동하는 좌표의 배율</ko>
  * @param {Number} [threshold=0] Minimal scale before recognizing <ko>사용자의 Pinch 동작을 인식하기 위해산 최소한의 배율</ko>
+ * @param {String[]} [inputType=["touch", "pointer"]] Types of input devices
+ * - touch: Touch screen
+ * - pointer: Mouse and touch <ko>입력 장치 종류
+ * - touch: 터치 입력 장치
+ * - pointer: 마우스 및 터치</ko>
+ * @param {String} [touchAction="none"] Value that overrides the element's "touch-action" css property. It is set to "none" to prevent scrolling during touch. <ko>엘리먼트의 "touch-action" CSS 속성을 덮어쓰는 값. 터치 도중 스크롤을 방지하기 위해 "none" 으로 설정되어 있다.</ko>
  **/
 
 /**
@@ -57,6 +63,7 @@ export class PinchInput implements InputType {
       scale: 1,
       threshold: 0,
       inputType: ["touch", "pointer"],
+      touchAction: "none",
       ...options,
     };
     this._onPinchStart = this._onPinchStart.bind(this);
@@ -73,14 +80,14 @@ export class PinchInput implements InputType {
       this._detachEvent();
     }
     this._attachEvent(observer);
-    this._originalCssProps = setCssProps(this.element);
+    this._originalCssProps = setCssProps(this.element, this.options);
     return this;
   }
 
   public disconnect() {
     this._detachEvent();
-    if (this._originalCssProps !== PREVENT_SCROLL_CSSPROPS) {
-      setCssProps(this.element, this._originalCssProps);
+    if (!isCssPropsFromAxes(this._originalCssProps)) {
+      setCssProps(this.element, this.options, this._originalCssProps);
     }
     return this;
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,6 +3,12 @@ import { PREVENT_DRAG_CSSPROPS } from "./const";
 import { PanInputOption } from "./inputType/PanInput";
 import { PinchInputOption } from "./inputType/PinchInput";
 import { ObjectInterface } from "./types";
+import {
+  DIRECTION_NONE,
+  DIRECTION_VERTICAL,
+  DIRECTION_HORIZONTAL,
+  DIRECTION_ALL,
+} from "./const";
 
 declare let jQuery: any;
 
@@ -245,17 +251,40 @@ export const isCssPropsFromAxes = (originalCssProps: {
 export const setCssProps = (
   element: HTMLElement,
   option: PanInputOption | PinchInputOption,
-  originalCssProps?: { [key: string]: string }
+  direction: number
 ): { [key: string]: string } => {
+  const touchActionMap = {
+    [DIRECTION_NONE]: "auto",
+    [DIRECTION_ALL]: "none",
+    [DIRECTION_VERTICAL]: "pan-x",
+    [DIRECTION_HORIZONTAL]: "pan-y",
+  };
   const oldCssProps = {};
   if (element && element.style) {
-    const newCssProps = originalCssProps
-      ? originalCssProps
-      : { ...PREVENT_DRAG_CSSPROPS, "touch-action": option.touchAction };
+    const touchAction = option.touchAction
+      ? option.touchAction
+      : touchActionMap[direction];
+    const newCssProps = {
+      ...PREVENT_DRAG_CSSPROPS,
+      "touch-action":
+        element.style["touch-action"] === "none" ? "none" : touchAction,
+    };
     Object.keys(newCssProps).forEach((prop) => {
       oldCssProps[prop] = element.style[prop];
       element.style[prop] = newCssProps[prop];
     });
   }
   return oldCssProps;
+};
+
+export const revertCssProps = (
+  element: HTMLElement,
+  originalCssProps: { [key: string]: string }
+): { [key: string]: string } => {
+  if (element && element.style && originalCssProps) {
+    Object.keys(originalCssProps).forEach((prop) => {
+      element.style[prop] = originalCssProps[prop];
+    });
+  }
+  return;
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,7 @@
 import { window } from "./browser";
-import { PREVENT_SCROLL_CSSPROPS } from "./const";
+import { PREVENT_DRAG_CSSPROPS } from "./const";
+import { PanInputOption } from "./inputType/PanInput";
+import { PinchInputOption } from "./inputType/PinchInput";
 import { ObjectInterface } from "./types";
 
 declare let jQuery: any;
@@ -225,15 +227,31 @@ export const getAngle = (posX: number, posY: number) => {
   return (Math.atan2(posY, posX) * 180) / Math.PI;
 };
 
+export const isCssPropsFromAxes = (originalCssProps: {
+  [key: string]: string;
+}) => {
+  let same = true;
+  Object.keys(PREVENT_DRAG_CSSPROPS).forEach((prop) => {
+    if (
+      !originalCssProps ||
+      originalCssProps[prop] !== PREVENT_DRAG_CSSPROPS[prop]
+    ) {
+      same = false;
+    }
+  });
+  return same;
+};
+
 export const setCssProps = (
   element: HTMLElement,
+  option: PanInputOption | PinchInputOption,
   originalCssProps?: { [key: string]: string }
 ): { [key: string]: string } => {
   const oldCssProps = {};
   if (element && element.style) {
     const newCssProps = originalCssProps
       ? originalCssProps
-      : PREVENT_SCROLL_CSSPROPS;
+      : { ...PREVENT_DRAG_CSSPROPS, "touch-action": option.touchAction };
     Object.keys(newCssProps).forEach((prop) => {
       oldCssProps[prop] = element.style[prop];
       element.style[prop] = newCssProps[prop];

--- a/test/unit/inputType/PanInput.spec.js
+++ b/test/unit/inputType/PanInput.spec.js
@@ -85,6 +85,7 @@ describe("PanInput", () => {
       inst = null;
     });
   });
+
   describe("enable/disable", () => {
     beforeEach(() => {
       el = sandbox();
@@ -372,5 +373,21 @@ describe("PanInput", () => {
         );
       });
     });
+
+    ["auto", "none", "manipulation", "pan-x", "pan-y"].forEach(
+      (touchAction) => {
+        it(`should check 'touchAction' option (${touchAction})`, () => {
+          // Given
+          input = new PanInput(el, {
+            touchAction,
+          });
+          inst.connect(["x", "y"], input);
+
+          // Then
+          expect(el.style.touchAction).to.be.equal(touchAction);
+          expect(el.style.userSelect).to.be.equal("none");
+        });
+      }
+    );
   });
 });

--- a/test/unit/inputType/PinchInput.spec.js
+++ b/test/unit/inputType/PinchInput.spec.js
@@ -43,6 +43,7 @@ describe("PinchInput", () => {
       inst = null;
     });
   });
+
   describe("enable/disable", () => {
     beforeEach(() => {
       el = sandbox();
@@ -214,5 +215,45 @@ describe("PinchInput", () => {
         }
       );
     });
+  });
+
+  describe("options test", () => {
+    beforeEach(() => {
+      el = sandbox();
+      input = new PinchInput(el, { inputType: ["touch"] });
+      inst = new Axes({
+        zoom: {
+          range: [0, 100],
+        },
+      });
+      inst.connect(["x"], input);
+    });
+    afterEach(() => {
+      if (inst) {
+        inst.destroy();
+        inst = null;
+      }
+      if (input) {
+        input.destroy();
+        input = null;
+      }
+      cleanup();
+    });
+
+    ["auto", "none", "manipulation", "pan-x", "pan-y"].forEach(
+      (touchAction) => {
+        it(`should check 'touchAction' option (${touchAction})`, () => {
+          // Given
+          input = new PinchInput(el, {
+            touchAction,
+          });
+          inst.connect(["zoom"], input);
+
+          // Then
+          expect(el.style.touchAction).to.be.equal(touchAction);
+          expect(el.style.userSelect).to.be.equal("none");
+        });
+      }
+    );
   });
 });

--- a/test/unit/inputType/PinchInput.spec.js
+++ b/test/unit/inputType/PinchInput.spec.js
@@ -220,13 +220,11 @@ describe("PinchInput", () => {
   describe("options test", () => {
     beforeEach(() => {
       el = sandbox();
-      input = new PinchInput(el, { inputType: ["touch"] });
       inst = new Axes({
         zoom: {
           range: [0, 100],
         },
       });
-      inst.connect(["x"], input);
     });
     afterEach(() => {
       if (inst) {

--- a/test/unit/utils.spec.js
+++ b/test/unit/utils.spec.js
@@ -4,6 +4,7 @@ import {
   equal,
   getDecimalPlace,
   roundNumber,
+  isCssPropsFromAxes,
 } from "../../src/utils";
 
 describe("Util Test", () => {
@@ -15,6 +16,7 @@ describe("Util Test", () => {
   afterEach(() => {
     cleanup();
   });
+
   it("should check 'equal' method", () => {
     // Given
     const target1 = {
@@ -31,6 +33,7 @@ describe("Util Test", () => {
     expect(equal(target1, target2)).to.be.false;
     expect(equal(target2, target1)).to.be.true;
   });
+
   it("should check `$` method", () => {
     // Given
     // When
@@ -48,6 +51,7 @@ describe("Util Test", () => {
     expect($("#sandbox")).to.be.equal(el);
     expect(el).to.be.equal(el);
   });
+
   it("should check `toArray` method", () => {
     // Given
     el.innerHTML = `<div>content1</div>
@@ -58,6 +62,35 @@ describe("Util Test", () => {
 
     // Then
     expect(toArray(el.childNodes)).to.be.eql(useSlice);
+  });
+
+  it("should check 'isCssPropsFromAxes' method", () => {
+    // Given
+    const cssProps1 = {
+      "touch-action": "auto",
+      "user-select": "none",
+      "-webkit-user-drag": "none",
+    };
+    const cssProps2 = {
+      "touch-action": "none",
+      "user-select": "text",
+      "-webkit-user-drag": "auto",
+    };
+    const cssProps3 = {
+      "text-align": "center",
+    };
+    const cssProps4 = {
+      "user-select": "none",
+      "-webkit-user-drag": "none",
+    };
+    const cssProps5 = null;
+
+    // Then
+    expect(isCssPropsFromAxes(cssProps1)).to.be.true;
+    expect(isCssPropsFromAxes(cssProps2)).to.be.false;
+    expect(isCssPropsFromAxes(cssProps3)).to.be.false;
+    expect(isCssPropsFromAxes(cssProps4)).to.be.true;
+    expect(isCssPropsFromAxes(cssProps5)).to.be.false;
   });
 
   it("should roundNumber by round unit", () => {

--- a/test/unit/utils.spec.js
+++ b/test/unit/utils.spec.js
@@ -1,10 +1,17 @@
 import {
+  DIRECTION_ALL,
+  DIRECTION_HORIZONTAL,
+  DIRECTION_NONE,
+  DIRECTION_VERTICAL,
+} from "../../src/const";
+import {
   $,
   toArray,
   equal,
   getDecimalPlace,
   roundNumber,
   isCssPropsFromAxes,
+  setCssProps,
 } from "../../src/utils";
 
 describe("Util Test", () => {
@@ -91,6 +98,36 @@ describe("Util Test", () => {
     expect(isCssPropsFromAxes(cssProps3)).to.be.false;
     expect(isCssPropsFromAxes(cssProps4)).to.be.true;
     expect(isCssPropsFromAxes(cssProps5)).to.be.false;
+  });
+
+  [
+    DIRECTION_NONE,
+    DIRECTION_ALL,
+    DIRECTION_HORIZONTAL,
+    DIRECTION_VERTICAL,
+  ].forEach((direction) => {
+    it(`should check 'setCssProps' method (direction:${direction})`, () => {
+      // Given
+      setCssProps(el, {}, direction);
+
+      // Then
+      const answers = {
+        [DIRECTION_NONE]: "auto",
+        [DIRECTION_ALL]: "none",
+        [DIRECTION_VERTICAL]: "pan-x",
+        [DIRECTION_HORIZONTAL]: "pan-y",
+      };
+      expect(el.style.touchAction).to.be.equal(answers[direction]);
+    });
+  });
+
+  it(`should check 'setCssProps' method (multiple times)`, () => {
+    // Given
+    setCssProps(el, {}, DIRECTION_ALL);
+    setCssProps(el, {}, DIRECTION_VERTICAL);
+
+    // Then
+    expect(el.style.touchAction).to.be.equal("none");
   });
 
   it("should roundNumber by round unit", () => {


### PR DESCRIPTION
## Details
After we removed `hammerManagerOptions` In PanInput and PinchInput, the touch-action css property of the element is set to "none" to prevent scrolling when a touch event occurs. 
However, There are cases which should allow scrolling by touch entirely or only for a specific direction.
For example, [Flicking ](https://github.com/naver/egjs-flicking) that only moves horizontally should allow vertical scrolling via touch event. This provides usable option for [issue 637](https://github.com/naver/egjs-flicking/issues/673) on Flicking.
Also there are `useDrag` option at [conveyer](https://github.com/naver/egjs-conveyer/blob/main/packages/conveyer/src/Conveyer.ts#L427-L429) which set touch-action property to "auto".

Added `touchAction` options to PanInput and PinchInput so that we can set various touch-actions on elements.

