### PR TITLE
fix: prevent nested flicking (direction-based)

### DIFF
--- a/packages/axes/src/InputObserver.ts
+++ b/packages/axes/src/InputObserver.ts
@@ -56,7 +56,6 @@ export class InputObserver implements InputTypeObserver {
       return;
     }
 
-    // console.log("hold: ", event.srcEvent.currentTarget, event.srcEvent)
     const changeOption: ChangeEventOption = {
       input,
       event,

--- a/packages/axes/src/InputObserver.ts
+++ b/packages/axes/src/InputObserver.ts
@@ -7,6 +7,7 @@ import { InputType, InputTypeObserver, toAxis } from "./inputType/InputType";
 import { EventManager, ChangeEventOption } from "./EventManager";
 import { AxisManager, Axis } from "./AxisManager";
 import { AxesOption } from "./Axes";
+import { DIRECTION_HORIZONTAL, DIRECTION_VERTICAL } from "./const";
 import {
   isOutside,
   getInsidePosition,
@@ -102,10 +103,17 @@ export class InputObserver implements InputTypeObserver {
     ) {
       this._isOutside = false;
     }
+
     depaPos = this._atOutside(depaPos);
     destPos = this._atOutside(destPos);
-
-    if (!this.options.nested || !this._isEndofAxis(offset, depaPos, destPos)) {
+    const isSameAxis = this._isSameAxisWithPrimary(nativeEvent, input);
+    
+    if (
+      !this.options.nested ||
+      !this._isEndofAxis(offset, depaPos, destPos) ||
+      /* 부모 전파 중단 조건 중, 최초 동작 축(방향)과 동일한 축인지 확인하는 조건 추가 */
+      !isSameAxis
+    ) {
       nativeEvent.__childrenAxesAlreadyChanged = true;
     }
 
@@ -137,14 +145,16 @@ export class InputObserver implements InputTypeObserver {
     velocity: number[],
     inputDuration?: number
   ) {
+    const nativeEvent = event.srcEvent ? event.srcEvent : event;
     if (
       this._isStopped ||
       !this._interruptManager.isInterrupting() ||
-      !this._moveDistance
+      !this._moveDistance ||
+      /* 인터랙션 종료 시점에서도, 축 방향 확인을 위한 가드 추가 */
+      !this._isSameAxisWithPrimary(nativeEvent, input)
     ) {
       return;
     }
-    const nativeEvent = event.srcEvent ? event.srcEvent : event;
     if (nativeEvent.__childrenAxesAlreadyReleased) {
       velocity = velocity.map(() => 0);
     }
@@ -269,5 +279,21 @@ export class InputObserver implements InputTypeObserver {
             option.circular as boolean[]
           ))
     );
+  }
+
+  /* 최초 동작 축(방향)과 동일한 축인지 확인 */
+  private _isSameAxisWithPrimary(nativeEvent: any, input: InputType): boolean {
+    const primary = nativeEvent.__axesPrimaryDirection;
+    if (!primary) {
+      return false;
+    }
+    const hasX = !!input.axes[0];
+    const hasY = !!input.axes[1];
+    if (primary === DIRECTION_HORIZONTAL) {
+      return hasX && !hasY;
+    } else if (primary === DIRECTION_VERTICAL) {
+      return hasY && !hasX;
+    }
+    return false;
   }
 }

