### PR TITLE
fix: do not enable PanInput when there is no inputType

### DIFF
--- a/packages/axes/src/inputType/PanInput.ts
+++ b/packages/axes/src/inputType/PanInput.ts
@@ -198,7 +198,11 @@ export class PanInput implements InputType {
    * @return {PanInput} An instance of a module itself <ko>모듈 자신의 인스턴스</ko>
    */
   public enable() {
-    if (!this._enabled) {
+    const activeEvent = convertInputType(this.options.inputType);
+
+    if (!activeEvent) {
+      throw new Error("PanInput cannot be enabled if there is no available input event.");
+    } else if (!this._enabled) {
       this._enabled = true;
       this._originalCssProps = setCssProps(
         this.element,

--- a/packages/axes/test/unit/AnimationManager.spec.js
+++ b/packages/axes/test/unit/AnimationManager.spec.js
@@ -302,7 +302,7 @@ describe("AnimationManager", () => {
       axes.off();
     });
 
-    it("should check 'setTo' method(duration: 0)", () => {
+    it("should check 'setTo' method (duration: 0)", () => {
       // Given
       const changeHandler = sinon.spy();
       const finishHandler = sinon.spy();

--- a/packages/axes/test/unit/inputType/PanInput.spec.js
+++ b/packages/axes/test/unit/inputType/PanInput.spec.js
@@ -242,6 +242,15 @@ describe("PanInput", () => {
           }
         );
       });
+
+      it("should not enable PanInput if there is no available input event.", () => {
+        // Given
+        input.options.inputType = [];
+
+        // When
+        // Then
+        expect(() => input.enable()).to.throw();
+      });
     });
 
     describe("getDirectionByAngle", () => {


### PR DESCRIPTION
## Details
Added code to prevent PanInput from being enabled in when there is no device available for input.