### PR TITLE
feat: add inputKey option to PanInput and WheelInput

### DIFF
--- a/packages/axes/package.json
+++ b/packages/axes/package.json
@@ -78,7 +78,7 @@
 		"sinon": "^4.1.4",
 		"string-replace-webpack-plugin": "0.1.3",
 		"sync-exec": "^0.6.2",
-		"ts-loader": "^8.0.6",
+		"ts-loader": "8.0.6",
     "typescript": "^4.6.2",
 		"uglifyjs-webpack-plugin": "^1.1.6",
 		"webpack": "^3.10.0",

--- a/packages/axes/src/const.ts
+++ b/packages/axes/src/const.ts
@@ -15,6 +15,8 @@ export const MOUSE_LEFT = "left";
 export const MOUSE_RIGHT = "right";
 export const MOUSE_MIDDLE = "middle";
 
+export const ANY = "any";
+export const NONE = "none";
 export const SHIFT = "shift";
 export const CTRL = "ctrl";
 export const ALT = "alt";

--- a/packages/axes/src/const.ts
+++ b/packages/axes/src/const.ts
@@ -15,6 +15,11 @@ export const MOUSE_LEFT = "left";
 export const MOUSE_RIGHT = "right";
 export const MOUSE_MIDDLE = "middle";
 
