### PR TITLE
fix: fix threshold option not working

### DIFF
--- a/packages/axes/package.json
+++ b/packages/axes/package.json
@@ -3,7 +3,7 @@
 	"version": "3.8.0",
 	"description": "A module used to change the information of user action entered by various input devices such as touch screen or mouse into the logical virtual coordinates. You can easily create a UI that responds to user actions.",
 	"sideEffects": false,
-	"main": "dist/axes.js",
+	"main": "dist/axes.cjs.js",
 	"module": "dist/axes.esm.js",
 	"types": "declaration/index.d.ts",
 	"scripts": {

--- a/packages/axes/rollup.config.js
+++ b/packages/axes/rollup.config.js
@@ -2,7 +2,7 @@ const buildHelper = require("@egjs/build-helper");
 
 const external = {
   "@egjs/agent": "eg.agent",
-  "@egjs/component": "eg.Component",
+  "@egjs/component": "Component",
 };
 const name = "eg.Axes";
 const fileName = "axes";

--- a/packages/axes/rollup.config.js
+++ b/packages/axes/rollup.config.js
@@ -1,8 +1,8 @@
 const buildHelper = require("@egjs/build-helper");
 
 const external = {
-	"@egjs/agent": "eg.agent",
-	"@egjs/component": "eg.Component",
+  "@egjs/agent": "eg.agent",
+  "@egjs/component": "eg.Component",
 };
 const name = "eg.Axes";
 const fileName = "axes";
@@ -37,6 +37,12 @@ export default buildHelper([
     format: "umd",
     resolve: true,
     uglify: true
+  },
+  {
+    input: "./src/index.cjs.ts",
+    output: `./dist/${fileName}.cjs.js`,
+    format: "cjs",
+    exports: "named",
   },
   {
     input: "./src/index.ts",

--- a/packages/axes/src/index.cjs.ts
+++ b/packages/axes/src/index.cjs.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2015 NAVER Corp.
+ * egjs projects are licensed under the MIT license
+ */
+import Axes, * as modules from "./index";
+
+for (const name in modules) {
+  (Axes as any)[name] = (modules as any)[name];
+}
+
+declare const module: any;
+module.exports = Axes;
+export default Axes;
+export * from "./index";

--- a/packages/axes/test/unit/inputType/PanInput.spec.js
+++ b/packages/axes/test/unit/inputType/PanInput.spec.js
@@ -361,6 +361,64 @@ describe("PanInput", () => {
       });
     });
 
+    describe("threshold", () => {
+      it("should not trigger change event when moving below threshold", (done) => {
+        // Given
+        const change = sinon.spy();
+        input = new PanInput(el, {
+          inputType: ["touch", "mouse"],
+          threshold: 100,
+        });
+        inst.connect(["x", "y"], input);
+        inst.on("change", change);
+
+        // When
+        Simulator.gestures.pan(
+          el,
+          {
+            pos: [0, 0],
+            deltaX: 50,
+            deltaY: 0,
+            duration: 200,
+            easing: "linear",
+          },
+          () => {
+            // Then
+            expect(change.called).to.be.false;
+            done();
+          }
+        );
+      });
+
+      it("should trigger change event when moving above threshold", (done) => {
+        // Given
+        const change = sinon.spy();
+        input = new PanInput(el, {
+          inputType: ["touch", "mouse"],
+          threshold: 100,
+        });
+        inst.connect(["x", "y"], input);
+        inst.on("change", change);
+
+        // When
+        Simulator.gestures.pan(
+          el,
+          {
+            pos: [0, 0],
+            deltaX: 150,
+            deltaY: 0,
+            duration: 200,
+            easing: "linear",
+          },
+          () => {
+            // Then
+            expect(change.called).to.be.true;
+            done();
+          }
+        );
+      });
+    });
+
     describe("inputButton", () => {
       ["left", "middle", "right"].forEach((button) => {
         it("should check only the button set in inputButton is available", (done) => {

--- a/packages/axes/test/unit/inputType/PinchInput.spec.js
+++ b/packages/axes/test/unit/inputType/PinchInput.spec.js
@@ -7,7 +7,7 @@ describe("PinchInput", () => {
   let inst;
   let observer;
 
-  describe("instance method", () => {
+  describe("Methods", () => {
     beforeEach(() => {
       inst = new PinchInput(sandbox());
     });
@@ -18,7 +18,7 @@ describe("PinchInput", () => {
       }
       cleanup();
     });
-    it("should check status after disconnect", () => {
+    it("should check status is completely empty after disconnect", () => {
       // Given
       inst.connect({});
 
@@ -29,7 +29,7 @@ describe("PinchInput", () => {
       expect(observer).to.be.not.exist;
       expect(inst.element).to.be.exist;
     });
-    it("should check status after destroy", () => {
+    it("should check status is completely empty after destroy", () => {
       // Given
       inst.connect({});
 
@@ -222,7 +222,7 @@ describe("PinchInput", () => {
       el = sandbox();
       inst = new Axes({
         zoom: {
-          range: [0, 100],
+          range: [1, 100],
         },
       });
     });
@@ -238,9 +238,61 @@ describe("PinchInput", () => {
       cleanup();
     });
 
+    describe("threshold", () => {
+      it("should not trigger change event when moving below threshold", (done) => {
+        // Given
+        const change = sinon.spy();
+        input = new PinchInput(el, {
+          inputType: ["touch"],
+          threshold: 0.5,
+        });
+        inst.connect("zoom", input);
+        inst.on("change", change);
+
+        // When
+        Simulator.gestures.pinch(
+          el,
+          {
+            duration: 500,
+            scale: 1.3,
+          },
+          () => {
+            // Then
+            expect(change.called).to.be.false;
+            done();
+          }
+        );
+      });
+
+      it("should trigger change event when moving above threshold", (done) => {
+        // Given
+        const change = sinon.spy();
+        input = new PinchInput(el, {
+          inputType: ["touch"],
+          threshold: 0.5,
+        });
+        inst.connect("zoom", input);
+        inst.on("change", change);
+
+        // When
+        Simulator.gestures.pinch(
+          el,
+          {
+            duration: 500,
+            scale: 2,
+          },
+          () => {
+            // Then
+            expect(change.called).to.be.true;
+            done();
+          }
+        );
+      });
+    });
+
     ["auto", "none", "manipulation", "pan-x", "pan-y"].forEach(
       (touchAction) => {
-        it(`should check 'touchAction' option (${touchAction})`, () => {
+        it(`should check whether the style set in touchAction is applied correctly (touchAction: ${touchAction})`, () => {
           // Given
           input = new PinchInput(el, {
             touchAction,


### PR DESCRIPTION
## Details
This fixes an issue that `threshold` option of `PanInput` and `PinchInput` did not work after the removal of the hammerjs dependency.