--- a/packages/axes/src/InputObserver.ts
+++ b/packages/axes/src/InputObserver.ts
@@ -55,6 +55,8 @@ export class InputObserver implements InputTypeObserver {
     if (this._interruptManager.isInterrupted() || !input.axes.length) {
       return;
     }
+
+    // console.log("hold: ", event.srcEvent.currentTarget, event.srcEvent)
     const changeOption: ChangeEventOption = {
       input,
       event,
@@ -72,8 +74,12 @@ export class InputObserver implements InputTypeObserver {
 
   public change(input: InputType, event, offset: Axis, useAnimation?: boolean) {
     const nativeEvent = event.srcEvent ? event.srcEvent : event;
-    const isSameAxis = this._isSameAxisWithPrimary(nativeEvent, input);
+    // console.log("change: ", event.srcEvent.currentTarget, JSON.stringify(event.srcEvent))
+    console.log("change: ", this, nativeEvent.__axesPrimaryDirection)
 
+    // TODO: 변수명 변경
+    const isCrossInput = nativeEvent.__axesPrimaryDirection && !this._isSameAxisWithPrimary(nativeEvent, input)
+  
     /* early return condition */
     if (
       this._isStopped ||
@@ -81,7 +87,7 @@ export class InputObserver implements InputTypeObserver {
       this._axisManager.every(offset, (v) => v === 0) ||
       nativeEvent.__childrenAxesAlreadyChanged ||
       /* 부모 전파 중단 조건 중, 최초 동작 축(방향)과 동일한 축인지 확인하는 조건 추가 */
-      !isSameAxis
+      isCrossInput
     ) {
       return;
     }
@@ -150,9 +156,7 @@ export class InputObserver implements InputTypeObserver {
     if (
       this._isStopped ||
       !this._interruptManager.isInterrupting() ||
-      !this._moveDistance ||
-      /* 인터랙션 종료 시점에서도, 축 방향 확인을 위한 가드 추가 */
-      !this._isSameAxisWithPrimary(nativeEvent, input)
+      !this._moveDistance
     ) {
       return;
     }

--- a/packages/axes/src/InputObserver.ts
+++ b/packages/axes/src/InputObserver.ts
@@ -73,11 +73,12 @@ export class InputObserver implements InputTypeObserver {
   }
 
   public change(input: InputType, event, offset: Axis, useAnimation?: boolean) {
-    const nativeEvent = event.srcEvent ? event.srcEvent : event;
-    // console.log("change: ", event.srcEvent.currentTarget, JSON.stringify(event.srcEvent))
-    console.log("change: ", this, nativeEvent.__axesPrimaryDirection)
+    const nativeEvent = event.srcEvent ? event.srcEvent : event;   
 
-    // TODO: 변수명 변경
+    /** 
+     * 아래 early return 판단 조건 중, 최초 동작 축(방향)과 동일한 축인지 확인하는 조건 추가
+     * TODO(@gyutato): 비직관적인 변수명이므로 가능하다면 변경
+     */
     const isCrossInput = nativeEvent.__axesPrimaryDirection && !this._isSameAxisWithPrimary(nativeEvent, input)
   
     /* early return condition */
@@ -86,7 +87,6 @@ export class InputObserver implements InputTypeObserver {
       !this._interruptManager.isInterrupting() ||
       this._axisManager.every(offset, (v) => v === 0) ||
       nativeEvent.__childrenAxesAlreadyChanged ||
-      /* 부모 전파 중단 조건 중, 최초 동작 축(방향)과 동일한 축인지 확인하는 조건 추가 */
       isCrossInput
     ) {
       return;

--- a/packages/axes/src/InputObserver.ts
+++ b/packages/axes/src/InputObserver.ts
@@ -71,17 +71,21 @@ export class InputObserver implements InputTypeObserver {
   }
 
   public change(input: InputType, event, offset: Axis, useAnimation?: boolean) {
+    const nativeEvent = event.srcEvent ? event.srcEvent : event;
+    const isSameAxis = this._isSameAxisWithPrimary(nativeEvent, input);
+
+    /* early return condition */
     if (
       this._isStopped ||
       !this._interruptManager.isInterrupting() ||
-      this._axisManager.every(offset, (v) => v === 0)
+      this._axisManager.every(offset, (v) => v === 0) ||
+      nativeEvent.__childrenAxesAlreadyChanged ||
+      /* 부모 전파 중단 조건 중, 최초 동작 축(방향)과 동일한 축인지 확인하는 조건 추가 */
+      !isSameAxis
     ) {
       return;
     }
-    const nativeEvent = event.srcEvent ? event.srcEvent : event;
-    if (nativeEvent.__childrenAxesAlreadyChanged) {
-      return;
-    }
+
     let depaPos: Axis = this._moveDistance || this._axisManager.get(input.axes);
     let destPos: Axis;
 
@@ -106,13 +110,10 @@ export class InputObserver implements InputTypeObserver {
 
     depaPos = this._atOutside(depaPos);
     destPos = this._atOutside(destPos);
-    const isSameAxis = this._isSameAxisWithPrimary(nativeEvent, input);
-    
+
     if (
       !this.options.nested ||
-      !this._isEndofAxis(offset, depaPos, destPos) ||
-      /* 부모 전파 중단 조건 중, 최초 동작 축(방향)과 동일한 축인지 확인하는 조건 추가 */
-      !isSameAxis
+      !this._isEndofAxis(offset, depaPos, destPos)
     ) {
       nativeEvent.__childrenAxesAlreadyChanged = true;
     }
@@ -284,6 +285,7 @@ export class InputObserver implements InputTypeObserver {
   /* 최초 동작 축(방향)과 동일한 축인지 확인 */
   private _isSameAxisWithPrimary(nativeEvent: any, input: InputType): boolean {
     const primary = nativeEvent.__axesPrimaryDirection;
+
     if (!primary) {
       return false;
     }

--- a/packages/axes/src/inputType/PanInput.ts
+++ b/packages/axes/src/inputType/PanInput.ts
@@ -20,6 +20,7 @@ import {
   DIRECTION_HORIZONTAL,
   MOUSE_LEFT,
   ANY,
+  DIRECTION_ALL,
 } from "../const";
 import { ActiveEvent, ElementType, InputEventType } from "../types";
 
@@ -137,6 +138,7 @@ export class PanInput implements InputType {
   private _rightEdgeTimer = 0;
   private _dragged = false;
   private _isOverThreshold = false;
+  private _isDirectionSet = false;
   /* 최초 동작 축(방향) */
   private _primaryDirection = DIRECTION_NONE;
 
@@ -318,12 +320,19 @@ export class PanInput implements InputType {
       userDirection
     );
 
-    /* 최초 동작 축(방향) 결정 */
+    console.log("panInput: ", this, userDirection)
+    /* 현재 동작 축(방향) 결정 */
     if (this._primaryDirection === DIRECTION_NONE) {
-      if (useHorizontal && !useVertical) {
-        this._primaryDirection = DIRECTION_HORIZONTAL;
-      } else if (useVertical && !useHorizontal) {
-        this._primaryDirection = DIRECTION_VERTICAL;
+      switch (true) {
+        case useHorizontal && !useVertical:
+          this._primaryDirection = DIRECTION_HORIZONTAL;
+          break;
+        case useVertical && !useHorizontal:
+          this._primaryDirection = DIRECTION_VERTICAL;
+          break;
+        case useHorizontal && useVertical:
+          this._primaryDirection = DIRECTION_ALL;
+          break;
       }
     }
 
@@ -367,9 +376,21 @@ export class PanInput implements InputType {
     panEvent.preventSystemEvent = prevent;
     /* 부모에게 전달되는 네이티브 이벤트 객체(srcEvent)에 방향 정보 추가 */
     const panSrcEvent = panEvent?.srcEvent as any;
-    if (this._primaryDirection !== DIRECTION_NONE && panSrcEvent && !panSrcEvent.__axesPrimaryDirection) {
+    const hasPrimaryDirection = panSrcEvent.__axesPrimaryDirection;
+    // TODO: 거리 관련 적절한 threshold 추가 (기존 값 사용 X)
+    // (1) 전달받은 최초 동작 축이 없고, (2) 현재 동작이 threshold 이상인 경우 축 정보를 설정
+    const DIRECTION_THRESHOLD = 20;
+    const delta = this._primaryDirection === DIRECTION_HORIZONTAL ?
+      activeEvent.prevEvent.deltaX :
+      activeEvent.prevEvent.deltaY;
+    if (!this._isDirectionSet && Math.abs(delta) >= DIRECTION_THRESHOLD) {
+      this._isDirectionSet = true;
+    }
+    if (this._primaryDirection !== DIRECTION_NONE && panSrcEvent && !hasPrimaryDirection && this._isDirectionSet) {
+      // console.log("panInput: ", this, this._primaryDirection)
       panSrcEvent.__axesPrimaryDirection = this._primaryDirection;
     }
+
     if (prevent && (this._isOverThreshold || distance >= threshold)) {
       this._dragged = preventClickOnDrag;
       this._isOverThreshold = true;
@@ -402,6 +423,7 @@ export class PanInput implements InputType {
     this._observer.release(this, prevEvent, velocity);
     /* 최초 동작 축(방향) 초기화 */
     this._primaryDirection = DIRECTION_NONE;
+    this._isDirectionSet = false;
   }
 
   protected _attachWindowEvent(activeEvent: ActiveEvent) {

--- a/packages/axes/src/inputType/PanInput.ts
+++ b/packages/axes/src/inputType/PanInput.ts
@@ -366,8 +366,9 @@ export class PanInput implements InputType {
     }
     panEvent.preventSystemEvent = prevent;
     /* 부모에게 전달되는 네이티브 이벤트 객체(srcEvent)에 방향 정보 추가 */
-    if (this._primaryDirection !== DIRECTION_NONE && panEvent && panEvent.srcEvent) {
-      (panEvent.srcEvent as any).__axesPrimaryDirection = this._primaryDirection;
+    const panSrcEvent = panEvent?.srcEvent as any;
+    if (this._primaryDirection !== DIRECTION_NONE && panSrcEvent && !panSrcEvent.__axesPrimaryDirection) {
+      panSrcEvent.__axesPrimaryDirection = this._primaryDirection;
     }
     if (prevent && (this._isOverThreshold || distance >= threshold)) {
       this._dragged = preventClickOnDrag;

--- a/packages/axes/src/inputType/PanInput.ts
+++ b/packages/axes/src/inputType/PanInput.ts
@@ -137,6 +137,8 @@ export class PanInput implements InputType {
   private _rightEdgeTimer = 0;
   private _dragged = false;
   private _isOverThreshold = false;
+  /* 최초 동작 축(방향) */
+  private _primaryDirection = DIRECTION_NONE;
 
   /**
    *
@@ -267,6 +269,8 @@ export class PanInput implements InputType {
 
       this._dragged = false;
       this._isOverThreshold = false;
+      /* 최초 동작 축(방향) 초기화 */
+      this._primaryDirection = DIRECTION_NONE;
       this._observer.hold(this, panEvent);
       this._atRightEdge =
         IS_IOS_SAFARI && panEvent.center.x > window.innerWidth - edgeThreshold;
@@ -314,6 +318,15 @@ export class PanInput implements InputType {
       userDirection
     );
 
+    /* 최초 동작 축(방향) 결정 */
+    if (this._primaryDirection === DIRECTION_NONE) {
+      if (useHorizontal && !useVertical) {
+        this._primaryDirection = DIRECTION_HORIZONTAL;
+      } else if (useVertical && !useHorizontal) {
+        this._primaryDirection = DIRECTION_VERTICAL;
+      }
+    }
+
     if (activeEvent.prevEvent && IS_IOS_SAFARI) {
       const swipeLeftToRight = panEvent.center.x < 0;
 
@@ -352,6 +365,10 @@ export class PanInput implements InputType {
       panEvent.srcEvent.stopPropagation();
     }
     panEvent.preventSystemEvent = prevent;
+    /* 부모에게 전달되는 네이티브 이벤트 객체(srcEvent)에 방향 정보 추가 */
+    if (this._primaryDirection !== DIRECTION_NONE && panEvent && panEvent.srcEvent) {
+      (panEvent.srcEvent as any).__axesPrimaryDirection = this._primaryDirection;
+    }
     if (prevent && (this._isOverThreshold || distance >= threshold)) {
       this._dragged = preventClickOnDrag;
       this._isOverThreshold = true;
@@ -382,6 +399,8 @@ export class PanInput implements InputType {
     ) : [0, 0];
     activeEvent.onRelease();
     this._observer.release(this, prevEvent, velocity);
+    /* 최초 동작 축(방향) 초기화 */
+    this._primaryDirection = DIRECTION_NONE;
   }
 
   protected _attachWindowEvent(activeEvent: ActiveEvent) {

--- a/packages/axes/src/inputType/PanInput.ts
+++ b/packages/axes/src/inputType/PanInput.ts
@@ -259,6 +259,7 @@ export class PanInput implements InputType {
     const { inputKey, inputButton, preventDefaultOnDrag } = this.options;
     const activeEvent = this._activeEvent;
     const panEvent = activeEvent.onEventStart(event, inputKey, inputButton);
+
     if (
       !panEvent ||
       !this._enabled ||
@@ -320,7 +321,6 @@ export class PanInput implements InputType {
       userDirection
     );
 
-    console.log("panInput: ", this, userDirection)
     /* 현재 동작 축(방향) 결정 */
     if (this._primaryDirection === DIRECTION_NONE) {
       switch (true) {
@@ -374,8 +374,21 @@ export class PanInput implements InputType {
       panEvent.srcEvent.stopPropagation();
     }
     panEvent.preventSystemEvent = prevent;
-    /* 부모에게 전달되는 네이티브 이벤트 객체(srcEvent)에 방향 정보 추가 */
+
+    /**
+     * 전파되는 이벤트 객체에 여태까지의 Input 객체를 저장한 스택을 추가.
+     * 위의 early return 조건에 의해, 이미 diasabled 상태인 경우에는 스택에 추가되지 않음
+     */
     const panSrcEvent = panEvent?.srcEvent as any;
+
+    if (panSrcEvent) {
+      const stack = panSrcEvent.__inputStack || [];
+      panSrcEvent.__inputStack = stack.concat([this]);
+    }
+
+    /**
+     *  부모에게 전달되는 네이티브 이벤트 객체(srcEvent)에 방향 정보 추가
+     */
     const hasPrimaryDirection = panSrcEvent.__axesPrimaryDirection;
     // TODO: 거리 관련 적절한 threshold 추가 (기존 값 사용 X)
     // (1) 전달받은 최초 동작 축이 없고, (2) 현재 동작이 threshold 이상인 경우 축 정보를 설정
@@ -383,12 +396,21 @@ export class PanInput implements InputType {
     const delta = this._primaryDirection === DIRECTION_HORIZONTAL ?
       activeEvent.prevEvent.deltaX :
       activeEvent.prevEvent.deltaY;
+
     if (!this._isDirectionSet && Math.abs(delta) >= DIRECTION_THRESHOLD) {
       this._isDirectionSet = true;
     }
+
+    // TODO(@gyutato): 하단 prevent 조건문 내부로 이동할 수 있는지 확인
     if (this._primaryDirection !== DIRECTION_NONE && panSrcEvent && !hasPrimaryDirection && this._isDirectionSet) {
-      // console.log("panInput: ", this, this._primaryDirection)
       panSrcEvent.__axesPrimaryDirection = this._primaryDirection;
+      panSrcEvent.__inputStack.forEach((input, index) => {
+        if (index === panSrcEvent.__inputStack.length - 1) {
+          return;
+        } 
+
+        input.release();
+      });
     }
 
     if (prevent && (this._isOverThreshold || distance >= threshold)) {

--- a/packages/axes/src/inputType/PanInput.ts
+++ b/packages/axes/src/inputType/PanInput.ts
@@ -141,6 +141,7 @@ export class PanInput implements InputType {
   private _isDirectionSet = false;
   /* 최초 동작 축(방향) */
   private _primaryDirection = DIRECTION_NONE;
+  private _ignoreChange = false;
 
   /**
    *
@@ -242,6 +243,28 @@ export class PanInput implements InputType {
   }
 
   /**
+   * Disables change event propagation to subsequent events
+   * @ko 후속 이벤트에서 change 가 동작하지 않도록 설정한다.
+   * @return {PanInput} An instance of a module itself <ko>모듈 자신의 인스턴스</ko>
+   */
+  public ignoreChange() {
+    this._ignoreChange = true;
+
+    return this;
+  }
+
+  /**
+   * Resumes change event propagation to subsequent events
+   * @ko 후속 이벤트에서 change 가 동작하도록 설정한다.
+   * @returns {PanInput} An instance of a module itself <ko>모듈 자신의 인스턴스</ko>
+   */
+  public resumeChange() {
+    this._ignoreChange = false;
+
+    return this;
+  }
+
+  /**
    * Releases current user input.
    * @ko 사용자의 입력을 강제로 중단시킨다.
    * @return {PanInput} An instance of a module itself <ko>모듈 자신의 인스턴스</ko>
@@ -305,7 +328,7 @@ export class PanInput implements InputType {
       return;
     }
 
-    if (!panEvent || !this._enabled || touches > 1) {
+    if (!panEvent || !this._enabled || touches > 1 || this._ignoreChange) {
       return;
     }
 
@@ -379,7 +402,9 @@ export class PanInput implements InputType {
      * 전파되는 이벤트 객체에 여태까지의 Input 객체를 저장한 스택을 추가.
      * 위의 early return 조건에 의해, 이미 diasabled 상태인 경우에는 스택에 추가되지 않음
      */
-    const panSrcEvent = panEvent?.srcEvent as any;
+    // TODO(@gyutato): any 타입 캐스팅 개선 (InternalSrcEvent, ExtendedEvent 타입 정의 필요)
+    const panSrcEvent = panEvent?.srcEvent as Record<PropertyKey, any> 
+      & { __inputStack?: PanInput[], __axesPrimaryDirection?: number };
 
     if (panSrcEvent) {
       const stack = panSrcEvent.__inputStack || [];
@@ -390,33 +415,29 @@ export class PanInput implements InputType {
      *  부모에게 전달되는 네이티브 이벤트 객체(srcEvent)에 방향 정보 추가
      */
     const hasPrimaryDirection = panSrcEvent.__axesPrimaryDirection;
-    // TODO: 거리 관련 적절한 threshold 추가 (기존 값 사용 X)
+
     // (1) 전달받은 최초 동작 축이 없고, (2) 현재 동작이 threshold 이상인 경우 축 정보를 설정
-    const DIRECTION_THRESHOLD = 20;
     const delta = this._primaryDirection === DIRECTION_HORIZONTAL ?
       activeEvent.prevEvent.deltaX :
       activeEvent.prevEvent.deltaY;
 
-    if (!this._isDirectionSet && Math.abs(delta) >= DIRECTION_THRESHOLD) {
+    if (!this._isDirectionSet && Math.abs(delta) >= threshold) {
       this._isDirectionSet = true;
     }
 
-    // TODO(@gyutato): 하단 prevent 조건문 내부로 이동할 수 있는지 확인
+    /* 이벤트를 통해 최초 방향을 전파하기 위한 조건 */
     if (this._primaryDirection !== DIRECTION_NONE && panSrcEvent && !hasPrimaryDirection && this._isDirectionSet) {
       panSrcEvent.__axesPrimaryDirection = this._primaryDirection;
-      panSrcEvent.__inputStack.forEach((input, index) => {
-        if (index === panSrcEvent.__inputStack.length - 1) {
-          return;
-        } 
-
-        input.release();
+      const childrenInput = panSrcEvent.__inputStack.slice(0, -1);
+      childrenInput.forEach((input, index) => {
+        input.ignoreChange();
       });
     }
 
     if (prevent && (this._isOverThreshold || distance >= threshold)) {
       this._dragged = preventClickOnDrag;
       this._isOverThreshold = true;
-      this._observer.change(this, panEvent, toAxis(this.axes, offset));
+      this._observer.change(this, panEvent, toAxis(this.axes, offset))
     }
     activeEvent.prevEvent = panEvent;
   }
@@ -431,7 +452,7 @@ export class PanInput implements InputType {
     this._detachWindowEvent(activeEvent);
     clearTimeout(this._rightEdgeTimer);
     const prevEvent = activeEvent.prevEvent;
-    const velocity = this._isOverThreshold ? this._getOffset(
+    let velocity = this._isOverThreshold ? this._getOffset(
       [
         Math.abs(prevEvent.velocityX) * prevEvent.directionX,
         Math.abs(prevEvent.velocityY) * prevEvent.directionY,
@@ -441,11 +462,18 @@ export class PanInput implements InputType {
         useDirection(DIRECTION_VERTICAL, this._direction),
       ]
     ) : [0, 0];
+
+    /* _ignoreChange 옵션에 의해 change 가 동작하지 않은 경우, velocity 를 0으로 설정 */
+    if (this._ignoreChange) {
+      velocity = [0, 0];
+    }
+
     activeEvent.onRelease();
     this._observer.release(this, prevEvent, velocity);
     /* 최초 동작 축(방향) 초기화 */
     this._primaryDirection = DIRECTION_NONE;
     this._isDirectionSet = false;
+    this._ignoreChange = false;
   }
 
   protected _attachWindowEvent(activeEvent: ActiveEvent) {

--- a/packages/axes/test/manual/cross.html
+++ b/packages/axes/test/manual/cross.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <title>egjs-axes</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1 user-scalable=no">
+  <style>
+    .viewport {
+      overflow: hidden;
+    }
+
+    .camera {
+      display: flex;
+    }
+
+    .viewport.vertical {
+      height: 800px;
+    }
+    .camera.vertical {
+      flex-direction: column;
+    }
+
+    .panel {
+      padding: 0 10px;
+    }
+  </style>
+</head>
+
+<body>
+  <div class="viewport vertical">
+    <div class="camera vertical">
+      <div class="viewport horizontal">
+        <div class="camera">
+          <div class="panel">
+            <img src="https://dummyimage.com/300x300/110010/fff&text=1" />
+          </div>
+          <div class="panel">
+            <img src="https://dummyimage.com/300x300/220020/fff&text=2" />
+          </div>
+          <div class="panel">
+            <img src="https://dummyimage.com/300x300/330030/fff&text=3" />
+          </div>
+          <div class="panel">
+            <img src="https://dummyimage.com/300x300/440040/fff&text=4" />
+          </div>
+          <div class="panel">
+            <img src="https://dummyimage.com/300x300/550050/fff&text=5" />
+          </div>
+          <div class="panel">
+            <img src="https://dummyimage.com/300x300/660060/fff&text=6" />
+          </div>
+          <div class="panel">
+            <img src="https://dummyimage.com/300x300/770070/fff&text=7" />
+          </div>
+          <div class="panel">
+            <img src="https://dummyimage.com/300x300/880080/fff&text=8" />
+          </div>
+          <div class="panel">
+            <img src="https://dummyimage.com/300x300/990090/fff&text=9" />
+          </div>
+        </div>
+      </div>
+      <div class="viewport horizontal">
+        <div class="camera">
+          <div class="panel">
+            <img src="https://dummyimage.com/300x300/110010/fff&text=1" />
+          </div>
+          <div class="panel">
+            <img src="https://dummyimage.com/300x300/220020/fff&text=2" />
+          </div>
+          <div class="panel">
+            <img src="https://dummyimage.com/300x300/330030/fff&text=3" />
+          </div>
+          <div class="panel">
+            <img src="https://dummyimage.com/300x300/440040/fff&text=4" />
+          </div>
+          <div class="panel">
+            <img src="https://dummyimage.com/300x300/550050/fff&text=5" />
+          </div>
+          <div class="panel">
+            <img src="https://dummyimage.com/300x300/660060/fff&text=6" />
+          </div>
+          <div class="panel">
+            <img src="https://dummyimage.com/300x300/770070/fff&text=7" />
+          </div>
+          <div class="panel">
+            <img src="https://dummyimage.com/300x300/880080/fff&text=8" />
+          </div>
+          <div class="panel">
+            <img src="https://dummyimage.com/300x300/990090/fff&text=9" />
+          </div>
+        </div>
+      </div>
+      <div class="viewport horizontal">
+        <div class="camera">
+          <div class="panel">
+            <img src="https://dummyimage.com/300x300/110010/fff&text=1" />
+          </div>
+          <div class="panel">
+            <img src="https://dummyimage.com/300x300/220020/fff&text=2" />
+          </div>
+          <div class="panel">
+            <img src="https://dummyimage.com/300x300/330030/fff&text=3" />
+          </div>
+          <div class="panel">
+            <img src="https://dummyimage.com/300x300/440040/fff&text=4" />
+          </div>
+          <div class="panel">
+            <img src="https://dummyimage.com/300x300/550050/fff&text=5" />
+          </div>
+          <div class="panel">
+            <img src="https://dummyimage.com/300x300/660060/fff&text=6" />
+          </div>
+          <div class="panel">
+            <img src="https://dummyimage.com/300x300/770070/fff&text=7" />
+          </div>
+          <div class="panel">
+            <img src="https://dummyimage.com/300x300/880080/fff&text=8" />
+          </div>
+          <div class="panel">
+            <img src="https://dummyimage.com/300x300/990090/fff&text=9" />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script src="../../../../node_modules/@egjs/component/dist/component.js"></script>
+  <script src="../../dist/axes.pkgd.js"></script>
+  <!-- <script src="../../dist/axes.pkgd.js"></script> -->
+  <script src="js/cross.js"></script>
+</body>
+
+</html>

--- a/packages/axes/test/manual/js/cross.js
+++ b/packages/axes/test/manual/js/cross.js
@@ -1,0 +1,44 @@
+
+var viewport = document.querySelector(".viewport.vertical");
+var camera = document.querySelector(".camera.vertical");
+var input = new eg.Axes.PanInput(viewport, {
+	scale: [1, 1],
+	inputType: ["touch", "mouse"],
+	preventClickOnDrag: true,
+	preventDefaultOnDrag: true,
+});
+var axes = new eg.Axes(
+	{
+		y: {
+			range: [-1000, 0],
+			startPos: 0,
+		},
+	},
+).on("change", function (e) {
+	camera.style.transform = "translateY(" + e.pos.y + "px)";
+});
+
+axes.connect(["", "y"], input);
+
+
+document.querySelectorAll(".viewport.horizontal").forEach(child => {
+	var camera = child.querySelector(".camera");
+	var input = new eg.Axes.PanInput(child, {
+		scale: [1, 1],
+		inputType: ["touch", "mouse"],
+		preventClickOnDrag: true,
+		preventDefaultOnDrag: true,
+	});
+	var axes = new eg.Axes(
+		{
+			x: {
+				range: [-1000, 0],
+				startPos: 0,
+			},
+		},
+	).on("change", function (e) {
+		camera.style.transform = "translateX(" + e.pos.x + "px)";
+	});
+
+	axes.connect(["x"], input);
+});


### PR DESCRIPTION
## Issue
https://oss.navercorp.com/egjs/work/issues/2127

## Details
- flicking 컨테이너가 중첩된 경우, 특정 축(방향)의 flicking 이 시작되었을 때 다른 축 방향으로의 전파를 방지합니다.
- 본 PR에서는, **자식 요소에서 시작된 flicking 이 부모에게 전파되는 것을 방지**하는 로직만 구현하였습니다.

### 리뷰 요청 사항
- 적절한 객체를 수정하였는지 (`PanInput`, `InputObserver`)
- 기존 구조를 잘 보존하는 방식으로, 적절한 위치에 로직이 추가되었는지 (`InputObserver.change`, `InputObserver.release`)