+export const SHIFT = "shift";
+export const CTRL = "ctrl";
+export const ALT = "alt";
+export const META = "meta";
+
 export const VELOCITY_INTERVAL = 16;
 
 export const AXES_METHODS = [

--- a/packages/axes/src/eventInput/EventInput.ts
+++ b/packages/axes/src/eventInput/EventInput.ts
@@ -7,11 +7,13 @@ import { getAngle } from "../utils";
 import { window } from "../browser";
 import {
   ALT,
+  ANY,
   CTRL,
   META,
   MOUSE_LEFT,
   MOUSE_MIDDLE,
   MOUSE_RIGHT,
+  NONE,
   SHIFT,
   VELOCITY_INTERVAL,
 } from "../const";
@@ -27,11 +29,16 @@ export const isValidKey = (
 ): boolean => {
   if (
     !inputKey ||
-    !inputKey.length ||
-    (inputKey.indexOf(SHIFT) > -1 && event.shiftKey === true) ||
-    (inputKey.indexOf(CTRL) > -1 && event.ctrlKey === true) ||
-    (inputKey.indexOf(ALT) > -1 && event.altKey === true) ||
-    (inputKey.indexOf(META) > -1 && event.metaKey === true)
+    inputKey.indexOf(ANY) > -1 ||
+    (inputKey.indexOf(NONE) > -1 &&
+      !event.shiftKey &&
+      !event.ctrlKey &&
+      !event.altKey &&
+      !event.metaKey) ||
+    (inputKey.indexOf(SHIFT) > -1 && event.shiftKey) ||
+    (inputKey.indexOf(CTRL) > -1 && event.ctrlKey) ||
+    (inputKey.indexOf(ALT) > -1 && event.altKey) ||
+    (inputKey.indexOf(META) > -1 && event.metaKey)
   ) {
     return true;
   }

--- a/packages/axes/src/eventInput/EventInput.ts
+++ b/packages/axes/src/eventInput/EventInput.ts
@@ -6,9 +6,13 @@ import { ExtendedEvent, InputEventType, LatestInterval } from "../types";
 import { getAngle } from "../utils";
 import { window } from "../browser";
 import {
+  ALT,
+  CTRL,
+  META,
   MOUSE_LEFT,
   MOUSE_MIDDLE,
   MOUSE_RIGHT,
+  SHIFT,
   VELOCITY_INTERVAL,
 } from "../const";
 
@@ -16,6 +20,23 @@ export const SUPPORT_TOUCH = "ontouchstart" in window;
 export const SUPPORT_POINTER = "PointerEvent" in window;
 export const SUPPORT_MSPOINTER = "MSPointerEvent" in window;
 export const SUPPORT_POINTER_EVENTS = SUPPORT_POINTER || SUPPORT_MSPOINTER;
+
+export const isValidKey = (
+  event: InputEventType | WheelEvent,
+  inputKey?: string[]
+): boolean => {
+  if (
+    !inputKey ||
+    !inputKey.length ||
+    (inputKey.indexOf(SHIFT) > -1 && event.shiftKey === true) ||
+    (inputKey.indexOf(CTRL) > -1 && event.ctrlKey === true) ||
+    (inputKey.indexOf(ALT) > -1 && event.altKey === true) ||
+    (inputKey.indexOf(META) > -1 && event.metaKey === true)
+  ) {
+    return true;
+  }
+  return false;
+};
 
 export abstract class EventInput {
   public prevEvent: ExtendedEvent;
@@ -35,7 +56,11 @@ export abstract class EventInput {
 
   public abstract onRelease(event: InputEventType): void;
 
-  public abstract getTouches(event: InputEventType, inputButton?: string[]): number;
+  public abstract getTouches(
+    event: InputEventType,
+    inputKey?: string[],
+    inputButton?: string[]
+  ): number;
 
   protected abstract _getScale(event: InputEventType): number;
 
@@ -112,11 +137,22 @@ export abstract class EventInput {
   }
 
   protected _isTouchEvent(event: InputEventType): event is TouchEvent {
-    return event.type.indexOf("touch") > -1;
+    return event.type && event.type.indexOf("touch") > -1;
   }
 
   protected _isValidButton(button: string, inputButton: string[]): boolean {
     return inputButton.indexOf(button) > -1;
+  }
+
+  protected _isValidEvent(
+    event: InputEventType,
+    inputKey?: string[],
+    inputButton?: string[]
+  ): boolean {
+    return (
+      (!inputKey || isValidKey(event, inputKey)) &&
+      (!inputButton || this._isValidButton(this._getButton(event), inputButton))
+    );
   }
 
   protected _preventMouseButton(event: InputEventType, button: string): void {

--- a/packages/axes/src/eventInput/MouseEventInput.ts
+++ b/packages/axes/src/eventInput/MouseEventInput.ts
@@ -14,10 +14,11 @@ export class MouseEventInput extends EventInput {
 
   public onEventStart(
     event: InputEventType,
+    inputKey?: string[],
     inputButton?: string[]
   ): ExtendedEvent {
     const button = this._getButton(event);
-    if (inputButton && !this._isValidButton(button, inputButton)) {
+    if (!this._isValidEvent(event, inputKey, inputButton)) {
       return null;
     }
     this._preventMouseButton(event, button);
@@ -26,12 +27,10 @@ export class MouseEventInput extends EventInput {
 
   public onEventMove(
     event: InputEventType,
+    inputKey?: string[],
     inputButton?: string[]
   ): ExtendedEvent {
-    if (
-      inputButton &&
-      !this._isValidButton(this._getButton(event), inputButton)
-    ) {
+    if (!this._isValidEvent(event, inputKey, inputButton)) {
       return null;
     }
     return this.extendEvent(event);

--- a/packages/axes/src/eventInput/PointerEventInput.ts
+++ b/packages/axes/src/eventInput/PointerEventInput.ts
@@ -19,10 +19,11 @@ export class PointerEventInput extends EventInput {
 
   public onEventStart(
     event: InputEventType,
+    inputKey?: string[],
     inputButton?: string[]
   ): ExtendedEvent {
     const button = this._getButton(event);
-    if (inputButton && !this._isValidButton(button, inputButton)) {
+    if (!this._isValidEvent(event, inputKey, inputButton)) {
       return null;
     }
     this._preventMouseButton(event, button);
@@ -32,12 +33,10 @@ export class PointerEventInput extends EventInput {
 
   public onEventMove(
     event: InputEventType,
+    inputKey?: string[],
     inputButton?: string[]
   ): ExtendedEvent {
-    if (
-      inputButton &&
-      !this._isValidButton(this._getButton(event), inputButton)
-    ) {
+    if (!this._isValidEvent(event, inputKey, inputButton)) {
       return null;
     }
     this._updatePointerEvent(event as PointerEvent);

--- a/packages/axes/src/eventInput/TouchEventInput.ts
+++ b/packages/axes/src/eventInput/TouchEventInput.ts
@@ -13,12 +13,24 @@ export class TouchEventInput extends EventInput {
 
   private _baseTouches: TouchList;
 
-  public onEventStart(event: InputEventType): ExtendedEvent {
+  public onEventStart(
+    event: InputEventType,
+    inputKey?: string[]
+  ): ExtendedEvent {
     this._baseTouches = (event as TouchEvent).touches;
+    if (!this._isValidEvent(event, inputKey)) {
+      return null;
+    }
     return this.extendEvent(event);
   }
 
-  public onEventMove(event: InputEventType): ExtendedEvent {
+  public onEventMove(
+    event: InputEventType,
+    inputKey?: string[]
+  ): ExtendedEvent {
+    if (!this._isValidEvent(event, inputKey)) {
+      return null;
+    }
     return this.extendEvent(event);
   }
 

--- a/packages/axes/src/eventInput/TouchMouseEventInput.ts
+++ b/packages/axes/src/eventInput/TouchMouseEventInput.ts
@@ -15,13 +15,14 @@ export class TouchMouseEventInput extends EventInput {
 
   public onEventStart(
     event: InputEventType,
+    inputKey?: string[],
     inputButton?: string[]
   ): ExtendedEvent {
     const button = this._getButton(event);
     if (this._isTouchEvent(event)) {
       this._baseTouches = event.touches;
     }
-    if (inputButton && !this._isValidButton(button, inputButton)) {
+    if (!this._isValidEvent(event, inputKey, inputButton)) {
       return null;
     }
     this._preventMouseButton(event, button);
@@ -30,12 +31,10 @@ export class TouchMouseEventInput extends EventInput {
 
   public onEventMove(
     event: InputEventType,
+    inputKey?: string[],
     inputButton?: string[]
   ): ExtendedEvent {
-    if (
-      inputButton &&
-      !this._isValidButton(this._getButton(event), inputButton)
-    ) {
+    if (!this._isValidEvent(event, inputKey, inputButton)) {
       return null;
     }
     return this.extendEvent(event);

--- a/packages/axes/src/inputType/PanInput.ts
+++ b/packages/axes/src/inputType/PanInput.ts
@@ -31,6 +31,7 @@ import {
 
 export interface PanInputOption {
   inputType?: string[];
+  inputKey?: string[];
   inputButton?: string[];
   scale?: number[];
   thresholdAngle?: number;
@@ -66,6 +67,15 @@ export const getDirectionByAngle = (
  * - touch: 터치 입력 장치
  * - mouse: 마우스
  * - pointer: 마우스 및 터치</ko>
+ * @param {String[]} [inputKey=[]] Allow input only when one of these keys is pressed. If the array is empty, it accepts all keys with case of no key is pressed.
+ * - shift: shift key
+ * - ctrl: ctrl key
+ * - alt: alt key
+ * - meta: meta key <ko>이 중 하나의 키가 눌린 상태에서만 입력이 허용된다. 배열이 비었다면 아무 키도 눌리지 않은 상태와 모든 키가 눌린 상태 모두 허용한다.
+ * - shift: shift 키
+ * - ctrl: ctrl 키
+ * - alt: alt 키
+ * - meta: meta 키 </ko>
  * @param {String[]} [inputButton=["left"]] List of buttons to allow input
  * - left: Left mouse button and normal touch
  * - middle: Mouse wheel press
@@ -127,6 +137,7 @@ export class PanInput implements InputType {
     this.element = $(el);
     this.options = {
       inputType: ["touch", "mouse", "pointer"],
+      inputKey: [],
       inputButton: [MOUSE_LEFT],
       scale: [1, 1],
       thresholdAngle: 45,
@@ -224,10 +235,14 @@ export class PanInput implements InputType {
   }
 
   protected _onPanstart(event: InputEventType) {
-    const inputButton = this.options.inputButton;
+    const { inputKey, inputButton } = this.options;
     const activeEvent = this._activeEvent;
-    const panEvent = activeEvent.onEventStart(event, inputButton);
-    if (!panEvent || !this._enabled || activeEvent.getTouches(event, inputButton) > 1) {
+    const panEvent = activeEvent.onEventStart(event, inputKey, inputButton);
+    if (
+      !panEvent ||
+      !this._enabled ||
+      activeEvent.getTouches(event, inputButton) > 1
+    ) {
       return;
     }
     if (panEvent.srcEvent.cancelable !== false) {
@@ -247,12 +262,13 @@ export class PanInput implements InputType {
     const {
       iOSEdgeSwipeThreshold,
       releaseOnScroll,
+      inputKey,
       inputButton,
       threshold,
       thresholdAngle,
     } = this.options;
     const activeEvent = this._activeEvent;
-    const panEvent = activeEvent.onEventMove(event, inputButton);
+    const panEvent = activeEvent.onEventMove(event, inputKey, inputButton);
     const touches = activeEvent.getTouches(event, inputButton);
 
     if (

--- a/packages/axes/src/inputType/PanInput.ts
+++ b/packages/axes/src/inputType/PanInput.ts
@@ -71,13 +71,13 @@ export const getDirectionByAngle = (
  * @param {String[]} [inputKey=["any"]] List of key combinations to allow input
  * - any: any key
  * - shift: shift key
- * - ctrl: ctrl key
+ * - ctrl: ctrl key and pinch gesture on the trackpad
  * - alt: alt key
  * - meta: meta key
  * - none: none of these keys are pressed <ko>입력을 허용할 키 조합 목록
  * - any: 아무 키
  * - shift: shift 키
- * - ctrl: ctrl 키
+ * - ctrl: ctrl 키 및 트랙패드의 pinch 제스쳐
  * - alt: alt 키
  * - meta: meta 키
  * - none: 아무 키도 눌리지 않은 상태 </ko>

--- a/packages/axes/src/inputType/PanInput.ts
+++ b/packages/axes/src/inputType/PanInput.ts
@@ -19,6 +19,7 @@ import {
   DIRECTION_VERTICAL,
   DIRECTION_HORIZONTAL,
   MOUSE_LEFT,
+  ANY,
 } from "../const";
 import { ActiveEvent, ElementType, InputEventType } from "../types";
 
@@ -67,15 +68,19 @@ export const getDirectionByAngle = (
  * - touch: 터치 입력 장치
  * - mouse: 마우스
  * - pointer: 마우스 및 터치</ko>
- * @param {String[]} [inputKey=[]] Allow input only when one of these keys is pressed. If the array is empty, it accepts all keys with case of no key is pressed.
+ * @param {String[]} [inputKey=["any"]] List of key combinations to allow input
+ * - any: any key
  * - shift: shift key
  * - ctrl: ctrl key
  * - alt: alt key
- * - meta: meta key <ko>이 중 하나의 키가 눌린 상태에서만 입력이 허용된다. 배열이 비었다면 아무 키도 눌리지 않은 상태와 모든 키가 눌린 상태 모두 허용한다.
+ * - meta: meta key
+ * - none: none of these keys are pressed <ko>입력을 허용할 키 조합 목록
+ * - any: 아무 키
  * - shift: shift 키
  * - ctrl: ctrl 키
  * - alt: alt 키
- * - meta: meta 키 </ko>
+ * - meta: meta 키
+ * - none: 아무 키도 눌리지 않은 상태 </ko>
  * @param {String[]} [inputButton=["left"]] List of buttons to allow input
  * - left: Left mouse button and normal touch
  * - middle: Mouse wheel press
@@ -137,7 +142,7 @@ export class PanInput implements InputType {
     this.element = $(el);
     this.options = {
       inputType: ["touch", "mouse", "pointer"],
-      inputKey: [],
+      inputKey: [ANY],
       inputButton: [MOUSE_LEFT],
       scale: [1, 1],
       thresholdAngle: 45,

--- a/packages/axes/src/inputType/RotatePanInput.ts
+++ b/packages/axes/src/inputType/RotatePanInput.ts
@@ -52,8 +52,9 @@ export class RotatePanInput extends PanInput {
   }
 
   protected _onPanstart(event: MouseEvent) {
+    const { inputKey, inputButton } = this.options;
     const activeEvent = this._activeEvent;
-    const panEvent = activeEvent.onEventStart(event, this.options.inputButton);
+    const panEvent = activeEvent.onEventStart(event, inputKey, inputButton);
     if (!panEvent || !this.isEnabled()) {
       return;
     }
@@ -78,8 +79,9 @@ export class RotatePanInput extends PanInput {
   }
 
   protected _onPanmove(event: MouseEvent) {
+    const { inputKey, inputButton } = this.options;
     const activeEvent = this._activeEvent;
-    const panEvent = activeEvent.onEventMove(event, this.options.inputButton);
+    const panEvent = activeEvent.onEventMove(event, inputKey, inputButton);
     if (!panEvent || !this.isEnabled()) {
       return;
     }

--- a/packages/axes/src/inputType/WheelInput.ts
+++ b/packages/axes/src/inputType/WheelInput.ts
@@ -3,7 +3,7 @@
  * egjs projects are licensed under the MIT license
  */
 import { $, getDirection, useDirection } from "../utils";
-import { DIRECTION_HORIZONTAL, DIRECTION_VERTICAL } from "../const";
+import { ANY, DIRECTION_HORIZONTAL, DIRECTION_VERTICAL } from "../const";
 import { ElementType } from "../types";
 
 import { toAxis, InputType, InputTypeObserver } from "./InputType";
@@ -20,15 +20,19 @@ export interface WheelInputOption {
 /**
  * @typedef {Object} WheelInputOption The option object of the eg.Axes.WheelInput module
  * @ko eg.Axes.WheelInput 모듈의 옵션 객체
- * @param {String[]} [inputKey=[]] Allow input only when one of these keys is pressed. If the array is empty, it accepts all keys with case of no key is pressed.
+ * @param {String[]} [inputKey=["any"]] List of key combinations to allow input
+ * - any: any key
  * - shift: shift key
- * - ctrl: ctrl key
+ * - ctrl: ctrl key and pinch gesture on the trackpad
  * - alt: alt key
- * - meta: meta key <ko>이 중 하나의 키가 눌린 상태에서만 입력이 허용된다. 배열이 비었다면 아무 키도 눌리지 않은 상태와 모든 키가 눌린 상태 모두 허용한다.
+ * - meta: meta key
+ * - none: none of these keys are pressed <ko>입력을 허용할 키 조합 목록
+ * - any: 아무 키
  * - shift: shift 키
- * - ctrl: ctrl 키
+ * - ctrl: ctrl 키 및 트랙패드의 pinch 제스쳐
  * - alt: alt 키
- * - meta: meta 키 </ko>
+ * - meta: meta 키
+ * - none: 아무 키도 눌리지 않은 상태 </ko>
  * @param {Number} [scale=1] Coordinate scale that a user can move<ko>사용자의 동작으로 이동하는 좌표의 배율</ko>
  * @param {Number} [releaseDelay=300] Millisecond that trigger release event after last input<ko>마지막 입력 이후 release 이벤트가 트리거되기까지의 밀리초</ko>
  * @param {Boolean} [useNormalized=true] Whether to calculate scroll speed the same in all browsers<ko>모든 브라우저에서 스크롤 속도를 동일하게 처리할지 여부</ko>
@@ -74,13 +78,11 @@ export class WheelInput implements InputType {
   public constructor(el: ElementType, options?: WheelInputOption) {
     this.element = $(el);
     this.options = {
-      ...{
-        inputKey: [],
-        scale: 1,
-        releaseDelay: 300,
-        useNormalized: true,
-        useAnimation: false,
-      },
+      inputKey: [ANY],
+      scale: 1,
+      releaseDelay: 300,
+      useNormalized: true,
+      useAnimation: false,
       ...options,
     };
     this._onWheel = this._onWheel.bind(this);

--- a/packages/axes/src/inputType/WheelInput.ts
+++ b/packages/axes/src/inputType/WheelInput.ts
@@ -203,7 +203,9 @@ export class WheelInput implements InputType {
       throw new Error("Element to connect input does not exist.");
     }
     this._observer = observer;
-    element.addEventListener("wheel", this._onWheel);
+    element.addEventListener("wheel", this._onWheel, {
+      passive: true,
+    });
     this._enabled = true;
   }
 

--- a/packages/axes/src/inputType/WheelInput.ts
+++ b/packages/axes/src/inputType/WheelInput.ts
@@ -7,8 +7,10 @@ import { DIRECTION_HORIZONTAL, DIRECTION_VERTICAL } from "../const";
 import { ElementType } from "../types";
 
 import { toAxis, InputType, InputTypeObserver } from "./InputType";
+import { isValidKey } from "../eventInput/EventInput";
 
 export interface WheelInputOption {
+  inputKey?: string[];
   scale?: number;
   releaseDelay?: number;
   useNormalized?: boolean;
@@ -18,6 +20,15 @@ export interface WheelInputOption {
 /**
  * @typedef {Object} WheelInputOption The option object of the eg.Axes.WheelInput module
  * @ko eg.Axes.WheelInput 모듈의 옵션 객체
+ * @param {String[]} [inputKey=[]] Allow input only when one of these keys is pressed. If the array is empty, it accepts all keys with case of no key is pressed.
+ * - shift: shift key
+ * - ctrl: ctrl key
+ * - alt: alt key
+ * - meta: meta key <ko>이 중 하나의 키가 눌린 상태에서만 입력이 허용된다. 배열이 비었다면 아무 키도 눌리지 않은 상태와 모든 키가 눌린 상태 모두 허용한다.
+ * - shift: shift 키
+ * - ctrl: ctrl 키
+ * - alt: alt 키
+ * - meta: meta 키 </ko>
  * @param {Number} [scale=1] Coordinate scale that a user can move<ko>사용자의 동작으로 이동하는 좌표의 배율</ko>
  * @param {Number} [releaseDelay=300] Millisecond that trigger release event after last input<ko>마지막 입력 이후 release 이벤트가 트리거되기까지의 밀리초</ko>
  * @param {Boolean} [useNormalized=true] Whether to calculate scroll speed the same in all browsers<ko>모든 브라우저에서 스크롤 속도를 동일하게 처리할지 여부</ko>
@@ -64,6 +75,7 @@ export class WheelInput implements InputType {
     this.element = $(el);
     this.options = {
       ...{
+        inputKey: [],
         scale: 1,
         releaseDelay: 300,
         useNormalized: true,
@@ -130,7 +142,7 @@ export class WheelInput implements InputType {
   }
 
   private _onWheel(event: WheelEvent) {
-    if (!this._enabled) {
+    if (!this._enabled || !isValidKey(event, this.options.inputKey)) {
       return;
     }
 

--- a/packages/axes/src/inputType/WheelInput.ts
+++ b/packages/axes/src/inputType/WheelInput.ts
@@ -203,9 +203,7 @@ export class WheelInput implements InputType {
       throw new Error("Element to connect input does not exist.");
     }
     this._observer = observer;
-    element.addEventListener("wheel", this._onWheel, {
-      passive: true,
-    });
+    element.addEventListener("wheel", this._onWheel);
     this._enabled = true;
   }
 

--- a/packages/axes/test/unit/inputType/PanInput.spec.js
+++ b/packages/axes/test/unit/inputType/PanInput.spec.js
@@ -457,7 +457,7 @@ describe("PanInput", () => {
 
     describe("inputButton", () => {
       ["left", "middle", "right"].forEach((button) => {
-        it("should check only the button set in inputButton is available", (done) => {
+        it("should trigger event when the button set in inputButton matches", (done) => {
           // Given
           const hold = sinon.spy();
           const change = sinon.spy();
@@ -491,6 +491,40 @@ describe("PanInput", () => {
           );
         });
       });
+
+			it("should not trigger event when the inputButton is empty", (done) => {
+				// Given
+				const hold = sinon.spy();
+				const change = sinon.spy();
+				const release = sinon.spy();
+				input = new PanInput(el, {
+					inputType: ["touch", "mouse"],
+					inputButton: [],
+				});
+				inst.connect(["x", "y"], input);
+				inst.on("hold", hold);
+				inst.on("change", change);
+				inst.on("release", release);
+
+				// When
+				Simulator.gestures.pan(
+					el,
+					{
+						pos: [0, 0],
+						deltaX: 50,
+						deltaY: 50,
+						duration: 200,
+						easing: "linear",
+					},
+					() => {
+						// Then
+						expect(hold.called).to.be.equals(false);
+						expect(change.called).to.be.equals(false);
+						expect(release.called).to.be.equals(false);
+						done();
+					}
+				);
+			});
     });
 
     describe("touchAction", () => {

--- a/packages/axes/test/unit/inputType/PanInput.spec.js
+++ b/packages/axes/test/unit/inputType/PanInput.spec.js
@@ -419,6 +419,42 @@ describe("PanInput", () => {
       });
     });
 
+    describe("inputKey", () => {
+      it("should not trigger events when the key set in inputKey is not pressed", (done) => {
+        // Given
+        const hold = sinon.spy();
+        const change = sinon.spy();
+        const release = sinon.spy();
+        input = new PanInput(el, {
+          inputType: ["touch", "mouse"],
+          inputKey: ["shift"],
+        });
+        inst.connect(["x", "y"], input);
+        inst.on("hold", hold);
+        inst.on("change", change);
+        inst.on("release", release);
+
+        // When
+        Simulator.gestures.pan(
+          el,
+          {
+            pos: [0, 0],
+            deltaX: 50,
+            deltaY: 50,
+            duration: 200,
+            easing: "linear",
+          },
+          () => {
+            // Then
+            expect(hold.called).to.be.equals(false);
+            expect(change.called).to.be.equals(false);
+            expect(release.called).to.be.equals(false);
+            done();
+          }
+        );
+      });
+    });
+
     describe("inputButton", () => {
       ["left", "middle", "right"].forEach((button) => {
         it("should check only the button set in inputButton is available", (done) => {

--- a/packages/axes/test/unit/inputType/PanInput.spec.js
+++ b/packages/axes/test/unit/inputType/PanInput.spec.js
@@ -492,39 +492,39 @@ describe("PanInput", () => {
         });
       });
 
-			it("should not trigger event when the inputButton is empty", (done) => {
-				// Given
-				const hold = sinon.spy();
-				const change = sinon.spy();
-				const release = sinon.spy();
-				input = new PanInput(el, {
-					inputType: ["touch", "mouse"],
-					inputButton: [],
-				});
-				inst.connect(["x", "y"], input);
-				inst.on("hold", hold);
-				inst.on("change", change);
-				inst.on("release", release);
+      it("should not trigger event when the inputButton is empty", (done) => {
+        // Given
+        const hold = sinon.spy();
+        const change = sinon.spy();
+        const release = sinon.spy();
+        input = new PanInput(el, {
+          inputType: ["touch", "mouse"],
+          inputButton: [],
+        });
+        inst.connect(["x", "y"], input);
+        inst.on("hold", hold);
+        inst.on("change", change);
+        inst.on("release", release);
 
-				// When
-				Simulator.gestures.pan(
-					el,
-					{
-						pos: [0, 0],
-						deltaX: 50,
-						deltaY: 50,
-						duration: 200,
-						easing: "linear",
-					},
-					() => {
-						// Then
-						expect(hold.called).to.be.equals(false);
-						expect(change.called).to.be.equals(false);
-						expect(release.called).to.be.equals(false);
-						done();
-					}
-				);
-			});
+        // When
+        Simulator.gestures.pan(
+          el,
+          {
+            pos: [0, 0],
+            deltaX: 50,
+            deltaY: 50,
+            duration: 200,
+            easing: "linear",
+          },
+          () => {
+            // Then
+            expect(hold.called).to.be.equals(false);
+            expect(change.called).to.be.equals(false);
+            expect(release.called).to.be.equals(false);
+            done();
+          }
+        );
+      });
     });
 
     describe("touchAction", () => {

--- a/packages/axes/test/unit/inputType/TestHelper.js
+++ b/packages/axes/test/unit/inputType/TestHelper.js
@@ -1,11 +1,9 @@
 export default class TestHelper {
-  static dispatchWheel(target, direction, value, callback) {
+  static dispatchWheel(target, params, callback) {
     if (target instanceof Element === false) {
       return;
     }
 
-    const params =
-      direction === "horizontal" ? { deltaX: value } : { deltaY: value };
     let wheelEvent;
 
     try {

--- a/packages/axes/test/unit/inputType/WheelInput.spec.js
+++ b/packages/axes/test/unit/inputType/WheelInput.spec.js
@@ -159,7 +159,7 @@ describe("WheelInput", () => {
       const deltaY = 300;
       // When
       // 1. Scroll
-      TestHelper.dispatchWheel(el, "vertical", deltaY, () => {
+      TestHelper.dispatchWheel(el, { deltaY }, () => {
         // 2. detach & destroy wheel input
         inst.disconnect(input);
         input.destroy();
@@ -227,7 +227,11 @@ describe("WheelInput", () => {
               inst.on("release", (e) => {
                 done();
               });
-              TestHelper.dispatchWheel(el, direction, d, () => {});
+              TestHelper.dispatchWheel(
+                el,
+                direction === "vertical" ? { deltaY: d } : { deltaX: d },
+                () => {}
+              );
             });
           });
         });
@@ -242,7 +246,7 @@ describe("WheelInput", () => {
           inst.disconnect();
 
           // When
-          TestHelper.dispatchWheel(el, "vertical", deltaY, () => {
+          TestHelper.dispatchWheel(el, { deltaY }, () => {
             // Then
             expect(changeTriggered).to.be.false;
             done();
@@ -259,7 +263,7 @@ describe("WheelInput", () => {
           });
 
           // When
-          TestHelper.dispatchWheel(el, "vertical", deltaY, () => {
+          TestHelper.dispatchWheel(el, { deltaY }, () => {
             // Then
             expect(changeTriggered).to.be.false;
             done();
@@ -283,9 +287,9 @@ describe("WheelInput", () => {
             });
 
           // When
-          TestHelper.dispatchWheel(el, "vertical", deltaY, () => {
+          TestHelper.dispatchWheel(el, { deltaY }, () => {
             setTimeout(() => {
-              TestHelper.dispatchWheel(el, "vertical", deltaY, () => {
+              TestHelper.dispatchWheel(el, { deltaY }, () => {
                 setTimeout(() => {
                   // Then
                   eventLog.forEach((log, index) => {
@@ -327,6 +331,37 @@ describe("WheelInput", () => {
       }
       cleanup();
     });
+
+    describe("inputKey", () => {
+      it("should trigger events when the key set in inputKey is pressed", (done) => {
+        // Given
+        const deltaY = 1;
+        input = new WheelInput(el, { inputKey: ["shift"], scale: -10 });
+        inst.connect(["x"], input);
+
+        // When
+        TestHelper.dispatchWheel(el, { deltaY, shiftKey: true }, () => {
+          // Then
+          expect(inst.axisManager.get().x).to.be.equal(10);
+					done();
+        });
+      });
+
+      it("should not trigger events when the key set in inputKey is not pressed", (done) => {
+        // Given
+        const deltaY = 1;
+        input = new WheelInput(el, { inputKey: ["alt"], scale: -10 });
+        inst.connect(["x"], input);
+
+        // When
+        TestHelper.dispatchWheel(el, { deltaY }, () => {
+          // Then
+          expect(inst.axisManager.get().x).to.be.equal(0);
+					done();
+        });
+      });
+    });
+
     describe("useAnimation", () => {
       let animationStartHandler;
       let animationEndHandler;
@@ -346,7 +381,7 @@ describe("WheelInput", () => {
         inst.connect(["x"], input);
 
         // When
-        TestHelper.dispatchWheel(el, "vertical", deltaY, () => {
+        TestHelper.dispatchWheel(el, { deltaY }, () => {
           // Then
           expect(inst.axisManager.get().x).to.be.not.equal(10);
           setTimeout(() => {
@@ -365,7 +400,7 @@ describe("WheelInput", () => {
         inst.connect(["x"], input);
 
         // When
-        TestHelper.dispatchWheel(el, "vertical", deltaY, () => {
+        TestHelper.dispatchWheel(el, { deltaY }, () => {
           // Then
           expect(inst.axisManager.get().x).to.be.equal(10);
           setTimeout(() => {

--- a/packages/demo/src/css/demos/logo.css
+++ b/packages/demo/src/css/demos/logo.css
@@ -1,4 +1,4 @@
-#container {
+#logo-container {
   display: flex;
   justify-content: center;
   position: relative;

--- a/packages/demo/src/pages/Options.mdx
+++ b/packages/demo/src/pages/Options.mdx
@@ -370,18 +370,20 @@ Types of input devices.
 </div>
 
 ### inputKey
-Allow input only when one of these keys is pressed. If the array is empty, it accepts all keys with case of no key is pressed.
- - shift: shift key
- - ctrl: ctrl key
- - alt: alt key
- - meta: meta key
+List of key combinations to allow input
+- any: any key
+- shift: shift key
+- ctrl: ctrl key and pinch gesture on the trackpad
+- alt: alt key
+- meta: meta key
+- none: none of these keys are pressed
 
 <div className="columns">
   <div className="column is-6">
   <div>
 
   ```js
-  inputKey: []
+  inputKey: ["any"]
   ```
   </div>
     <AxesBoard panInputOptions={{ inputKey: [] }}/>
@@ -576,6 +578,37 @@ Hint: These examples only have a x-axis. Try using the input direction similar t
 </div>
 
 ## WheelInput Options
+
+### inputKey
+List of key combinations to allow input
+- any: any key
+- shift: shift key
+- ctrl: ctrl key and pinch gesture on the trackpad
+- alt: alt key
+- meta: meta key
+- none: none of these keys are pressed
+
+<div className="columns">
+  <div className="column is-6">
+  <div>
+
+  ```js
+  inputKey: ["any"]
+  ```
+  </div>
+    <AxesBoard wheelInputOptions={{ inputKey: ["any"] }}/>
+  </div>
+  <div className="column is-6">
+  <div>
+
+  ```js
+  inputKey: ["ctrl"]
+  ```
+  </div>
+    <AxesBoard wheelInputOptions={{ inputKey: ["ctrl"] }}/>
+  </div>
+</div>
+
 ### scale
 Coordinate scale that a user can move.
 

--- a/packages/demo/src/pages/Options.mdx
+++ b/packages/demo/src/pages/Options.mdx
@@ -313,7 +313,7 @@ Whether the event propagates to other instances when the coordinates reach the e
   nested: true
   ```
   </div>
-    <AxesBoard options={{ nested: true }} setNested={true}/>
+    <AxesBoard options={{ nested: true }} demoType={"nested"}/>
   </div>
 </div>
 
@@ -366,6 +366,34 @@ Types of input devices.
   ```
   </div>
     <AxesBoard panInputOptions={{ inputType: ["touch"] }}/>
+  </div>
+</div>
+
+### inputKey
+Allow input only when one of these keys is pressed. If the array is empty, it accepts all keys with case of no key is pressed.
+ - shift: shift key
+ - ctrl: ctrl key
+ - alt: alt key
+ - meta: meta key
+
+<div className="columns">
+  <div className="column is-6">
+  <div>
+
+  ```js
+  inputKey: []
+  ```
+  </div>
+    <AxesBoard panInputOptions={{ inputKey: [] }}/>
+  </div>
+  <div className="column is-6">
+  <div>
+
+  ```js
+  inputKey: ["ctrl"]
+  ```
+  </div>
+    <AxesBoard panInputOptions={{ inputKey: ["ctrl"] }}/>
   </div>
 </div>
 
@@ -440,10 +468,34 @@ Minimal pan distance required before recognizing.
   <div>
 
   ```js
-  threshold: 5
+  threshold: 30
   ```
   </div>
-    <AxesBoard panInputOptions={{ threshold: 5 }}/>
+    <AxesBoard panInputOptions={{ threshold: 30 }}/>
+  </div>
+</div>
+
+### preventClickOnDrag
+Whether to cancel the click event when the user finishes dragging more than 1 pixel.
+
+<div className="columns">
+  <div className="column is-6">
+  <div>
+
+  ```js
+  preventClickOnDrag: false
+  ```
+  </div>
+    <AxesBoard panInputOptions={{ preventClickOnDrag: false }} demoType={"preventClickOnDrag"}/>
+  </div>
+  <div className="column is-6">
+  <div>
+
+  ```js
+  preventClickOnDrag: true
+  ```
+  </div>
+    <AxesBoard panInputOptions={{ preventClickOnDrag: true }} demoType={"preventClickOnDrag"}/>
   </div>
 </div>
 

--- a/packages/demo/src/pages/demos/axesboard.tsx
+++ b/packages/demo/src/pages/demos/axesboard.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef } from "react";
 import { useAxes, PanInput, MoveKeyInput, PinchInput, WheelInput } from "@egjs/react-axes";
 import "../../css/demos/axesboard.css";
 
-export default function AxesBoard({ axis, setNested, options, panInputOptions, pinchInputOptions, moveKeyInputOptions, wheelInputOptions }) {
+export default function AxesBoard({ axis, demoType, options, panInputOptions, pinchInputOptions, moveKeyInputOptions, wheelInputOptions }) {
   const board = useRef<HTMLDivElement>(null);
   const innerBoard = useRef<HTMLDivElement>(null);
   const target = useRef<HTMLDivElement>(null);
@@ -27,7 +27,7 @@ export default function AxesBoard({ axis, setNested, options, panInputOptions, p
     {
       round: 0.1,
       ...options,
-      nested: !!setNested,
+      nested: !!(demoType === "nested"),
     },
   );
 
@@ -46,6 +46,12 @@ export default function AxesBoard({ axis, setNested, options, panInputOptions, p
       round: 0.1,
     },
   );
+
+  const onClick = () => {
+    if (demoType === "preventClickOnDrag") {
+      window.open("https://www.naver.com/");
+    }
+  };
 
   useEffect(() => {
     const isNested = options?.nested;
@@ -121,6 +127,7 @@ export default function AxesBoard({ axis, setNested, options, panInputOptions, p
       <div className="nestedboard" ref={innerBoard} style={{ transform: `translate3d(${nested.innerX}px, ${nested.innerY}px, 0)`}}>
         <div className="target" ref={target} style={{ transform: `translate3d(${x}px, ${y}px, 0) scale(${zoom / 100})`}}>
           <img
+            draggable="false"
             className="egjsicon"
             src={
               require(`@site/static/img/favicon.ico`)
@@ -133,8 +140,9 @@ export default function AxesBoard({ axis, setNested, options, panInputOptions, p
     </div>) : (
     <div className="board" ref={board}>
       <div className="info">x: {x} y: {y}</div>
-      <div className="target" ref={target} style={{ transform: `translate3d(${x}px, ${y}px, 0) scale(${zoom / 100})` }}>
+      <div className="target" ref={target} style={{ transform: `translate3d(${x}px, ${y}px, 0) scale(${zoom / 100})` }} onClick={() => { onClick(); }}>
         <img
+          draggable="false"
           className="egjsicon"
           src={
             require(`@site/static/img/favicon.ico`)

--- a/packages/demo/src/pages/demos/logo.tsx
+++ b/packages/demo/src/pages/demos/logo.tsx
@@ -75,7 +75,7 @@ export default function Logo() {
   });
 
   useEffect(() => {
-    const container = document.getElementById("container");
+    const container = document.getElementById("logo-container");
     const containerWidth = container.getBoundingClientRect().width;
     setOffsetX1(60 + containerWidth / 2);
     setOffsetX2(containerWidth / 2);
@@ -96,7 +96,7 @@ export default function Logo() {
 
   return (
     <div>
-      <div id="container" style={{ opacity: `${offsetX1 ? "1" : "0"}` }}>
+      <div id="logo-container" style={{ opacity: `${offsetX1 ? "1" : "0"}` }}>
         <div id="square" className="item" style={{ transform: `translateX(${square.x}px) translateY(${square.y}px)` }}><SquareIcon /></div>
         <div id="triangle" className="item light" style={{ transform: `translateX(${triangle.x}px) translateY(${triangle.y}px)` }}><TriangleIcon /></div>
         <div id="circle" className="item" style={{ transform: `translateX(${circle.x}px) translateY(${circle.y}px)` }}><CircleIcon /></div>


### PR DESCRIPTION
## Details
This adds `InputKey` option that accepts input only when certain keys are pressed for the `PanInput` and `WheelInput`.
Considering that some devices don't have an Alt key and use a meta key instead, I implemented `InputKey` option to be an array of keys that allows input when any one of these is pressed.

