### PR TITLE
fix: set passive to false at window.addEventListener

### DIFF
--- a/src/inputType/PanInput.ts
+++ b/src/inputType/PanInput.ts
@@ -320,10 +320,10 @@ export class PanInput implements InputType {
 
   protected _attachWindowEvent(activeEvent: ActiveEvent) {
     activeEvent?.move.forEach((event) => {
-      window.addEventListener(event, this._onPanmove);
+      window.addEventListener(event, this._onPanmove, { passive: false });
     });
     activeEvent?.end.forEach((event) => {
-      window.addEventListener(event, this._onPanend);
+      window.addEventListener(event, this._onPanend, { passive: false });
     });
   }
 


### PR DESCRIPTION
## Details
Since the behavior of the passive property of `window.addEventListener` is different depending on the browser and version, now we always set it to false.
This fix resolves issue [#677](https://github.com/naver/egjs-flicking/issues/677) from Flicking component that uses Axes.