### PR TITLE
fix: fix preventClickOnDrag option not working when changed

### DIFF
--- a/packages/axes/src/inputType/PanInput.ts
+++ b/packages/axes/src/inputType/PanInput.ts
@@ -266,6 +266,7 @@ export class PanInput implements InputType {
   protected _onPanmove(event: InputEventType) {
     const {
       iOSEdgeSwipeThreshold,
+      preventClickOnDrag,
       releaseOnScroll,
       inputKey,
       inputButton,
@@ -339,7 +340,7 @@ export class PanInput implements InputType {
     }
     panEvent.preventSystemEvent = prevent;
     if (prevent && (this._isOverThreshold || distance >= threshold)) {
-      this._dragged = true;
+      this._dragged = preventClickOnDrag;
       this._isOverThreshold = true;
       this._observer.change(this, panEvent, toAxis(this.axes, offset));
     }
@@ -415,9 +416,7 @@ export class PanInput implements InputType {
     this._observer = observer;
     this._enabled = true;
     this._activeEvent = activeEvent;
-    if (this.options.preventClickOnDrag) {
-      element.addEventListener("click", this._preventClickWhenDragged, true);
-    }
+    element.addEventListener("click", this._preventClickWhenDragged, true);
     activeEvent.start.forEach((event) => {
       element.addEventListener(event, this._onPanstart);
     });
@@ -431,9 +430,7 @@ export class PanInput implements InputType {
     const activeEvent = this._activeEvent;
     const element = this.element;
     if (element) {
-      if (this.options.preventClickOnDrag) {
-        element.removeEventListener("click", this._preventClickWhenDragged, true);
-      }
+      element.removeEventListener("click", this._preventClickWhenDragged, true);
       activeEvent?.start.forEach((event) => {
         element.removeEventListener(event, this._onPanstart);
       });

--- a/packages/axes/test/unit/inputType/PanInput.spec.js
+++ b/packages/axes/test/unit/inputType/PanInput.spec.js
@@ -359,6 +359,36 @@ describe("PanInput", () => {
           }
         );
       });
+
+      it("should apply changes in preventClickOnDrag option after connected", (done) => {
+        // Given
+        const click = sinon.spy();
+        el.addEventListener("click", click);
+        input = new PanInput(el, {
+          inputType: ["touch", "mouse"],
+          preventClickOnDrag: true,
+        });
+        inst.connect(["x", "y"], input);
+        input.options.preventClickOnDrag = false;
+
+        // When
+        Simulator.gestures.pan(
+          el,
+          {
+            pos: [0, 0],
+            deltaX: 50,
+            deltaY: 50,
+            duration: 200,
+            easing: "linear",
+          },
+          () => {
+            el.click();
+            // Then
+            expect(click.called).to.be.true;
+            done();
+          }
+        );
+      });
     });
 
     describe("threshold", () => {


### PR DESCRIPTION
## Details
This fixes an error that `preventClickOnDrag` does not work properly when `panInput.options.preventClickOnDrag` changes to something different from the initial value.