### PR TITLE
fix: PanInput not working in iOS Safari

### DIFF
--- a/src/inputType/PanInput.ts
+++ b/src/inputType/PanInput.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+
 import { $, isCssPropsFromAxes, setCssProps, revertCssProps } from "../utils";
 import {
   IS_IOS_SAFARI,
@@ -339,15 +341,17 @@ export class PanInput implements InputType {
   private _attachElementEvent(observer: InputTypeObserver) {
     const activeEvent = convertInputType(this.options.inputType);
     if (!activeEvent) {
-      throw new Error(
-        "There is currently no inputType available for current device. There must be at least one available inputType."
-      );
+      return;
     }
     this._observer = observer;
     this._enabled = true;
     this._activeEvent = activeEvent;
-    activeEvent?.start.forEach((event) => {
+    activeEvent.start.forEach((event) => {
       this.element?.addEventListener(event, this._onPanstart);
+    });
+    // adding event listener to element prevents invalid behavior in iOS Safari
+    activeEvent.move.forEach((event) => {
+      this.element?.addEventListener(event, () => {});
     });
   }
 
@@ -355,6 +359,9 @@ export class PanInput implements InputType {
     const activeEvent = this._activeEvent;
     activeEvent?.start.forEach((event) => {
       this.element?.removeEventListener(event, this._onPanstart);
+    });
+    activeEvent?.move.forEach((event) => {
+      this.element?.removeEventListener(event, () => {});
     });
     this._enabled = false;
     this._observer = null;

--- a/src/inputType/PinchInput.ts
+++ b/src/inputType/PinchInput.ts
@@ -188,20 +188,18 @@ export class PinchInput implements InputType {
   private _attachEvent(observer: InputTypeObserver) {
     const activeEvent = convertInputType(this.options.inputType);
     if (!activeEvent) {
-      throw new Error(
-        "There is currently no inputType available for current device. There must be at least one available inputType."
-      );
+      return;
     }
     this._observer = observer;
     this._enabled = true;
     this._activeEvent = activeEvent;
-    activeEvent?.start.forEach((event) => {
+    activeEvent.start.forEach((event) => {
       this.element.addEventListener(event, this._onPinchStart, false);
     });
-    activeEvent?.move.forEach((event) => {
+    activeEvent.move.forEach((event) => {
       this.element.addEventListener(event, this._onPinchMove, false);
     });
-    activeEvent?.end.forEach((event) => {
+    activeEvent.end.forEach((event) => {
       this.element.addEventListener(event, this._onPinchEnd, false);
     });
   }


### PR DESCRIPTION
## Details
Fixed an error that remained in the iOS Safari environment in Axes 3.2.1.
You can check the [demo page](https://malangfox.github.io/egjs-flicking/Demos) that uses next version of Axes with this change applied.

Also Pan, Pinch input has changed so that if there is no inputType that fits the current device, it does not display an error and does not enable input.
Now the user interface designed to work only on the touch screen no longer displays an error when touch input is not possible.
