### PR TITLE
fix: fix bounce occuring when circular is set in only one direction

### DIFF
--- a/packages/axes/src/InputObserver.ts
+++ b/packages/axes/src/InputObserver.ts
@@ -234,7 +234,7 @@ export class InputObserver implements InputTypeObserver {
         const out = opt.bounce;
         const circular = opt.circular;
 
-        if (circular && (circular[0] || circular[1])) {
+        if ((circular[0] && v < min) || (circular[1] && v > max)) {
           return v;
         } else if (v < min) {
           // left

--- a/packages/axes/test/unit/InputObserver.spec.js
+++ b/packages/axes/test/unit/InputObserver.spec.js
@@ -23,8 +23,8 @@ describe("InputObserver", () => {
         },
         z: {
           range: [-100, 200],
-          bounce: [50, 0],
-          circular: true,
+          bounce: [0, 0],
+          circular: [false, true],
         },
       };
       options = {
@@ -226,6 +226,30 @@ describe("InputObserver", () => {
       // 40 * 25
       for (let i = 0; i < 25; ++i) {
         inst.change(inputType, {}, { z: 40 });
+      }
+      inst.release(inputType, {}, [0, 0, 0]);
+    });
+    it("should check bounce not occur to direction where the circular is false", (done) => {
+      // Given
+      // start pos
+      let z = 0;
+      axes.setTo({ z: 0 }, 0);
+      axes.on("change", ({ delta }) => {
+        z += delta.z;
+        expect(z).to.be.not.lt(-100);
+      });
+      axes.on("finish", () => {
+        done();
+      });
+
+      // When
+      const inputType = {
+        axes: ["z"],
+      };
+      inst.hold(inputType);
+      // 40 * 25
+      for (let i = 0; i < 25; ++i) {
+        inst.change(inputType, {}, { z: -40 });
       }
       inst.release(inputType, {}, [0, 0, 0]);
     });


### PR DESCRIPTION
## Details
This fixes an error that abnormal bounce area appearing when the `circular` option was set to only one direction.
You can check this error with [demo](https://codepen.io/malangfox/pen/oNdmJKR) by moving the element to right side, which `circular` is `false`.
