### PR TITLE
fix: add userSelect css props for non chrome browsers

### DIFF
--- a/packages/axes/src/const.ts
+++ b/packages/axes/src/const.ts
@@ -75,6 +75,8 @@ export const TRANSFORM = (() => {
 })();
 
 export const PREVENT_DRAG_CSSPROPS = {
+  "-webkit-user-select": "none", /* Safari */
+  "-ms-user-select": "none", /* IE 10 and IE 11 */
   "user-select": "none",
   "-webkit-user-drag": "none",
 };

--- a/packages/axes/src/const.ts
+++ b/packages/axes/src/const.ts
@@ -77,6 +77,7 @@ export const TRANSFORM = (() => {
 export const PREVENT_DRAG_CSSPROPS = {
   "-webkit-user-select": "none", /* Safari */
   "-ms-user-select": "none", /* IE 10 and IE 11 */
+  "-moz-user-select": "none", /* Firefox 2-68 */
   "user-select": "none",
   "-webkit-user-drag": "none",
 };

--- a/packages/axes/test/unit/utils.spec.js
+++ b/packages/axes/test/unit/utils.spec.js
@@ -84,6 +84,7 @@ describe("Util Functions", () => {
       const cssProps1 = {
         "-webkit-user-select": "none",
         "-ms-user-select": "none",
+        "-moz-user-select": "none",
         "touch-action": "auto",
         "user-select": "none",
         "-webkit-user-drag": "none",
@@ -91,6 +92,7 @@ describe("Util Functions", () => {
       const cssProps2 = {
         "-webkit-user-select": "none",
         "-ms-user-select": "none",
+        "-moz-user-select": "none",
         "touch-action": "none",
         "user-select": "text",
         "-webkit-user-drag": "auto",
@@ -98,11 +100,13 @@ describe("Util Functions", () => {
       const cssProps3 = {
         "-webkit-user-select": "none",
         "-ms-user-select": "none",
+        "-moz-user-select": "none",
         "text-align": "center",
       };
       const cssProps4 = {
         "-webkit-user-select": "none",
         "-ms-user-select": "none",
+        "-moz-user-select": "none",
         "user-select": "none",
         "-webkit-user-drag": "none",
       };

--- a/packages/axes/test/unit/utils.spec.js
+++ b/packages/axes/test/unit/utils.spec.js
@@ -82,19 +82,27 @@ describe("Util Functions", () => {
     it("should check element's css properties includes properties from PREVENT_DRAG_CSSPROPS", () => {
       // Given
       const cssProps1 = {
+        "-webkit-user-select": "none",
+        "-ms-user-select": "none",
         "touch-action": "auto",
         "user-select": "none",
         "-webkit-user-drag": "none",
       };
       const cssProps2 = {
+        "-webkit-user-select": "none",
+        "-ms-user-select": "none",
         "touch-action": "none",
         "user-select": "text",
         "-webkit-user-drag": "auto",
       };
       const cssProps3 = {
+        "-webkit-user-select": "none",
+        "-ms-user-select": "none",
         "text-align": "center",
       };
       const cssProps4 = {
+        "-webkit-user-select": "none",
+        "-ms-user-select": "none",
         "user-select": "none",
         "-webkit-user-drag": "none",
       };
@@ -110,6 +118,18 @@ describe("Util Functions", () => {
   });
 
   describe("setCssProps", () => {
+    it(`should check css properties are correctly set to element`, () => {
+      // Given
+      setCssProps(el, {}, DIRECTION_ALL);
+
+      // Then
+      expect(el.style["-webkit-user-select"]).to.be.equal("none");
+      expect(el.style["-ms-user-select"]).to.be.equal("none");
+      expect(el.style["user-select"]).to.be.equal("none");
+      expect(el.style["-webkit-user-drag"]).to.be.equal("none");
+      expect(el.style["touch-action"]).to.be.equal("none");
+    });
+
     [
       DIRECTION_NONE,
       DIRECTION_ALL,


### PR DESCRIPTION
## Details
This applies proper user-select styles for browsers that `user-select: none` is not available